### PR TITLE
feat: add WAN2.6 + Kling Video O3 nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3.1 Text-to-Video | google/veo3.1/text-to-video |
 | AtlasCloud VEO2 Text-to-Video | google/veo2 |
 | AtlasCloud WAN2.6 Text-to-Video | alibaba/wan-2.6/text-to-video |
+| AtlasCloud WAN2.6 Video-to-Video | alibaba/wan-2.6/video-to-video |
+| AtlasCloud Kling Video O3 Pro Text-to-Video | kwaivgi/kling-video-o3-pro/text-to-video |
+| AtlasCloud Kling Video O3 Std Text-to-Video | kwaivgi/kling-video-o3-std/text-to-video |
 | AtlasCloud WAN2.5 Text-to-Video | alibaba/wan-2.5/text-to-video |
 | AtlasCloud WAN2.2 Text-to-Video 720p | alibaba/wan-2.2/text-to-video-720p |
 | AtlasCloud Luma Ray 2 Text-to-Video | luma/ray-2-t2v |
@@ -104,6 +107,11 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3.1 Image-to-Video | google/veo3.1/image-to-video |
 | AtlasCloud VEO2 Image-to-Video | google/veo2/image-to-video |
 | AtlasCloud WAN2.5 Image-to-Video | alibaba/wan-2.5/image-to-video |
+| AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
+| AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |
+| AtlasCloud Kling Video O3 Std Image-to-Video | kwaivgi/kling-video-o3-std/image-to-video |
+| AtlasCloud Kling Video O3 Pro Reference-to-Video | kwaivgi/kling-video-o3-pro/reference-to-video |
+| AtlasCloud Kling Video O3 Std Reference-to-Video | kwaivgi/kling-video-o3-std/reference-to-video |
 | AtlasCloud Luma Ray 2 Image-to-Video | luma/ray-2-i2v |
 | AtlasCloud Pika V2.1 Image-to-Video | pika/v2.1-i2v |
 | AtlasCloud PixVerse V4.5 Image-to-Video | pixverse/pixverse-v4.5-i2v |
@@ -117,6 +125,9 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Hunyuan Image-to-Video | atlascloud/hunyuan-video/i2v |
 
 ### Text-to-Image (T2I)
+
+| AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
+
 
 | Node | Model |
 |------|-------|
@@ -136,6 +147,13 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Recraft V3 Text-to-Image | recraft-ai/recraft-v3 |
 | AtlasCloud Flux2 Flex Text-to-Image | flux2/flex |
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
+
+### Video Edit
+
+| Node | Model |
+|------|-------|
+| AtlasCloud Kling Video O3 Pro Video-Edit | kwaivgi/kling-video-o3-pro/video-edit |
+| AtlasCloud Kling Video O3 Std Video-Edit | kwaivgi/kling-video-o3-std/video-edit |
 
 ### Image Edit
 

--- a/src/atlascloud_comfyui/nodes/image/wan26_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/wan26_t2i.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+# Naming note: file uses wan26_t2i.py for brevity, but the model is text-to-image.
+# We still name the class AtlasWAN26TextToImage to match the product naming.
+
+
+class AtlasWAN26TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": ""}),
+                "size": (
+                    [
+                        "576*1344",
+                        "720*1280",
+                        "720*1680",
+                        "768*1024",
+                        "800*1200",
+                        "936*2184",
+                        "960*1280",
+                        "960*1440",
+                        "1024*768",
+                        "1024*1024",
+                        "1080*1920",
+                        "1168*1752",
+                        "1200*800",
+                        "1200*1600",
+                        "1224*1632",
+                        "1280*720",
+                        "1280*960",
+                        "1280*1280",
+                        "1344*576",
+                        "1440*960",
+                        "1440*1440",
+                        "1600*1200",
+                        "1632*1224",
+                        "1680*720",
+                        "1752*1168",
+                        "1920*1080",
+                        "2184*936",
+                    ],
+                    {"default": "1280*1280"},
+                ),
+                "enable_prompt_expansion": ("BOOLEAN", {"default": False}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        negative_prompt: str = "",
+        size: str = "1280*1280",
+        enable_prompt_expansion: bool = False,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.6/text-to-image",
+            "prompt": prompt,
+            "size": size,
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "seed": int(seed),
+        }
+
+        if (negative_prompt or "").strip():
+            payload["negative_prompt"] = negative_prompt
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_i2v.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO3ProImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL"}),
+            },
+            "optional": {
+                "end_image": ("STRING", {"default": "", "tooltip": "Last frame image URL (optional)"}),
+                "duration": ("INT", {"default": 5, "min": 3, "max": 15}),
+                "generate_audio": ("BOOLEAN", {"default": False}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        end_image: str = "",
+        duration: int = 5,
+        generate_audio: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling Video O3 Pro Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-pro/image-to-video",
+            "prompt": prompt,
+            "image": image,
+            "duration": int(duration),
+            "generate_audio": bool(generate_audio),
+        }
+
+        if (end_image or "").strip():
+            payload["end_image"] = end_image
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_r2v.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO3ProReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+            },
+            "optional": {
+                "video": ("STRING", {"default": "", "tooltip": "Reference video URL (optional)"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "0-7 image URLs, one per line"}),
+                "keep_original_sound": ("BOOLEAN", {"default": True}),
+                "sound": ("BOOLEAN", {"default": False}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9"}),
+                "duration": ("INT", {"default": 5, "min": 3, "max": 15}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video: str = "",
+        images: str = "",
+        keep_original_sound: bool = True,
+        sound: bool = False,
+        aspect_ratio: str = "16:9",
+        duration: int = 5,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) > 7:
+            raise RuntimeError("images maxItems is 7")
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-pro/reference-to-video",
+            "prompt": prompt,
+            "keep_original_sound": bool(keep_original_sound),
+            "sound": bool(sound),
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+        }
+
+        if (video or "").strip():
+            payload["video"] = video
+        if image_list:
+            payload["images"] = image_list
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_t2v.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO3ProTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+            },
+            "optional": {
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9"}),
+                "duration": ("INT", {"default": 5, "min": 3, "max": 15}),
+                "sound": ("BOOLEAN", {"default": False}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str = "16:9",
+        duration: int = 5,
+        sound: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-pro/text-to-video",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "sound": bool(sound),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_video_edit.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_video_edit.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO3ProVideoEdit:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+                "video": ("STRING", {"default": "", "tooltip": "Video URL (<=10s)"}),
+            },
+            "optional": {
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "0-4 image URLs, one per line"}),
+                "keep_original_sound": ("BOOLEAN", {"default": True}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video: str,
+        images: str = "",
+        keep_original_sound: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (video or "").strip():
+            raise RuntimeError("video is required for Kling Video O3 Pro Video-Edit")
+
+        client = atlas_client.client
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) > 4:
+            raise RuntimeError("images maxItems is 4")
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-pro/video-edit",
+            "prompt": prompt,
+            "video": video,
+            "keep_original_sound": bool(keep_original_sound),
+        }
+
+        if image_list:
+            payload["images"] = image_list
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_std_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_std_i2v.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO3StdImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL"}),
+            },
+            "optional": {
+                "end_image": ("STRING", {"default": "", "tooltip": "Last frame image URL (optional)"}),
+                "duration": ("INT", {"default": 5, "min": 3, "max": 15}),
+                "generate_audio": ("BOOLEAN", {"default": False}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        end_image: str = "",
+        duration: int = 5,
+        generate_audio: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling Video O3 Std Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-std/image-to-video",
+            "prompt": prompt,
+            "image": image,
+            "duration": int(duration),
+            "generate_audio": bool(generate_audio),
+        }
+
+        if (end_image or "").strip():
+            payload["end_image"] = end_image
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_std_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_std_r2v.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO3StdReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+            },
+            "optional": {
+                "video": ("STRING", {"default": "", "tooltip": "Reference video URL (optional)"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "0-7 image URLs, one per line"}),
+                "keep_original_sound": ("BOOLEAN", {"default": True}),
+                "sound": ("BOOLEAN", {"default": False}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9"}),
+                "duration": ("INT", {"default": 5, "min": 3, "max": 15}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video: str = "",
+        images: str = "",
+        keep_original_sound: bool = True,
+        sound: bool = False,
+        aspect_ratio: str = "16:9",
+        duration: int = 5,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) > 7:
+            raise RuntimeError("images maxItems is 7")
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-std/reference-to-video",
+            "prompt": prompt,
+            "keep_original_sound": bool(keep_original_sound),
+            "sound": bool(sound),
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+        }
+
+        if (video or "").strip():
+            payload["video"] = video
+        if image_list:
+            payload["images"] = image_list
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_std_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_std_t2v.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO3StdTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+            },
+            "optional": {
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9"}),
+                "duration": ("INT", {"default": 5, "min": 3, "max": 15}),
+                "sound": ("BOOLEAN", {"default": False}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str = "16:9",
+        duration: int = 5,
+        sound: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-std/text-to-video",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "sound": bool(sound),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_std_video_edit.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_std_video_edit.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO3StdVideoEdit:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+                "video": ("STRING", {"default": "", "tooltip": "Video URL (<=10s)"}),
+            },
+            "optional": {
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "0-4 image URLs, one per line"}),
+                "keep_original_sound": ("BOOLEAN", {"default": True}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video: str,
+        images: str = "",
+        keep_original_sound: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (video or "").strip():
+            raise RuntimeError("video is required for Kling Video O3 Std Video-Edit")
+
+        client = atlas_client.client
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) > 4:
+            raise RuntimeError("images maxItems is 4")
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-std/video-edit",
+            "prompt": prompt,
+            "video": video,
+            "keep_original_sound": bool(keep_original_sound),
+        }
+
+        if image_list:
+            payload["images"] = image_list
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan26_i2v_flash.py
+++ b/src/atlascloud_comfyui/nodes/video/wan26_i2v_flash.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWAN26ImageToVideoFlash:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True}),
+                "resolution": (["720p", "1080p"], {"default": "720p"}),
+            },
+            "optional": {
+                "audio": ("STRING", {"default": "", "tooltip": "Optional audio URL"}),
+                "negative_prompt": ("STRING", {"multiline": True, "default": ""}),
+                "duration": ("INT", {"default": 5, "min": 5, "max": 15, "tooltip": "Seconds"}),
+                "enable_prompt_expansion": ("BOOLEAN", {"default": True}),
+                "shot_type": (["multi", "single"], {"default": "multi"}),
+                "generate_audio": ("BOOLEAN", {"default": True}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        audio: str = "",
+        negative_prompt: str = "",
+        duration: int = 5,
+        enable_prompt_expansion: bool = True,
+        shot_type: str = "multi",
+        generate_audio: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for WAN2.6 Image-to-Video Flash")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.6/image-to-video-flash",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "shot_type": shot_type,
+            "generate_audio": bool(generate_audio),
+            "seed": int(seed),
+        }
+
+        if (audio or "").strip():
+            payload["audio"] = audio
+        if (negative_prompt or "").strip():
+            payload["negative_prompt"] = negative_prompt
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan26_v2v.py
+++ b/src/atlascloud_comfyui/nodes/video/wan26_v2v.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWAN26VideoToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Use character1/character2... to refer to input videos"}),
+                "videos": ("STRING", {"multiline": True, "tooltip": "1-3 video URLs, one per line"}),
+                "size": (
+                    [
+                        "1280*720",
+                        "720*1280",
+                        "960*960",
+                        "1088*832",
+                        "832*1088",
+                        "1920*1080",
+                        "1080*1920",
+                        "1440*1440",
+                        "1632*1248",
+                        "1248*1632",
+                    ],
+                    {"default": "1280*720"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": ""}),
+                "duration": ([5, 10], {"default": 5}),
+                "enable_prompt_expansion": ("BOOLEAN", {"default": True}),
+                "shot_type": (["multi", "single"], {"default": "multi"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        videos: str,
+        size: str,
+        negative_prompt: str = "",
+        duration: int = 5,
+        enable_prompt_expansion: bool = True,
+        shot_type: str = "multi",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        video_list: List[str] = [v.strip() for v in (videos or "").splitlines() if v.strip()]
+        if not video_list:
+            raise RuntimeError("videos is required (provide 1-3 URLs, one per line)")
+        if len(video_list) > 3:
+            raise RuntimeError("videos maxItems is 3")
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.6/video-to-video",
+            "prompt": prompt,
+            "videos": video_list,
+            "size": size,
+            "duration": int(duration),
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "shot_type": shot_type,
+            "seed": int(seed),
+        }
+
+        if (negative_prompt or "").strip():
+            payload["negative_prompt"] = negative_prompt
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -19,6 +19,19 @@ from atlascloud_comfyui.nodes.legacy.nodes import Example as LegacyExample
 from atlascloud_comfyui.nodes.auth.atlas_client_node import AtlasClientNode
 
 from atlascloud_comfyui.nodes.video.wan26_t2v import AtlasWAN26TextToVideo
+from atlascloud_comfyui.nodes.video.wan26_i2v_flash import AtlasWAN26ImageToVideoFlash
+from atlascloud_comfyui.nodes.video.wan26_v2v import AtlasWAN26VideoToVideo
+from atlascloud_comfyui.nodes.image.wan26_t2i import AtlasWAN26TextToImage
+
+from atlascloud_comfyui.nodes.video.kling_video_o3_pro_t2v import AtlasKlingVideoO3ProTextToVideo
+from atlascloud_comfyui.nodes.video.kling_video_o3_pro_i2v import AtlasKlingVideoO3ProImageToVideo
+from atlascloud_comfyui.nodes.video.kling_video_o3_pro_r2v import AtlasKlingVideoO3ProReferenceToVideo
+from atlascloud_comfyui.nodes.video.kling_video_o3_pro_video_edit import AtlasKlingVideoO3ProVideoEdit
+
+from atlascloud_comfyui.nodes.video.kling_video_o3_std_t2v import AtlasKlingVideoO3StdTextToVideo
+from atlascloud_comfyui.nodes.video.kling_video_o3_std_i2v import AtlasKlingVideoO3StdImageToVideo
+from atlascloud_comfyui.nodes.video.kling_video_o3_std_r2v import AtlasKlingVideoO3StdReferenceToVideo
+from atlascloud_comfyui.nodes.video.kling_video_o3_std_video_edit import AtlasKlingVideoO3StdVideoEdit
 from atlascloud_comfyui.nodes.video.wan25_t2v import AtlasWAN25TextToVideo
 from atlascloud_comfyui.nodes.video.wan22_t2v_720p import AtlasWAN22T2V720p
 from atlascloud_comfyui.nodes.video.veo31_t2v import AtlasVeo31TextToVideo
@@ -86,6 +99,19 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Client": AtlasClientNode,
     "AtlasCloud WAN2.5 Text-to-Video": AtlasWAN25TextToVideo,
     "AtlasCloud WAN2.6 Text-to-Video": AtlasWAN26TextToVideo,
+    "AtlasCloud WAN2.6 Text-to-Image": AtlasWAN26TextToImage,
+    "AtlasCloud WAN2.6 Image-to-Video Flash": AtlasWAN26ImageToVideoFlash,
+    "AtlasCloud WAN2.6 Video-to-Video": AtlasWAN26VideoToVideo,
+
+    "AtlasCloud Kling Video O3 Pro Text-to-Video": AtlasKlingVideoO3ProTextToVideo,
+    "AtlasCloud Kling Video O3 Pro Image-to-Video": AtlasKlingVideoO3ProImageToVideo,
+    "AtlasCloud Kling Video O3 Pro Reference-to-Video": AtlasKlingVideoO3ProReferenceToVideo,
+    "AtlasCloud Kling Video O3 Pro Video-Edit": AtlasKlingVideoO3ProVideoEdit,
+
+    "AtlasCloud Kling Video O3 Std Text-to-Video": AtlasKlingVideoO3StdTextToVideo,
+    "AtlasCloud Kling Video O3 Std Image-to-Video": AtlasKlingVideoO3StdImageToVideo,
+    "AtlasCloud Kling Video O3 Std Reference-to-Video": AtlasKlingVideoO3StdReferenceToVideo,
+    "AtlasCloud Kling Video O3 Std Video-Edit": AtlasKlingVideoO3StdVideoEdit,
     "AtlasCloud WAN2.2 Text-to-Video 720p": AtlasWAN22T2V720p,
     "AtlasCloud VEO3.1 Text-to-Video": AtlasVeo31TextToVideo,
     "AtlasCloud Kling V2.6 Pro Text-to-Video": AtlasKlingV26ProTextToVideo,
@@ -150,6 +176,19 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Client": "AtlasCloud Client (API Key/Base URL)",
     "AtlasCloud WAN2.5 Text-to-Video": "AtlasCloud WAN2.5 Text-to-Video",
     "AtlasCloud WAN2.6 Text-to-Video": "AtlasCloud WAN2.6 Text-to-Video",
+    "AtlasCloud WAN2.6 Text-to-Image": "AtlasCloud WAN2.6 Text-to-Image",
+    "AtlasCloud WAN2.6 Image-to-Video Flash": "AtlasCloud WAN2.6 Image-to-Video Flash",
+    "AtlasCloud WAN2.6 Video-to-Video": "AtlasCloud WAN2.6 Video-to-Video",
+
+    "AtlasCloud Kling Video O3 Pro Text-to-Video": "AtlasCloud Kling Video O3 Pro Text-to-Video",
+    "AtlasCloud Kling Video O3 Pro Image-to-Video": "AtlasCloud Kling Video O3 Pro Image-to-Video",
+    "AtlasCloud Kling Video O3 Pro Reference-to-Video": "AtlasCloud Kling Video O3 Pro Reference-to-Video",
+    "AtlasCloud Kling Video O3 Pro Video-Edit": "AtlasCloud Kling Video O3 Pro Video-Edit",
+
+    "AtlasCloud Kling Video O3 Std Text-to-Video": "AtlasCloud Kling Video O3 Std Text-to-Video",
+    "AtlasCloud Kling Video O3 Std Image-to-Video": "AtlasCloud Kling Video O3 Std Image-to-Video",
+    "AtlasCloud Kling Video O3 Std Reference-to-Video": "AtlasCloud Kling Video O3 Std Reference-to-Video",
+    "AtlasCloud Kling Video O3 Std Video-Edit": "AtlasCloud Kling Video O3 Std Video-Edit",
     "AtlasCloud WAN2.2 Text-to-Video 720p": "AtlasCloud WAN2.2 Text-to-Video 720p",
     "AtlasCloud VEO3.1 Text-to-Video": "AtlasCloud VEO3.1 Text-to-Video",
     "AtlasCloud Kling V2.6 Pro Text-to-Video": "AtlasCloud Kling V2.6 Pro Text-to-Video",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -35,7 +35,7 @@ _t2i_image_url: str | None = None
 
 @skip_no_key
 def test_t2i():
-    """Test T2I: Google Imagen4 Fast (minimal params, fast, reliable credits)."""
+    """Test T2I: Google Imagen4 Fast (minimal params, fast, stable credits)."""
     global _t2i_image_url
     from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import (
         AtlasImagen4FastTextToImage,

--- a/tests/test_e2e_new_models.py
+++ b/tests/test_e2e_new_models.py
@@ -199,10 +199,19 @@ def test_kling_video_o3_pro_i2v():
 # Optional: requires a user-provided video URL (<=10s). Set env var to enable.
 @skip_no_key
 def test_kling_video_o3_video_edit_requires_input_video():
-    """Video-edit needs a real video URL; skip unless provided."""
+    """Video-edit needs a real video URL; skip unless provided.
+
+    Note: we've observed this job can stay in `created` for a long time depending on backend queue.
+    We therefore treat it as optional even when a key is present.
+    """
+
     video = os.getenv("ATLASCLOUD_E2E_VIDEO_URL", "").strip()
     if not video:
         pytest.skip("Set ATLASCLOUD_E2E_VIDEO_URL to run video-edit E2E")
+
+    # Allow forcing skip in CI if this model is queueing
+    if os.getenv("ATLASCLOUD_SKIP_VIDEO_EDIT_E2E", "").strip() == "1":
+        pytest.skip("ATLASCLOUD_SKIP_VIDEO_EDIT_E2E=1")
 
     from atlascloud_comfyui.nodes.video.kling_video_o3_std_video_edit import AtlasKlingVideoO3StdVideoEdit
 
@@ -217,7 +226,7 @@ def test_kling_video_o3_video_edit_requires_input_video():
         images="",
         keep_original_sound=True,
         poll_interval_sec=3.0,
-        timeout_sec=600,
+        timeout_sec=1200,
     )
     elapsed = time.time() - start
 

--- a/tests/test_e2e_new_models.py
+++ b/tests/test_e2e_new_models.py
@@ -33,9 +33,15 @@ def make_client() -> AtlasClientHandle:
     return AtlasClientHandle(client=client)
 
 
+# Module-level cache so I2V tests can reuse the T2I output
+_wan26_t2i_image_url: str | None = None
+
+
 @skip_no_key
 def test_wan26_t2i():
     """WAN2.6 text-to-image should return a URL."""
+    global _wan26_t2i_image_url
+
     from atlascloud_comfyui.nodes.image.wan26_t2i import AtlasWAN26TextToImage
 
     node = AtlasWAN26TextToImage()
@@ -59,6 +65,8 @@ def test_wan26_t2i():
     assert prediction_id
     assert image_url
     assert image_url.startswith("http") or image_url.startswith("data:"), image_url[:80]
+
+    _wan26_t2i_image_url = image_url
 
 
 @skip_no_key
@@ -107,6 +115,75 @@ def test_kling_video_o3_std_t2v():
         sound=False,
         poll_interval_sec=3.0,
         timeout_sec=420,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]
+
+
+@skip_no_key
+def test_wan26_i2v_flash():
+    """WAN2.6 image-to-video-flash should work using the WAN2.6 T2I image as input."""
+    from atlascloud_comfyui.nodes.video.wan26_i2v_flash import AtlasWAN26ImageToVideoFlash
+
+    image_url = _wan26_t2i_image_url
+    if not image_url:
+        pytest.skip("No image available (test_wan26_t2i must run first)")
+
+    node = AtlasWAN26ImageToVideoFlash()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        image=image_url,
+        prompt="The mug slowly rotates on the table with soft studio lighting",
+        resolution="720p",
+        duration=5,
+        enable_prompt_expansion=True,
+        shot_type="single",
+        generate_audio=False,
+        poll_interval_sec=3.0,
+        timeout_sec=600,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]
+
+
+@skip_no_key
+def test_kling_video_o3_pro_i2v():
+    """Kling Video O3 Pro image-to-video should work using the WAN2.6 T2I image as input."""
+    from atlascloud_comfyui.nodes.video.kling_video_o3_pro_i2v import AtlasKlingVideoO3ProImageToVideo
+
+    image_url = _wan26_t2i_image_url
+    if not image_url:
+        pytest.skip("No image available (test_wan26_t2i must run first)")
+
+    node = AtlasKlingVideoO3ProImageToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="The mug gently slides into frame and the camera pulls focus",
+        image=image_url,
+        duration=5,
+        generate_audio=False,
+        poll_interval_sec=3.0,
+        timeout_sec=600,
     )
     elapsed = time.time() - start
 

--- a/tests/test_e2e_new_models.py
+++ b/tests/test_e2e_new_models.py
@@ -1,0 +1,153 @@
+"""End-to-end tests for newly added WAN2.6 + Kling Video O3 nodes.
+
+Requires ATLASCLOUD_API_KEY environment variable.
+Run:
+  ATLASCLOUD_API_KEY=... PYTHONPATH=../ComfyUI pytest tests/test_e2e_new_models.py -v -s
+
+Notes:
+- These tests are designed to be optional in CI (will skip if no key).
+- Some nodes require user-provided assets (video URLs, reference videos). Those tests are included but skipped unless env vars are provided.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+# Add src to path
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+_HAS_KEY = bool(os.getenv("ATLASCLOUD_API_KEY", "").strip())
+skip_no_key = pytest.mark.skipif(not _HAS_KEY, reason="ATLASCLOUD_API_KEY not set")
+
+from atlascloud_comfyui.client.atlas_client import AtlasClient
+from atlascloud_comfyui.nodes.auth.atlas_client_node import AtlasClientHandle
+
+
+def make_client() -> AtlasClientHandle:
+    client = AtlasClient.from_env()
+    return AtlasClientHandle(client=client)
+
+
+@skip_no_key
+def test_wan26_t2i():
+    """WAN2.6 text-to-image should return a URL."""
+    from atlascloud_comfyui.nodes.image.wan26_t2i import AtlasWAN26TextToImage
+
+    node = AtlasWAN26TextToImage()
+    handle = make_client()
+
+    start = time.time()
+    image_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A minimalist product photo of a ceramic mug on a wooden table",
+        size="1024*1024",
+        enable_prompt_expansion=False,
+        poll_interval_sec=2.0,
+        timeout_sec=180,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  image_url:     {image_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert image_url
+    assert image_url.startswith("http") or image_url.startswith("data:"), image_url[:80]
+
+
+@skip_no_key
+def test_kling_video_o3_pro_t2v():
+    """Kling Video O3 Pro text-to-video should return a video URL."""
+    from atlascloud_comfyui.nodes.video.kling_video_o3_pro_t2v import AtlasKlingVideoO3ProTextToVideo
+
+    node = AtlasKlingVideoO3ProTextToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A cat wearing sunglasses rides a skateboard down a sunny street",
+        aspect_ratio="16:9",
+        duration=5,
+        sound=False,
+        poll_interval_sec=3.0,
+        timeout_sec=420,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]
+
+
+@skip_no_key
+def test_kling_video_o3_std_t2v():
+    """Kling Video O3 Std text-to-video should return a video URL."""
+    from atlascloud_comfyui.nodes.video.kling_video_o3_std_t2v import AtlasKlingVideoO3StdTextToVideo
+
+    node = AtlasKlingVideoO3StdTextToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A drone shot flying over a forest in early morning fog",
+        aspect_ratio="16:9",
+        duration=5,
+        sound=False,
+        poll_interval_sec=3.0,
+        timeout_sec=420,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]
+
+
+# Optional: requires a user-provided video URL (<=10s). Set env var to enable.
+@skip_no_key
+def test_kling_video_o3_video_edit_requires_input_video():
+    """Video-edit needs a real video URL; skip unless provided."""
+    video = os.getenv("ATLASCLOUD_E2E_VIDEO_URL", "").strip()
+    if not video:
+        pytest.skip("Set ATLASCLOUD_E2E_VIDEO_URL to run video-edit E2E")
+
+    from atlascloud_comfyui.nodes.video.kling_video_o3_std_video_edit import AtlasKlingVideoO3StdVideoEdit
+
+    node = AtlasKlingVideoO3StdVideoEdit()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="Remove the background and add a subtle cinematic color grade",
+        video=video,
+        images="",
+        keep_original_sound=True,
+        poll_interval_sec=3.0,
+        timeout_sec=600,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]

--- a/tests/test_new_nodes_wan26_kling_o3.py
+++ b/tests/test_new_nodes_wan26_kling_o3.py
@@ -1,0 +1,63 @@
+"""Metadata-only tests for newly added WAN2.6 + Kling O3 nodes.
+
+Keep these tests lightweight: they should not require ATLASCLOUD_API_KEY.
+"""
+
+from __future__ import annotations
+
+
+def test_wan26_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.wan26_t2i import AtlasWAN26TextToImage
+
+    required = AtlasWAN26TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasWAN26TextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan26_i2v_flash_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan26_i2v_flash import AtlasWAN26ImageToVideoFlash
+
+    required = AtlasWAN26ImageToVideoFlash.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasWAN26ImageToVideoFlash.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan26_v2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan26_v2v import AtlasWAN26VideoToVideo
+
+    required = AtlasWAN26VideoToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "videos" in required
+    assert "prompt" in required
+    assert AtlasWAN26VideoToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_video_o3_pro_nodes_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_pro_t2v import AtlasKlingVideoO3ProTextToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_pro_i2v import AtlasKlingVideoO3ProImageToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_pro_r2v import AtlasKlingVideoO3ProReferenceToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_pro_video_edit import AtlasKlingVideoO3ProVideoEdit
+
+    assert "atlas_client" in AtlasKlingVideoO3ProTextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in AtlasKlingVideoO3ProImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasKlingVideoO3ProImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in AtlasKlingVideoO3ProReferenceToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in AtlasKlingVideoO3ProVideoEdit.INPUT_TYPES()["required"]
+    assert "video" in AtlasKlingVideoO3ProVideoEdit.INPUT_TYPES()["required"]
+
+
+def test_kling_video_o3_std_nodes_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_std_t2v import AtlasKlingVideoO3StdTextToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_std_i2v import AtlasKlingVideoO3StdImageToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_std_r2v import AtlasKlingVideoO3StdReferenceToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_std_video_edit import AtlasKlingVideoO3StdVideoEdit
+
+    assert "atlas_client" in AtlasKlingVideoO3StdTextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in AtlasKlingVideoO3StdImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasKlingVideoO3StdImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in AtlasKlingVideoO3StdReferenceToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in AtlasKlingVideoO3StdVideoEdit.INPUT_TYPES()["required"]
+    assert "video" in AtlasKlingVideoO3StdVideoEdit.INPUT_TYPES()["required"]


### PR DESCRIPTION
## Summary
Adds new ComfyUI nodes for:
- **WAN2.6**
  - Text-to-Image: `alibaba/wan-2.6/text-to-image`
  - Image-to-Video Flash: `alibaba/wan-2.6/image-to-video-flash`
  - Video-to-Video: `alibaba/wan-2.6/video-to-video`
- **Kling Video O3 (Pro/Std)**
  - Text-to-Video: `kwaivgi/kling-video-o3-{pro|std}/text-to-video`
  - Image-to-Video: `kwaivgi/kling-video-o3-{pro|std}/image-to-video`
  - Reference-to-Video: `kwaivgi/kling-video-o3-{pro|std}/reference-to-video`
  - Video-Edit: `kwaivgi/kling-video-o3-{pro|std}/video-edit`

Includes:
- Registry updates (`src/atlascloud_comfyui/registry.py`)
- README node tables update
- Metadata-only tests for the new nodes

## Test plan
- [x] `ruff check .`
- [x] `pytest tests/ -v`
- [x] Local E2E sanity (existing suite): `PYTHONPATH=../ComfyUI ATLASCLOUD_API_KEY=*** pytest tests/test_e2e.py -v -s` (3/3 passed)

Notes
- `luma/photon-flash` returns insufficient credits for this key; E2E T2I uses `google/imagen4-fast` for stability.