### PR TITLE
feat: sync new AtlasCloud visual model nodes (2026-03-03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3 Text-to-Video | google/veo3 |
 | AtlasCloud VEO3 Fast Text-to-Video | google/veo3-fast |
 | AtlasCloud VEO3.1 Text-to-Video | google/veo3.1/text-to-video |
+| AtlasCloud VEO3.1 Fast Text-to-Video | google/veo3.1-fast/text-to-video |
 | AtlasCloud VEO2 Text-to-Video | google/veo2 |
 | AtlasCloud WAN2.6 Text-to-Video | alibaba/wan-2.6/text-to-video |
 | AtlasCloud WAN2.6 Video-to-Video | alibaba/wan-2.6/video-to-video |
@@ -104,9 +105,12 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | Node | Model |
 |------|-------|
 | AtlasCloud VEO3 Image-to-Video | google/veo3/image-to-video |
+| AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
+| AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |
 | AtlasCloud VEO3.1 Image-to-Video | google/veo3.1/image-to-video |
 | AtlasCloud VEO2 Image-to-Video | google/veo2/image-to-video |
 | AtlasCloud WAN2.5 Image-to-Video | alibaba/wan-2.5/image-to-video |
+| AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
 | AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |
 | AtlasCloud Kling Video O3 Std Image-to-Video | kwaivgi/kling-video-o3-std/image-to-video |
@@ -121,7 +125,9 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V3.0 Pro Image-to-Video | kwaivgi/kling-v3.0-pro/image-to-video |
 | AtlasCloud Kling V3.0 Std Image-to-Video | kwaivgi/kling-v3.0-std/image-to-video |
 | AtlasCloud Kling V2.5 Turbo Pro Image-to-Video | kwaivgi/kling-v2.5-turbo-pro/image-to-video |
+| AtlasCloud Vidu Q3 Text-to-Video | vidu/q3/text-to-video |
 | AtlasCloud Vidu Q3 Image-to-Video | vidu/image-to-video-2.0 |
+| AtlasCloud Vidu Q3 Image-to-Video (Q3 API) | vidu/q3/image-to-video |
 | AtlasCloud Hunyuan Image-to-Video | atlascloud/hunyuan-video/i2v |
 
 ### Text-to-Image (T2I)
@@ -139,6 +145,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Nano Banana 2 Text-to-Image Developer | google/nano-banana-2/text-to-image-developer |
 | AtlasCloud Nano Banana Pro Text-to-Image Ultra | google/nano-banana-pro/text-to-image-ultra |
 | AtlasCloud Seedream V5.0 Lite Text-to-Image | bytedance/seedream-v5.0-lite |
+| AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image | bytedance/seedream-v5.0-lite/sequential |
 | AtlasCloud Seedream V4.5 Text-to-Image | bytedance/seedream-v4.5 |
 | AtlasCloud Ideogram V3 Quality Text-to-Image | ideogram-ai/ideogram-v3-quality |
 | AtlasCloud Ideogram V3 Turbo Text-to-Image | ideogram-ai/ideogram-v3-turbo |
@@ -162,6 +169,9 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Nano Banana 2 Edit | google/nano-banana-2/edit |
 | AtlasCloud Nano Banana 2 Edit Developer | google/nano-banana-2/edit-developer |
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |
+| AtlasCloud Seedream V5.0 Lite Edit Sequential | bytedance/seedream-v5.0-lite/edit-sequential |
+| AtlasCloud WAN2.6 Image-Edit | alibaba/wan-2.6/image-edit |
+| AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
 
 > Nodes are continuously expanded as new models are added to AtlasCloud.
 

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_edit_plus_20251215.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_edit_plus_20251215.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasQwenImageEditPlus20251215:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-3 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Exclude instruction"}),
+                "prompt_extend": ("BOOLEAN", {"default": False, "tooltip": "Intelligent prompt rewriting"}),
+                "size": ("STRING", {"default": "", "tooltip": "Output resolution (512-2048). Empty = keep last image resolution"}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 6, "tooltip": "Number of output images (1-6)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        negative_prompt: str = "",
+        prompt_extend: bool = False,
+        size: str = "",
+        num_images: int = 1,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-3 lines)")
+        if len(image_list) > 3:
+            raise RuntimeError("images maxItems is 3")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/qwen-image/edit-plus-20251215",
+            "images": image_list,
+            "prompt": prompt,
+            "prompt_extend": bool(prompt_extend),
+            "num_images": int(num_images),
+            "seed": int(seed),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        if (size or "").strip():
+            payload["size"] = str(size).strip()
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v50_lite_edit_sequential.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v50_lite_edit_sequential.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV50LiteEditSequential:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt for editing"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-14 image URLs/base64, one per line"}),
+                "size": (
+                    [
+                        "2048*2048",
+                        "2304*1728",
+                        "1728*2304",
+                        "2848*1600",
+                        "1600*2848",
+                        "2496*1664",
+                        "1664*2496",
+                        "3136*1344",
+                        "3072*3072",
+                        "3456*2592",
+                        "2592*3456",
+                        "4096*2304",
+                        "2304*4096",
+                        "2496*3744",
+                        "3744*2496",
+                        "4704*2016",
+                    ],
+                    {"default": "2048*2048", "tooltip": "Output size (WIDTH*HEIGHT)"},
+                ),
+                "max_images": ("INT", {"default": 1, "min": 1, "max": 15, "tooltip": "Max images (1-15)"}),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output format"}),
+            },
+            "optional": {
+                "optimize_prompt_mode": (["standard", "fast"], {"default": "standard", "tooltip": "Prompt optimization mode"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str,
+        max_images: int,
+        output_format: str,
+        optimize_prompt_mode: str = "standard",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-14 lines)")
+        if len(image_list) > 14:
+            raise RuntimeError("images maxItems is 14")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v5.0-lite/edit-sequential",
+            "prompt": prompt,
+            "images": image_list,
+            "size": size,
+            "max_images": int(max_images),
+            "output_format": output_format,
+            "optimize_prompt_options": {"mode": optimize_prompt_mode},
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v50_lite_sequential_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v50_lite_sequential_t2i.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV50LiteSequentialTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "size": (
+                    [
+                        "2048*2048",
+                        "2304*1728",
+                        "1728*2304",
+                        "2848*1600",
+                        "1600*2848",
+                        "2496*1664",
+                        "1664*2496",
+                        "3136*1344",
+                        "3072*3072",
+                        "3456*2592",
+                        "2592*3456",
+                        "4096*2304",
+                        "2304*4096",
+                        "2496*3744",
+                        "3744*2496",
+                        "4704*2016",
+                    ],
+                    {"default": "2048*2048", "tooltip": "Output size (WIDTH*HEIGHT)"},
+                ),
+                "max_images": ("INT", {"default": 1, "min": 1, "max": 15, "tooltip": "Max images (1-15)"}),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output format"}),
+            },
+            "optional": {
+                "optimize_prompt_mode": (["standard", "fast"], {"default": "standard", "tooltip": "Prompt optimization mode"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        max_images: int,
+        output_format: str,
+        optimize_prompt_mode: str = "standard",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v5.0-lite/sequential",
+            "prompt": prompt,
+            "size": size,
+            "max_images": int(max_images),
+            "output_format": output_format,
+            "optimize_prompt_options": {"mode": optimize_prompt_mode},
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/wan26_image_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/wan26_image_edit.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWAN26ImageEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-4 image URLs/base64, one per line"}),
+                "size": (
+                    [
+                        "576*1344",
+                        "720*1280",
+                        "720*1680",
+                        "768*1024",
+                        "800*1200",
+                        "816*1904",
+                        "936*1664",
+                        "960*1280",
+                        "960*1440",
+                        "1024*768",
+                        "1024*1024",
+                        "1040*1560",
+                        "1104*1472",
+                        "1200*800",
+                        "1280*720",
+                        "1280*960",
+                        "1280*1280",
+                        "1344*576",
+                        "1440*960",
+                        "1472*1104",
+                        "1560*1040",
+                        "1664*936",
+                        "1680*720",
+                        "1904*816",
+                    ],
+                    {"default": "1280*1280", "tooltip": "Output size (WIDTH*HEIGHT)"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "enable_prompt_expansion": ("BOOLEAN", {"default": False, "tooltip": "Enable prompt optimizer"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str,
+        negative_prompt: str = "",
+        enable_prompt_expansion: bool = False,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-4 lines)")
+        if len(image_list) > 4:
+            raise RuntimeError("images maxItems is 4")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.6/image-edit",
+            "images": image_list,
+            "prompt": prompt,
+            "size": size,
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        payload["enable_prompt_expansion"] = bool(enable_prompt_expansion)
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            # Some schemas declare outputs as objects; best-effort common fields.
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_veo31_fast_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_veo31_fast_i2v.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeo31FastImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+            },
+            "optional": {
+                "last_image": ("STRING", {"default": "", "tooltip": "Optional end image URL or base64"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "duration": ([4, 6, 8], {"default": 4, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p", "1080p"], {"default": "1080p", "tooltip": "Resolution"}),
+                "generate_audio": ("BOOLEAN", {"default": False, "tooltip": "Generate audio"}),
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        last_image: str = "",
+        aspect_ratio: str = "16:9",
+        duration: int = 4,
+        resolution: str = "1080p",
+        generate_audio: bool = False,
+        negative_prompt: str = "",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/veo3.1-fast/image-to-video",
+            "prompt": prompt,
+            "image": image,
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "resolution": resolution,
+            "generate_audio": bool(generate_audio),
+        }
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_veo31_fast_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_veo31_fast_t2v.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeo31FastTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "duration": ([4, 6, 8], {"default": 4, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p", "1080p"], {"default": "1080p", "tooltip": "Resolution"}),
+                "generate_audio": ("BOOLEAN", {"default": False, "tooltip": "Generate audio"}),
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str = "16:9",
+        duration: int = 4,
+        resolution: str = "1080p",
+        generate_audio: bool = False,
+        negative_prompt: str = "",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload = {
+            "model": "google/veo3.1-fast/text-to-video",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "resolution": resolution,
+            "generate_audio": bool(generate_audio),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_veo31_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_veo31_r2v.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeo31ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-3 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "resolution": (["720p", "1080p"], {"default": "1080p", "tooltip": "Resolution"}),
+                "generate_audio": ("BOOLEAN", {"default": False, "tooltip": "Generate audio"}),
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        resolution: str = "1080p",
+        generate_audio: bool = False,
+        negative_prompt: str = "",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-3 lines)")
+        if len(image_list) > 3:
+            raise RuntimeError("images maxItems is 3")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/veo3.1/reference-to-video",
+            "prompt": prompt,
+            "images": image_list,
+            "resolution": resolution,
+            "generate_audio": bool(generate_audio),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_i2v_v2.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_i2v_v2.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3ImageToVideoV2:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 16, "step": 1, "tooltip": "Duration (seconds)"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement intensity"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str = "720p",
+        duration: int = 5,
+        movement_amplitude: str = "auto",
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_t2v.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "style": (["general", "anime"], {"default": "general", "tooltip": "Output style"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 16, "step": 1, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16", "4:3", "3:4", "1:1"], {"default": "4:3", "tooltip": "Aspect ratio"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement intensity"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        style: str = "general",
+        resolution: str = "720p",
+        duration: int = 5,
+        aspect_ratio: str = "4:3",
+        movement_amplitude: str = "auto",
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3/text-to-video",
+            "prompt": prompt,
+            "style": style,
+            "resolution": resolution,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan26_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/wan26_i2v.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWAN26ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+            },
+            "optional": {
+                "audio": ("STRING", {"default": "", "tooltip": "Optional audio URL"}),
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "duration": ([5, 10, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "enable_prompt_expansion": ("BOOLEAN", {"default": True, "tooltip": "Enable prompt optimizer"}),
+                "shot_type": (["multi", "single"], {"default": "multi", "tooltip": "Shot type (multi requires prompt expansion)"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Auto add audio"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        audio: str = "",
+        negative_prompt: str = "",
+        duration: int = 5,
+        enable_prompt_expansion: bool = True,
+        shot_type: str = "multi",
+        generate_audio: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for WAN2.6 Image-to-Video")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        # Schema constraint: when shot_type=multi, enable_prompt_expansion must be true.
+        if shot_type == "multi" and not enable_prompt_expansion:
+            raise RuntimeError("shot_type='multi' requires enable_prompt_expansion=True")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.6/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "shot_type": shot_type,
+            "generate_audio": bool(generate_audio),
+            "seed": int(seed),
+        }
+
+        if (audio or "").strip():
+            payload["audio"] = audio
+        if (negative_prompt or "").strip():
+            payload["negative_prompt"] = negative_prompt
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -20,8 +20,10 @@ from atlascloud_comfyui.nodes.auth.atlas_client_node import AtlasClientNode
 
 from atlascloud_comfyui.nodes.video.wan26_t2v import AtlasWAN26TextToVideo
 from atlascloud_comfyui.nodes.video.wan26_i2v_flash import AtlasWAN26ImageToVideoFlash
+from atlascloud_comfyui.nodes.video.wan26_i2v import AtlasWAN26ImageToVideo
 from atlascloud_comfyui.nodes.video.wan26_v2v import AtlasWAN26VideoToVideo
 from atlascloud_comfyui.nodes.image.wan26_t2i import AtlasWAN26TextToImage
+from atlascloud_comfyui.nodes.image.wan26_image_edit import AtlasWAN26ImageEdit
 
 from atlascloud_comfyui.nodes.video.kling_video_o3_pro_t2v import AtlasKlingVideoO3ProTextToVideo
 from atlascloud_comfyui.nodes.video.kling_video_o3_pro_i2v import AtlasKlingVideoO3ProImageToVideo
@@ -55,8 +57,13 @@ from atlascloud_comfyui.nodes.video.sora2_i2v import AtlasSora2ImageToVideo
 from atlascloud_comfyui.nodes.video.kling_v25_turbo_pro_t2v import AtlasKlingV25TurboProTextToVideo
 from atlascloud_comfyui.nodes.video.hunyuan_t2v import AtlasHunyuanTextToVideo
 from atlascloud_comfyui.nodes.video.vidu_q3_i2v import AtlasViduQ3ImageToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_i2v_v2 import AtlasViduQ3ImageToVideoV2
+from atlascloud_comfyui.nodes.video.vidu_q3_t2v import AtlasViduQ3TextToVideo
 from atlascloud_comfyui.nodes.video.veo3_fast_t2v import AtlasVeo3FastTextToVideo
 from atlascloud_comfyui.nodes.video.veo31_i2v import AtlasVeo31ImageToVideo
+from atlascloud_comfyui.nodes.video.google_veo31_fast_t2v import AtlasVeo31FastTextToVideo
+from atlascloud_comfyui.nodes.video.google_veo31_fast_i2v import AtlasVeo31FastImageToVideo
+from atlascloud_comfyui.nodes.video.google_veo31_r2v import AtlasVeo31ReferenceToVideo
 from atlascloud_comfyui.nodes.video.veo3_i2v import AtlasVeo3ImageToVideo
 from atlascloud_comfyui.nodes.video.veo2_t2v import AtlasVeo2TextToVideo
 from atlascloud_comfyui.nodes.video.veo2_i2v import AtlasVeo2ImageToVideo
@@ -81,6 +88,8 @@ from atlascloud_comfyui.nodes.image.nano_banana2_edit import AtlasNanoBanana2Edi
 from atlascloud_comfyui.nodes.image.nano_banana2_edit_dev import AtlasNanoBanana2EditDev
 from atlascloud_comfyui.nodes.image.seedream_v50_lite_t2i import AtlasSeedreamV50LiteTextToImage
 from atlascloud_comfyui.nodes.image.seedream_v50_lite_edit import AtlasSeedreamV50LiteEdit
+from atlascloud_comfyui.nodes.image.seedream_v50_lite_sequential_t2i import AtlasSeedreamV50LiteSequentialTextToImage
+from atlascloud_comfyui.nodes.image.seedream_v50_lite_edit_sequential import AtlasSeedreamV50LiteEditSequential
 from atlascloud_comfyui.nodes.image.imagen4_t2i import AtlasImagen4TextToImage
 from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import AtlasImagen4FastTextToImage
 from atlascloud_comfyui.nodes.image.imagen4_ultra_t2i import AtlasImagen4UltraTextToImage
@@ -90,6 +99,7 @@ from atlascloud_comfyui.nodes.image.ideogram_v3_turbo_t2i import AtlasIdeogramV3
 from atlascloud_comfyui.nodes.image.luma_photon_t2i import AtlasLumaPhotonTextToImage
 from atlascloud_comfyui.nodes.image.luma_photon_flash_t2i import AtlasLumaPhotonFlashTextToImage
 from atlascloud_comfyui.nodes.image.recraft_v3_t2i import AtlasRecraftV3TextToImage
+from atlascloud_comfyui.nodes.image.qwen_image_edit_plus_20251215 import AtlasQwenImageEditPlus20251215
 
 from atlascloud_comfyui.nodes.utils.image_preview import AtlasImagePreviewURL
 from atlascloud_comfyui.nodes.utils.video_previewer import AtlasVideoPreviewer
@@ -100,6 +110,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.5 Text-to-Video": AtlasWAN25TextToVideo,
     "AtlasCloud WAN2.6 Text-to-Video": AtlasWAN26TextToVideo,
     "AtlasCloud WAN2.6 Text-to-Image": AtlasWAN26TextToImage,
+    "AtlasCloud WAN2.6 Image-Edit": AtlasWAN26ImageEdit,
+    "AtlasCloud WAN2.6 Image-to-Video": AtlasWAN26ImageToVideo,
     "AtlasCloud WAN2.6 Image-to-Video Flash": AtlasWAN26ImageToVideoFlash,
     "AtlasCloud WAN2.6 Video-to-Video": AtlasWAN26VideoToVideo,
 
@@ -135,8 +147,12 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Nano Banana 2 Edit": AtlasNanoBanana2Edit,
     "AtlasCloud Nano Banana 2 Edit Developer": AtlasNanoBanana2EditDev,
     "AtlasCloud Seedream V5.0 Lite Text-to-Image": AtlasSeedreamV50LiteTextToImage,
+    "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image": AtlasSeedreamV50LiteSequentialTextToImage,
     "AtlasCloud Seedream V5.0 Lite Edit": AtlasSeedreamV50LiteEdit,
+    "AtlasCloud Seedream V5.0 Lite Edit Sequential": AtlasSeedreamV50LiteEditSequential,
+    "AtlasCloud Vidu Q3 Text-to-Video": AtlasViduQ3TextToVideo,
     "AtlasCloud Vidu Q3 Image-to-Video": AtlasViduQ3ImageToVideo,
+    "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)": AtlasViduQ3ImageToVideoV2,
     "AtlasCloud VEO3 Text-to-Video": AtlasVeo3TextToVideo,
     "AtlasCloud Imagen4 Text-to-Image": AtlasImagen4TextToImage,
     "AtlasCloud Imagen4 Fast Text-to-Image": AtlasImagen4FastTextToImage,
@@ -149,6 +165,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video": AtlasKlingV25TurboProTextToVideo,
     "AtlasCloud Hunyuan Text-to-Video": AtlasHunyuanTextToVideo,
     "AtlasCloud VEO3 Fast Text-to-Video": AtlasVeo3FastTextToVideo,
+    "AtlasCloud VEO3.1 Fast Text-to-Video": AtlasVeo31FastTextToVideo,
+    "AtlasCloud VEO3.1 Fast Image-to-Video": AtlasVeo31FastImageToVideo,
+    "AtlasCloud VEO3.1 Reference-to-Video": AtlasVeo31ReferenceToVideo,
     "AtlasCloud VEO3.1 Image-to-Video": AtlasVeo31ImageToVideo,
     "AtlasCloud VEO3 Image-to-Video": AtlasVeo3ImageToVideo,
     "AtlasCloud VEO2 Text-to-Video": AtlasVeo2TextToVideo,
@@ -170,13 +189,17 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Luma Photon Text-to-Image": AtlasLumaPhotonTextToImage,
     "AtlasCloud Luma Photon Flash Text-to-Image": AtlasLumaPhotonFlashTextToImage,
     "AtlasCloud Recraft V3 Text-to-Image": AtlasRecraftV3TextToImage,
+    "AtlasCloud Qwen Image Edit Plus 20251215": AtlasQwenImageEditPlus20251215,
 }
+
 
 NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Client": "AtlasCloud Client (API Key/Base URL)",
     "AtlasCloud WAN2.5 Text-to-Video": "AtlasCloud WAN2.5 Text-to-Video",
     "AtlasCloud WAN2.6 Text-to-Video": "AtlasCloud WAN2.6 Text-to-Video",
     "AtlasCloud WAN2.6 Text-to-Image": "AtlasCloud WAN2.6 Text-to-Image",
+    "AtlasCloud WAN2.6 Image-Edit": "AtlasCloud WAN2.6 Image-Edit",
+    "AtlasCloud WAN2.6 Image-to-Video": "AtlasCloud WAN2.6 Image-to-Video",
     "AtlasCloud WAN2.6 Image-to-Video Flash": "AtlasCloud WAN2.6 Image-to-Video Flash",
     "AtlasCloud WAN2.6 Video-to-Video": "AtlasCloud WAN2.6 Video-to-Video",
 
@@ -212,8 +235,12 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Nano Banana 2 Edit": "AtlasCloud Nano Banana 2 Edit",
     "AtlasCloud Nano Banana 2 Edit Developer": "AtlasCloud Nano Banana 2 Edit Developer",
     "AtlasCloud Seedream V5.0 Lite Text-to-Image": "AtlasCloud Seedream V5.0 Lite Text-to-Image",
+    "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image": "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image",
     "AtlasCloud Seedream V5.0 Lite Edit": "AtlasCloud Seedream V5.0 Lite Edit",
+    "AtlasCloud Seedream V5.0 Lite Edit Sequential": "AtlasCloud Seedream V5.0 Lite Edit Sequential",
+    "AtlasCloud Vidu Q3 Text-to-Video": "AtlasCloud Vidu Q3 Text-to-Video",
     "AtlasCloud Vidu Q3 Image-to-Video": "AtlasCloud Vidu Q3 Image-to-Video",
+    "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)": "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)",
     "AtlasCloud VEO3 Text-to-Video": "AtlasCloud VEO3 Text-to-Video",
     "AtlasCloud Imagen4 Text-to-Image": "AtlasCloud Imagen4 Text-to-Image",
     "AtlasCloud Imagen4 Fast Text-to-Image": "AtlasCloud Imagen4 Fast Text-to-Image",
@@ -226,6 +253,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video": "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video",
     "AtlasCloud Hunyuan Text-to-Video": "AtlasCloud Hunyuan Text-to-Video",
     "AtlasCloud VEO3 Fast Text-to-Video": "AtlasCloud VEO3 Fast Text-to-Video",
+    "AtlasCloud VEO3.1 Fast Text-to-Video": "AtlasCloud VEO3.1 Fast Text-to-Video",
+    "AtlasCloud VEO3.1 Fast Image-to-Video": "AtlasCloud VEO3.1 Fast Image-to-Video",
+    "AtlasCloud VEO3.1 Reference-to-Video": "AtlasCloud VEO3.1 Reference-to-Video",
     "AtlasCloud VEO3.1 Image-to-Video": "AtlasCloud VEO3.1 Image-to-Video",
     "AtlasCloud VEO3 Image-to-Video": "AtlasCloud VEO3 Image-to-Video",
     "AtlasCloud VEO2 Text-to-Video": "AtlasCloud VEO2 Text-to-Video",
@@ -247,7 +277,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Luma Photon Text-to-Image": "AtlasCloud Luma Photon Text-to-Image",
     "AtlasCloud Luma Photon Flash Text-to-Image": "AtlasCloud Luma Photon Flash Text-to-Image",
     "AtlasCloud Recraft V3 Text-to-Image": "AtlasCloud Recraft V3 Text-to-Image",
+    "AtlasCloud Qwen Image Edit Plus 20251215": "AtlasCloud Qwen Image Edit Plus 20251215",
 }
+
 
 NODE_CLASS_MAPPINGS["Example"] = LegacyExample
 NODE_DISPLAY_NAME_MAPPINGS["Example"] = "Example (Deprecated)"

--- a/tests/test_new_nodes_2026_03_03.py
+++ b/tests/test_new_nodes_2026_03_03.py
@@ -1,0 +1,94 @@
+"""Metadata-only tests for nodes added in the 2026-03-03 sync.
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+They only validate node metadata (INPUT_TYPES / RETURN_TYPES) so CI can run safely.
+"""
+
+from __future__ import annotations
+
+
+def test_vidu_q3_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_t2v import AtlasViduQ3TextToVideo
+
+    assert "atlas_client" in AtlasViduQ3TextToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasViduQ3TextToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q3_i2v_v2_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_i2v_v2 import AtlasViduQ3ImageToVideoV2
+
+    assert "atlas_client" in AtlasViduQ3ImageToVideoV2.INPUT_TYPES()["required"]
+    assert "image" in AtlasViduQ3ImageToVideoV2.INPUT_TYPES()["required"]
+    assert AtlasViduQ3ImageToVideoV2.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_veo31_fast_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_veo31_fast_t2v import AtlasVeo31FastTextToVideo
+
+    assert "atlas_client" in AtlasVeo31FastTextToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasVeo31FastTextToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeo31FastTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_veo31_fast_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_veo31_fast_i2v import AtlasVeo31FastImageToVideo
+
+    assert "atlas_client" in AtlasVeo31FastImageToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasVeo31FastImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasVeo31FastImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeo31FastImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_veo31_reference_to_video_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_veo31_r2v import AtlasVeo31ReferenceToVideo
+
+    assert "atlas_client" in AtlasVeo31ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasVeo31ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "images" in AtlasVeo31ReferenceToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeo31ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v50_lite_sequential_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_lite_sequential_t2i import AtlasSeedreamV50LiteSequentialTextToImage
+
+    assert "atlas_client" in AtlasSeedreamV50LiteSequentialTextToImage.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasSeedreamV50LiteSequentialTextToImage.INPUT_TYPES()["required"]
+    assert AtlasSeedreamV50LiteSequentialTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v50_lite_edit_sequential_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_lite_edit_sequential import AtlasSeedreamV50LiteEditSequential
+
+    assert "atlas_client" in AtlasSeedreamV50LiteEditSequential.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasSeedreamV50LiteEditSequential.INPUT_TYPES()["required"]
+    assert "images" in AtlasSeedreamV50LiteEditSequential.INPUT_TYPES()["required"]
+    assert AtlasSeedreamV50LiteEditSequential.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan26_image_to_video_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan26_i2v import AtlasWAN26ImageToVideo
+
+    assert "atlas_client" in AtlasWAN26ImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasWAN26ImageToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWAN26ImageToVideo.INPUT_TYPES()["required"]
+    assert "resolution" in AtlasWAN26ImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasWAN26ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan26_image_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.wan26_image_edit import AtlasWAN26ImageEdit
+
+    assert "atlas_client" in AtlasWAN26ImageEdit.INPUT_TYPES()["required"]
+    assert "images" in AtlasWAN26ImageEdit.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWAN26ImageEdit.INPUT_TYPES()["required"]
+    assert AtlasWAN26ImageEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_qwen_image_edit_plus_20251215_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_edit_plus_20251215 import AtlasQwenImageEditPlus20251215
+
+    assert "atlas_client" in AtlasQwenImageEditPlus20251215.INPUT_TYPES()["required"]
+    assert "images" in AtlasQwenImageEditPlus20251215.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasQwenImageEditPlus20251215.INPUT_TYPES()["required"]
+    assert AtlasQwenImageEditPlus20251215.RETURN_TYPES == ("STRING", "STRING")


### PR DESCRIPTION
## Summary
Adds ComfyUI node support for newly listed / HOT+NEW visual models from AtlasCloud API:

- Google VEO3.1 Fast: Text-to-Video + Image-to-Video
- Google VEO3.1 Reference-to-Video
- Vidu Q3: Text-to-Video + Image-to-Video (Q3 API)
- Bytedance Seedream v5.0 lite: sequential + edit-sequential
- Alibaba WAN2.6: image-to-video + image-edit
- Alibaba Qwen Image: edit-plus-20251215

Notes:
- Kept existing legacy Vidu Q3 I2V node (model id: ) and added a new Q3 API variant node so existing workflows don’t break.

## Test plan
- [x] ruff: All checks passed!
- [x] unit/metadata: ============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /Users/vcvdigital/Desktop/openclaw/workspace/atlascloud_comfyui/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/vcvdigital/Desktop/openclaw/workspace/atlascloud_comfyui/tests
configfile: pytest.ini
plugins: anyio-4.12.1
collecting ... collected 68 items

tests/test_atlascloud_comfyui.py::test_atlas_client_node_initialization PASSED [  1%]
tests/test_atlascloud_comfyui.py::test_atlas_client_node_metadata PASSED [  2%]
tests/test_atlascloud_comfyui.py::test_wan26_t2v_node_metadata PASSED    [  4%]
tests/test_atlascloud_comfyui.py::test_flux2_flex_t2i_node_metadata PASSED [  5%]
tests/test_atlascloud_comfyui.py::test_nano_banana2_t2i_node_metadata PASSED [  7%]
tests/test_atlascloud_comfyui.py::test_nano_banana2_t2i_dev_node_metadata PASSED [  8%]
tests/test_atlascloud_comfyui.py::test_nano_banana2_edit_node_metadata PASSED [ 10%]
tests/test_atlascloud_comfyui.py::test_nano_banana2_edit_dev_node_metadata PASSED [ 11%]
tests/test_atlascloud_comfyui.py::test_seedream_v50_lite_t2i_node_metadata PASSED [ 13%]
tests/test_atlascloud_comfyui.py::test_seedream_v50_lite_edit_node_metadata PASSED [ 14%]
tests/test_atlascloud_comfyui.py::test_vidu_q3_i2v_node_metadata PASSED  [ 16%]
tests/test_atlascloud_comfyui.py::test_veo3_t2v_node_metadata PASSED     [ 17%]
tests/test_atlascloud_comfyui.py::test_imagen4_t2i_node_metadata PASSED  [ 19%]
tests/test_atlascloud_comfyui.py::test_imagen4_fast_t2i_node_metadata PASSED [ 20%]
tests/test_atlascloud_comfyui.py::test_luma_ray2_t2v_node_metadata PASSED [ 22%]
tests/test_atlascloud_comfyui.py::test_luma_ray2_i2v_node_metadata PASSED [ 23%]
tests/test_atlascloud_comfyui.py::test_pika_v22_t2v_node_metadata PASSED [ 25%]
tests/test_atlascloud_comfyui.py::test_pixverse_v45_t2v_node_metadata PASSED [ 26%]
tests/test_atlascloud_comfyui.py::test_hailuo_02_t2v_pro_node_metadata PASSED [ 27%]
tests/test_atlascloud_comfyui.py::test_sora2_i2v_node_metadata PASSED    [ 29%]
tests/test_atlascloud_comfyui.py::test_kling_v25_turbo_pro_t2v_node_metadata PASSED [ 30%]
tests/test_atlascloud_comfyui.py::test_hunyuan_t2v_node_metadata PASSED  [ 32%]
tests/test_atlascloud_comfyui.py::test_veo3_fast_t2v_node_metadata PASSED [ 33%]
tests/test_atlascloud_comfyui.py::test_veo31_i2v_node_metadata PASSED    [ 35%]
tests/test_atlascloud_comfyui.py::test_veo3_i2v_node_metadata PASSED     [ 36%]
tests/test_atlascloud_comfyui.py::test_veo2_t2v_node_metadata PASSED     [ 38%]
tests/test_atlascloud_comfyui.py::test_veo2_i2v_node_metadata PASSED     [ 39%]
tests/test_atlascloud_comfyui.py::test_luma_ray2_flash_t2v_node_metadata PASSED [ 41%]
tests/test_atlascloud_comfyui.py::test_pika_v20_turbo_t2v_node_metadata PASSED [ 42%]
tests/test_atlascloud_comfyui.py::test_pika_v21_i2v_node_metadata PASSED [ 44%]
tests/test_atlascloud_comfyui.py::test_pixverse_v45_i2v_node_metadata PASSED [ 45%]
tests/test_atlascloud_comfyui.py::test_hailuo_02_i2v_pro_node_metadata PASSED [ 47%]
tests/test_atlascloud_comfyui.py::test_sora2_i2v_pro_node_metadata PASSED [ 48%]
tests/test_atlascloud_comfyui.py::test_sora2_t2v_node_metadata PASSED    [ 50%]
tests/test_atlascloud_comfyui.py::test_kling_v25_turbo_pro_i2v_node_metadata PASSED [ 51%]
tests/test_atlascloud_comfyui.py::test_hunyuan_i2v_node_metadata PASSED  [ 52%]
tests/test_atlascloud_comfyui.py::test_wan25_i2v_node_metadata PASSED    [ 54%]
tests/test_atlascloud_comfyui.py::test_imagen4_ultra_t2i_node_metadata PASSED [ 55%]
tests/test_atlascloud_comfyui.py::test_imagen3_t2i_node_metadata PASSED  [ 57%]
tests/test_atlascloud_comfyui.py::test_ideogram_v3_quality_t2i_node_metadata PASSED [ 58%]
tests/test_atlascloud_comfyui.py::test_ideogram_v3_turbo_t2i_node_metadata PASSED [ 60%]
tests/test_atlascloud_comfyui.py::test_luma_photon_t2i_node_metadata PASSED [ 61%]
tests/test_atlascloud_comfyui.py::test_luma_photon_flash_t2i_node_metadata PASSED [ 63%]
tests/test_atlascloud_comfyui.py::test_recraft_v3_t2i_node_metadata PASSED [ 64%]
tests/test_e2e.py::test_t2i SKIPPED (ATLASCLOUD_API_KEY not set)         [ 66%]
tests/test_e2e.py::test_t2v SKIPPED (ATLASCLOUD_API_KEY not set)         [ 67%]
tests/test_e2e.py::test_i2v SKIPPED (ATLASCLOUD_API_KEY not set)         [ 69%]
tests/test_e2e_new_models.py::test_wan26_t2i SKIPPED (ATLASCLOUD_API...) [ 70%]
tests/test_e2e_new_models.py::test_kling_video_o3_pro_t2v SKIPPED (A...) [ 72%]
tests/test_e2e_new_models.py::test_kling_video_o3_std_t2v SKIPPED (A...) [ 73%]
tests/test_e2e_new_models.py::test_wan26_i2v_flash SKIPPED (ATLASCLO...) [ 75%]
tests/test_e2e_new_models.py::test_kling_video_o3_pro_i2v SKIPPED (A...) [ 76%]
tests/test_e2e_new_models.py::test_kling_video_o3_video_edit_requires_input_video SKIPPED [ 77%]
tests/test_new_nodes_2026_03_03.py::test_vidu_q3_t2v_node_metadata PASSED [ 79%]
tests/test_new_nodes_2026_03_03.py::test_vidu_q3_i2v_v2_node_metadata PASSED [ 80%]
tests/test_new_nodes_2026_03_03.py::test_veo31_fast_t2v_node_metadata PASSED [ 82%]
tests/test_new_nodes_2026_03_03.py::test_veo31_fast_i2v_node_metadata PASSED [ 83%]
tests/test_new_nodes_2026_03_03.py::test_veo31_reference_to_video_node_metadata PASSED [ 85%]
tests/test_new_nodes_2026_03_03.py::test_seedream_v50_lite_sequential_t2i_node_metadata PASSED [ 86%]
tests/test_new_nodes_2026_03_03.py::test_seedream_v50_lite_edit_sequential_node_metadata PASSED [ 88%]
tests/test_new_nodes_2026_03_03.py::test_wan26_image_to_video_node_metadata PASSED [ 89%]
tests/test_new_nodes_2026_03_03.py::test_wan26_image_edit_node_metadata PASSED [ 91%]
tests/test_new_nodes_2026_03_03.py::test_qwen_image_edit_plus_20251215_node_metadata PASSED [ 92%]
tests/test_new_nodes_wan26_kling_o3.py::test_wan26_t2i_node_metadata PASSED [ 94%]
tests/test_new_nodes_wan26_kling_o3.py::test_wan26_i2v_flash_node_metadata PASSED [ 95%]
tests/test_new_nodes_wan26_kling_o3.py::test_wan26_v2v_node_metadata PASSED [ 97%]
tests/test_new_nodes_wan26_kling_o3.py::test_kling_video_o3_pro_nodes_metadata PASSED [ 98%]
tests/test_new_nodes_wan26_kling_o3.py::test_kling_video_o3_std_nodes_metadata PASSED [100%]

======================== 59 passed, 9 skipped in 0.02s ========================= (E2E auto-skips without key)
- [x] E2E baseline: ============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /Users/vcvdigital/Desktop/openclaw/workspace/atlascloud_comfyui/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/vcvdigital/Desktop/openclaw/workspace/atlascloud_comfyui/tests
configfile: pytest.ini
plugins: anyio-4.12.1
collecting ... collected 3 items

tests/test_e2e.py::test_t2i FAILED
tests/test_e2e.py::test_t2v FAILED
tests/test_e2e.py::test_i2v SKIPPED (No image available (test_t2i mu...)

=================================== FAILURES ===================================
___________________________________ test_t2i ___________________________________

    @skip_no_key
    def test_t2i():
        """Test T2I: Google Imagen4 Fast (minimal params, fast, stable credits)."""
        global _t2i_image_url
        from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import (
            AtlasImagen4FastTextToImage,
        )
    
        node = AtlasImagen4FastTextToImage()
        handle = make_client()
    
        start = time.time()
>       result = node.run(
            atlas_client=handle,
            prompt="A cute orange cat sitting on a windowsill",
            aspect_ratio="1:1",
            num_images=1,
            enable_base64_output=False,
            poll_interval_sec=2.0,
            timeout_sec=120,
        )

tests/test_e2e.py:48: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/atlascloud_comfyui/nodes/image/imagen4_fast_t2i.py:63: in run
    prediction_id = client.generate_image(payload)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/atlascloud_comfyui/client/atlas_client.py:75: in generate_image
    r.raise_for_status()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Response [404]>

    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""
    
        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason
    
        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )
    
        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )
    
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.atlascloud.ai/api/v1/model/generateImage?utm_source=github&utm_medium=readme&utm_campaign=comfyui

.venv/lib/python3.11/site-packages/requests/models.py:1026: HTTPError
___________________________________ test_t2v ___________________________________

    @skip_no_key
    def test_t2v():
        """Test T2V: Hailuo 02 T2V Pro (minimal params)."""
        from atlascloud_comfyui.nodes.video.hailuo_02_t2v_pro import AtlasHailuo02T2VPro
    
        node = AtlasHailuo02T2VPro()
        handle = make_client()
    
        start = time.time()
>       result = node.run(
            atlas_client=handle,
            prompt="A cat walking across a sunny garden",
            enable_prompt_expansion=False,
            poll_interval_sec=3.0,
            timeout_sec=300,
        )

tests/test_e2e.py:79: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/atlascloud_comfyui/nodes/video/hailuo_02_t2v_pro.py:44: in run
    prediction_id = client.generate_video(payload)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/atlascloud_comfyui/client/atlas_client.py:61: in generate_video
    r.raise_for_status()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Response [404]>

    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""
    
        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason
    
        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )
    
        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )
    
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.atlascloud.ai/api/v1/model/generateVideo?utm_source=github&utm_medium=readme&utm_campaign=comfyui

.venv/lib/python3.11/site-packages/requests/models.py:1026: HTTPError
=========================== short test summary info ============================
FAILED tests/test_e2e.py::test_t2i - requests.exceptions.HTTPError: 404 Clien...
FAILED tests/test_e2e.py::test_t2v - requests.exceptions.HTTPError: 404 Clien...
========================= 2 failed, 1 skipped in 0.44s =========================
- [x] E2E new models: ============================= test session starts ==============================
platform darwin -- Python 3.11.14, pytest-9.0.2, pluggy-1.6.0 -- /Users/vcvdigital/Desktop/openclaw/workspace/atlascloud_comfyui/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/vcvdigital/Desktop/openclaw/workspace/atlascloud_comfyui/tests
configfile: pytest.ini
plugins: anyio-4.12.1
collecting ... collected 6 items

tests/test_e2e_new_models.py::test_wan26_t2i FAILED
tests/test_e2e_new_models.py::test_kling_video_o3_pro_t2v FAILED
tests/test_e2e_new_models.py::test_kling_video_o3_std_t2v FAILED
tests/test_e2e_new_models.py::test_wan26_i2v_flash SKIPPED (No image...)
tests/test_e2e_new_models.py::test_kling_video_o3_pro_i2v SKIPPED (N...)
tests/test_e2e_new_models.py::test_kling_video_o3_video_edit_requires_input_video SKIPPED

=================================== FAILURES ===================================
________________________________ test_wan26_t2i ________________________________

    @skip_no_key
    def test_wan26_t2i():
        """WAN2.6 text-to-image should return a URL."""
        global _wan26_t2i_image_url
    
        from atlascloud_comfyui.nodes.image.wan26_t2i import AtlasWAN26TextToImage
    
        node = AtlasWAN26TextToImage()
        handle = make_client()
    
        start = time.time()
>       image_url, prediction_id = node.run(
            atlas_client=handle,
            prompt="A minimalist product photo of a ceramic mug on a wooden table",
            size="1024*1024",
            enable_prompt_expansion=False,
            poll_interval_sec=2.0,
            timeout_sec=180,
        )

tests/test_e2e_new_models.py:51: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/atlascloud_comfyui/nodes/image/wan26_t2i.py:90: in run
    prediction_id = client.generate_image(payload)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/atlascloud_comfyui/client/atlas_client.py:75: in generate_image
    r.raise_for_status()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Response [404]>

    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""
    
        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason
    
        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )
    
        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )
    
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.atlascloud.ai/api/v1/model/generateImage?utm_source=github&utm_medium=readme&utm_campaign=comfyui

.venv/lib/python3.11/site-packages/requests/models.py:1026: HTTPError
_________________________ test_kling_video_o3_pro_t2v __________________________

    @skip_no_key
    def test_kling_video_o3_pro_t2v():
        """Kling Video O3 Pro text-to-video should return a video URL."""
        from atlascloud_comfyui.nodes.video.kling_video_o3_pro_t2v import AtlasKlingVideoO3ProTextToVideo
    
        node = AtlasKlingVideoO3ProTextToVideo()
        handle = make_client()
    
        start = time.time()
>       video_url, prediction_id = node.run(
            atlas_client=handle,
            prompt="A cat wearing sunglasses rides a skateboard down a sunny street",
            aspect_ratio="16:9",
            duration=5,
            sound=False,
            poll_interval_sec=3.0,
            timeout_sec=420,
        )

tests/test_e2e_new_models.py:81: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/atlascloud_comfyui/nodes/video/kling_video_o3_pro_t2v.py:50: in run
    prediction_id = client.generate_video(payload)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/atlascloud_comfyui/client/atlas_client.py:61: in generate_video
    r.raise_for_status()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Response [404]>

    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""
    
        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason
    
        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )
    
        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )
    
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.atlascloud.ai/api/v1/model/generateVideo?utm_source=github&utm_medium=readme&utm_campaign=comfyui

.venv/lib/python3.11/site-packages/requests/models.py:1026: HTTPError
_________________________ test_kling_video_o3_std_t2v __________________________

    @skip_no_key
    def test_kling_video_o3_std_t2v():
        """Kling Video O3 Std text-to-video should return a video URL."""
        from atlascloud_comfyui.nodes.video.kling_video_o3_std_t2v import AtlasKlingVideoO3StdTextToVideo
    
        node = AtlasKlingVideoO3StdTextToVideo()
        handle = make_client()
    
        start = time.time()
>       video_url, prediction_id = node.run(
            atlas_client=handle,
            prompt="A drone shot flying over a forest in early morning fog",
            aspect_ratio="16:9",
            duration=5,
            sound=False,
            poll_interval_sec=3.0,
            timeout_sec=420,
        )

tests/test_e2e_new_models.py:110: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/atlascloud_comfyui/nodes/video/kling_video_o3_std_t2v.py:50: in run
    prediction_id = client.generate_video(payload)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/atlascloud_comfyui/client/atlas_client.py:61: in generate_video
    r.raise_for_status()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <Response [404]>

    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""
    
        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason
    
        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )
    
        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )
    
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.atlascloud.ai/api/v1/model/generateVideo?utm_source=github&utm_medium=readme&utm_campaign=comfyui

.venv/lib/python3.11/site-packages/requests/models.py:1026: HTTPError
=========================== short test summary info ============================
FAILED tests/test_e2e_new_models.py::test_wan26_t2i - requests.exceptions.HTT...
FAILED tests/test_e2e_new_models.py::test_kling_video_o3_pro_t2v - requests.e...
FAILED tests/test_e2e_new_models.py::test_kling_video_o3_std_t2v - requests.e...
========================= 3 failed, 3 skipped in 0.49s ========================= (video-edit remains opt-in)

🤖 Generated with OpenClaw