### PR TITLE
test: make E2E T2I use imagen4-fast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ node.zip
 .claude/
 
 WORKFLOW.md
+
+# local
+.venv/

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -35,19 +35,21 @@ _t2i_image_url: str | None = None
 
 @skip_no_key
 def test_t2i():
-    """Test T2I: Luma Photon Flash (minimal params, fast)."""
+    """Test T2I: Google Imagen4 Fast (minimal params, fast, reliable credits)."""
     global _t2i_image_url
-    from atlascloud_comfyui.nodes.image.luma_photon_flash_t2i import (
-        AtlasLumaPhotonFlashTextToImage,
+    from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import (
+        AtlasImagen4FastTextToImage,
     )
 
-    node = AtlasLumaPhotonFlashTextToImage()
+    node = AtlasImagen4FastTextToImage()
     handle = make_client()
 
     start = time.time()
     result = node.run(
         atlas_client=handle,
         prompt="A cute orange cat sitting on a windowsill",
+        aspect_ratio="1:1",
+        num_images=1,
         enable_base64_output=False,
         poll_interval_sec=2.0,
         timeout_sec=120,


### PR DESCRIPTION
## Summary
- Switch E2E T2I from `luma/photon-flash` to `google/imagen4-fast` (luma model returns insufficient credits for this key)
- Add required params for Imagen4 Fast node (`aspect_ratio`, `num_images`)
- Add `.venv/` to `.gitignore` (local only)

## Test plan
- [x] `ruff check .`
- [x] `pytest tests/ -v`
- [x] `PYTHONPATH=../ComfyUI ATLASCLOUD_API_KEY=*** pytest tests/test_e2e.py -v -s` (3/3 passed; ProgressBar import OK)

Notes: ComfyUI is used at runtime for `ProgressBar`; we validate with `PYTHONPATH=../ComfyUI`.