### PR TITLE
feat: sync new AtlasCloud visual model nodes (2026-03-04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,15 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V3.0 Pro Text-to-Video | kwaivgi/kling-v3.0-pro/text-to-video |
 | AtlasCloud Kling V3.0 Std Text-to-Video | kwaivgi/kling-v3.0-std/text-to-video |
 | AtlasCloud Kling V2.6 Pro Text-to-Video | kwaivgi/kling-v2.6-pro/text-to-video |
+| AtlasCloud Kling V2.6 Pro Avatar | kwaivgi/kling-v2.6-pro/avatar |
+| AtlasCloud Kling V2.6 Std Avatar | kwaivgi/kling-v2.6-std/avatar |
+| AtlasCloud Kling V2.6 Pro Motion-Control | kwaivgi/kling-v2.6-pro/motion-control |
+| AtlasCloud Kling V2.6 Std Motion-Control | kwaivgi/kling-v2.6-std/motion-control |
 | AtlasCloud Kling V2.5 Turbo Pro Text-to-Video | kwaivgi/kling-v2.5-turbo-pro/text-to-video |
 | AtlasCloud Kling Video O1 Text-to-Video | kwaivgi/kling-video-o1/text-to-video |
 | AtlasCloud Seedance V1 Pro Text-to-Video 1080p | bytedance/seedance-v1-pro/text-to-video-1080p |
 | AtlasCloud Seedance V1.5 Pro Text-to-Video | bytedance/seedance-v1.5-pro/text-to-video |
+| AtlasCloud Seedance V1.5 Pro Text-to-Video Fast | bytedance/seedance-v1.5-pro/text-to-video-fast |
 | AtlasCloud Hunyuan Text-to-Video | atlascloud/hunyuan-video/t2v |
 
 ### Image-to-Video (I2V)
@@ -124,6 +129,10 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Sora 2 Image-to-Video Pro | openai/sora-2/image-to-video-pro |
 | AtlasCloud Kling V3.0 Pro Image-to-Video | kwaivgi/kling-v3.0-pro/image-to-video |
 | AtlasCloud Kling V3.0 Std Image-to-Video | kwaivgi/kling-v3.0-std/image-to-video |
+| AtlasCloud Kling V2.6 Pro Image-to-Video | kwaivgi/kling-v2.6-pro/image-to-video |
+| AtlasCloud Kling Video O1 Image-to-Video | kwaivgi/kling-video-o1/image-to-video |
+| AtlasCloud Seedance V1.5 Pro Image-to-Video | bytedance/seedance-v1.5-pro/image-to-video |
+| AtlasCloud Seedance V1.5 Pro Image-to-Video Fast | bytedance/seedance-v1.5-pro/image-to-video-fast |
 | AtlasCloud Kling V2.5 Turbo Pro Image-to-Video | kwaivgi/kling-v2.5-turbo-pro/image-to-video |
 | AtlasCloud Vidu Q3 Text-to-Video | vidu/q3/text-to-video |
 | AtlasCloud Vidu Q3 Image-to-Video | vidu/image-to-video-2.0 |
@@ -132,11 +141,9 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 
 ### Text-to-Image (T2I)
 
-| AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
-
-
 | Node | Model |
 |------|-------|
+| AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
 | AtlasCloud Imagen4 Text-to-Image | google/imagen4 |
 | AtlasCloud Imagen4 Fast Text-to-Image | google/imagen4-fast |
 | AtlasCloud Imagen4 Ultra Text-to-Image | google/imagen4-ultra |
@@ -144,9 +151,12 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Nano Banana 2 Text-to-Image | google/nano-banana-2/text-to-image |
 | AtlasCloud Nano Banana 2 Text-to-Image Developer | google/nano-banana-2/text-to-image-developer |
 | AtlasCloud Nano Banana Pro Text-to-Image Ultra | google/nano-banana-pro/text-to-image-ultra |
+| AtlasCloud Nano Banana Pro Text-to-Image | google/nano-banana-pro/text-to-image |
 | AtlasCloud Seedream V5.0 Lite Text-to-Image | bytedance/seedream-v5.0-lite |
 | AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image | bytedance/seedream-v5.0-lite/sequential |
 | AtlasCloud Seedream V4.5 Text-to-Image | bytedance/seedream-v4.5 |
+| AtlasCloud Seedream V4.5 Sequential Text-to-Image | bytedance/seedream-v4.5/sequential |
+| AtlasCloud ZImage Turbo Text-to-Image | z-image/turbo |
 | AtlasCloud Ideogram V3 Quality Text-to-Image | ideogram-ai/ideogram-v3-quality |
 | AtlasCloud Ideogram V3 Turbo Text-to-Image | ideogram-ai/ideogram-v3-turbo |
 | AtlasCloud Luma Photon Text-to-Image | luma/photon |
@@ -171,6 +181,10 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |
 | AtlasCloud Seedream V5.0 Lite Edit Sequential | bytedance/seedream-v5.0-lite/edit-sequential |
 | AtlasCloud WAN2.6 Image-Edit | alibaba/wan-2.6/image-edit |
+| AtlasCloud Seedream V4.5 Edit | bytedance/seedream-v4.5/edit |
+| AtlasCloud Seedream V4.5 Edit Sequential | bytedance/seedream-v4.5/edit-sequential |
+| AtlasCloud Qwen Image Edit | atlascloud/qwen-image/edit |
+| AtlasCloud Nano Banana Pro Edit | google/nano-banana-pro/edit |
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
 
 > Nodes are continuously expanded as new models are added to AtlasCloud.

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_pro_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_pro_edit.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBananaProEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "If true, server may try to return result synchronously"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        aspect_ratio: str,
+        resolution: str,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-pro/edit",
+            "images": image_list,
+            "prompt": p,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBananaProTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "If true, server may try to return result synchronously"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        resolution: str,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-pro/text-to-image",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_edit.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasQwenImageEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+            },
+            "optional": {
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "If true, server may try to return result synchronously"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Qwen Image Edit")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/qwen-image/edit",
+            "image": (image or "").strip(),
+            "prompt": prompt,
+            "seed": int(seed),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v45_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v45_edit.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV45Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "size": ("STRING", {"default": "2048*2048", "tooltip": "Output size (WIDTH*HEIGHT)"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        size: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v4.5/edit",
+            "images": image_list,
+            "prompt": p,
+            "size": str(size).strip(),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v45_edit_sequential.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v45_edit_sequential.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV45EditSequential:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "size": ("STRING", {"default": "2048*2048", "tooltip": "Output size (WIDTH*HEIGHT)"}),
+                "max_images": ("INT", {"default": 1, "min": 1, "max": 15, "tooltip": "Max images to generate"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        size: str,
+        max_images: int,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v4.5/edit-sequential",
+            "images": image_list,
+            "prompt": p,
+            "size": str(size).strip(),
+            "max_images": int(max_images),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v45_sequential_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v45_sequential_t2i.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV45SequentialTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Prompt (should describe a sequence)"}),
+                "size": ("STRING", {"default": "2048*2048", "tooltip": "Output size (WIDTH*HEIGHT)"}),
+                "max_images": ("INT", {"default": 1, "min": 1, "max": 15, "tooltip": "Max images to generate"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        max_images: int,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v4.5/sequential",
+            "prompt": prompt,
+            "size": str(size).strip(),
+            "max_images": int(max_images),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/zimage_turbo_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/zimage_turbo_t2i.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasZImageTurboTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "width": ("INT", {"default": 1024, "min": 256, "max": 2048, "step": 64, "tooltip": "Width"}),
+                "height": ("INT", {"default": 1536, "min": 256, "max": 2048, "step": 64, "tooltip": "Height"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+            },
+            "optional": {
+                "prompt_extend": ("BOOLEAN", {"default": False, "tooltip": "Prompt extension"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "If true, server may try to return result synchronously"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        width: int,
+        height: int,
+        seed: int,
+        prompt_extend: bool = False,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        size = f"{int(width)}*{int(height)}"
+
+        payload: Dict[str, Any] = {
+            "model": "z-image/turbo",
+            "prompt": prompt,
+            "prompt_extend": bool(prompt_extend),
+            "seed": int(seed),
+            "size": size,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v26_pro_avatar.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v26_pro_avatar.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV26ProAvatar:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "audio": ("STRING", {"default": "", "tooltip": "Audio URL/base64"}),
+                "image": ("STRING", {"default": "", "tooltip": "Reference image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional prompt"}),
+            },
+            "optional": {
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        audio: str,
+        image: str,
+        prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (audio or "").strip():
+            raise RuntimeError("audio is required for Kling V2.6 Pro Avatar")
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling V2.6 Pro Avatar")
+
+        client = atlas_client.client
+
+        payload = {
+            "model": "kwaivgi/kling-v2.6-pro/avatar",
+            "audio": (audio or "").strip(),
+            "image": (image or "").strip(),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v26_pro_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v26_pro_i2v.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV26ProImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling V2.6 Pro Image-to-Video")
+
+        client = atlas_client.client
+
+        payload = {
+            "model": "kwaivgi/kling-v2.6-pro/image-to-video",
+            "image": (image or "").strip(),
+            "prompt": prompt,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v26_pro_motion_control.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v26_pro_motion_control.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV26ProMotionControl:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "video": ("STRING", {"default": "", "tooltip": "Reference video URL"}),
+                "character_orientation": (
+                    ["left", "right", "front", "back"],
+                    {"default": "front", "tooltip": "Character orientation"},
+                ),
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional prompt"}),
+            },
+            "optional": {
+                "keep_original_sound": ("BOOLEAN", {"default": True, "tooltip": "Keep original sound"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        video: str,
+        character_orientation: str,
+        prompt: str = "",
+        keep_original_sound: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling V2.6 Pro Motion-Control")
+        if not (video or "").strip():
+            raise RuntimeError("video is required for Kling V2.6 Pro Motion-Control")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v2.6-pro/motion-control",
+            "image": (image or "").strip(),
+            "video": (video or "").strip(),
+            "character_orientation": character_orientation,
+            "keep_original_sound": bool(keep_original_sound),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v26_std_avatar.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v26_std_avatar.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV26StdAvatar:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "audio": ("STRING", {"default": "", "tooltip": "Audio URL/base64"}),
+                "image": ("STRING", {"default": "", "tooltip": "Reference image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional prompt"}),
+            },
+            "optional": {
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        audio: str,
+        image: str,
+        prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (audio or "").strip():
+            raise RuntimeError("audio is required for Kling V2.6 Std Avatar")
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling V2.6 Std Avatar")
+
+        client = atlas_client.client
+
+        payload = {
+            "model": "kwaivgi/kling-v2.6-std/avatar",
+            "audio": (audio or "").strip(),
+            "image": (image or "").strip(),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v26_std_motion_control.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v26_std_motion_control.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV26StdMotionControl:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "video": ("STRING", {"default": "", "tooltip": "Reference video URL"}),
+                "character_orientation": (
+                    ["left", "right", "front", "back"],
+                    {"default": "front", "tooltip": "Character orientation"},
+                ),
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional prompt"}),
+            },
+            "optional": {
+                "keep_original_sound": ("BOOLEAN", {"default": True, "tooltip": "Keep original sound"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        video: str,
+        character_orientation: str,
+        prompt: str = "",
+        keep_original_sound: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling V2.6 Std Motion-Control")
+        if not (video or "").strip():
+            raise RuntimeError("video is required for Kling V2.6 Std Motion-Control")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v2.6-std/motion-control",
+            "image": (image or "").strip(),
+            "video": (video or "").strip(),
+            "character_orientation": character_orientation,
+            "keep_original_sound": bool(keep_original_sound),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o1_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o1_i2v.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO1ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling Video O1 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload = {
+            "model": "kwaivgi/kling-video-o1/image-to-video",
+            "image": (image or "").strip(),
+            "prompt": prompt,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v15_pro_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v15_pro_i2v.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV15ProImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p", "480p"], {"default": "720p", "tooltip": "Resolution preset"}),
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+            },
+            "optional": {
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Fixed camera"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "last_image": ("STRING", {"default": "", "tooltip": "Optional last image URL/base64"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        aspect_ratio: str,
+        duration: int,
+        resolution: str,
+        prompt: str,
+        seed: int,
+        camera_fixed: bool = False,
+        generate_audio: bool = True,
+        last_image: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Seedance V1.5 Pro Image-to-Video")
+
+        client = atlas_client.client
+
+        payload = {
+            "model": "bytedance/seedance-v1.5-pro/image-to-video",
+            "image": (image or "").strip(),
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+            "camera_fixed": bool(camera_fixed),
+            "generate_audio": bool(generate_audio),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v15_pro_i2v_fast.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v15_pro_i2v_fast.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV15ProImageToVideoFast:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p", "480p"], {"default": "720p", "tooltip": "Resolution preset"}),
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+            },
+            "optional": {
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Fixed camera"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "last_image": ("STRING", {"default": "", "tooltip": "Optional last image URL/base64"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        aspect_ratio: str,
+        duration: int,
+        resolution: str,
+        prompt: str,
+        seed: int,
+        camera_fixed: bool = False,
+        generate_audio: bool = True,
+        last_image: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Seedance V1.5 Pro Image-to-Video Fast")
+
+        client = atlas_client.client
+
+        payload = {
+            "model": "bytedance/seedance-v1.5-pro/image-to-video-fast",
+            "image": (image or "").strip(),
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+            "camera_fixed": bool(camera_fixed),
+            "generate_audio": bool(generate_audio),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v15_pro_t2v_fast.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v15_pro_t2v_fast.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV15ProTextToVideoFast:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p"], {"default": "720p", "tooltip": "Resolution preset"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+            },
+            "optional": {
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Fixed camera"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        duration: int,
+        resolution: str,
+        seed: int,
+        camera_fixed: bool = False,
+        generate_audio: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload = {
+            "model": "bytedance/seedance-v1.5-pro/text-to-video-fast",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+            "camera_fixed": bool(camera_fixed),
+            "generate_audio": bool(generate_audio),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -78,9 +78,26 @@ from atlascloud_comfyui.nodes.video.kling_v25_turbo_pro_i2v import AtlasKlingV25
 from atlascloud_comfyui.nodes.video.hunyuan_i2v import AtlasHunyuanImageToVideo
 from atlascloud_comfyui.nodes.video.wan25_i2v import AtlasWAN25ImageToVideo
 
+from atlascloud_comfyui.nodes.video.kling_v26_pro_avatar import AtlasKlingV26ProAvatar
+from atlascloud_comfyui.nodes.video.kling_v26_std_avatar import AtlasKlingV26StdAvatar
+from atlascloud_comfyui.nodes.video.kling_v26_pro_motion_control import AtlasKlingV26ProMotionControl
+from atlascloud_comfyui.nodes.video.kling_v26_std_motion_control import AtlasKlingV26StdMotionControl
+from atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v import AtlasSeedanceV15ProImageToVideo
+from atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v_fast import AtlasSeedanceV15ProImageToVideoFast
+from atlascloud_comfyui.nodes.video.seedance_v15_pro_t2v_fast import AtlasSeedanceV15ProTextToVideoFast
+from atlascloud_comfyui.nodes.video.kling_video_o1_i2v import AtlasKlingVideoO1ImageToVideo
+from atlascloud_comfyui.nodes.video.kling_v26_pro_i2v import AtlasKlingV26ProImageToVideo
+
 from atlascloud_comfyui.nodes.image.seedream_v45_t2i import AtlasSeedreamV45TextToImage
+from atlascloud_comfyui.nodes.image.seedream_v45_edit import AtlasSeedreamV45Edit
+from atlascloud_comfyui.nodes.image.seedream_v45_sequential_t2i import AtlasSeedreamV45SequentialTextToImage
+from atlascloud_comfyui.nodes.image.seedream_v45_edit_sequential import AtlasSeedreamV45EditSequential
 from atlascloud_comfyui.nodes.image.zimage_turbo_lora_t2i import AtlasZImageTurboLoraTextToImage
+from atlascloud_comfyui.nodes.image.zimage_turbo_t2i import AtlasZImageTurboTextToImage
+from atlascloud_comfyui.nodes.image.qwen_image_edit import AtlasQwenImageEdit
 from atlascloud_comfyui.nodes.image.nano_banana_pro_t2i_ultra import AtlasNanoBananaProTextToImageUltra
+from atlascloud_comfyui.nodes.image.nano_banana_pro_t2i import AtlasNanoBananaProTextToImage
+from atlascloud_comfyui.nodes.image.nano_banana_pro_edit import AtlasNanoBananaProEdit
 from atlascloud_comfyui.nodes.image.flux2_flex_t2i import AtlasFlux2FlexTextToImage
 from atlascloud_comfyui.nodes.image.nano_banana2_t2i import AtlasNanoBanana2TextToImage
 from atlascloud_comfyui.nodes.image.nano_banana2_t2i_dev import AtlasNanoBanana2TextToImageDev
@@ -127,13 +144,26 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.2 Text-to-Video 720p": AtlasWAN22T2V720p,
     "AtlasCloud VEO3.1 Text-to-Video": AtlasVeo31TextToVideo,
     "AtlasCloud Kling V2.6 Pro Text-to-Video": AtlasKlingV26ProTextToVideo,
+    "AtlasCloud Kling V2.6 Pro Avatar": AtlasKlingV26ProAvatar,
+    "AtlasCloud Kling V2.6 Std Avatar": AtlasKlingV26StdAvatar,
+    "AtlasCloud Kling V2.6 Pro Motion-Control": AtlasKlingV26ProMotionControl,
+    "AtlasCloud Kling V2.6 Std Motion-Control": AtlasKlingV26StdMotionControl,
+    "AtlasCloud Kling V2.6 Pro Image-to-Video": AtlasKlingV26ProImageToVideo,
     "AtlasCloud Kling Video O1 Text-to-Video": AtlasKlingVideoO1TextToVideo,
+    "AtlasCloud Kling Video O1 Image-to-Video": AtlasKlingVideoO1ImageToVideo,
     "AtlasCloud Seedance V1 Pro Text-to-Video 1080p": AtlasSeedanceV1ProT2V1080p,
     "AtlasCloud Hailuo 2.3 Pro Text-to-Video": AtlasHailuo23T2VPro,
     "AtlasCloud Sora 2 Text-to-Video Pro": AtlasSora2TextToVideoPro,
     "AtlasCloud Seedance V1.5 Pro Text-to-Video": AtlasSeedanceV15ProTextToVideo,
+    "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast": AtlasSeedanceV15ProTextToVideoFast,
+    "AtlasCloud Seedance V1.5 Pro Image-to-Video": AtlasSeedanceV15ProImageToVideo,
+    "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast": AtlasSeedanceV15ProImageToVideoFast,
     "AtlasCloud Seedream V4.5 Text-to-Image": AtlasSeedreamV45TextToImage,
+    "AtlasCloud Seedream V4.5 Edit": AtlasSeedreamV45Edit,
+    "AtlasCloud Seedream V4.5 Sequential Text-to-Image": AtlasSeedreamV45SequentialTextToImage,
+    "AtlasCloud Seedream V4.5 Edit Sequential": AtlasSeedreamV45EditSequential,
     "AtlasCloud ZImage Turbo Lora Text-to-Image": AtlasZImageTurboLoraTextToImage,
+    "AtlasCloud ZImage Turbo Text-to-Image": AtlasZImageTurboTextToImage,
     "AtlasCloud Nano Banana Pro Text-to-Image Ultra": AtlasNanoBananaProTextToImageUltra,
     "AtlasCloud Flux2 Flex Text-to-Image": AtlasFlux2FlexTextToImage,
     "AtlasCloud Image Preview": AtlasImagePreviewURL,
@@ -189,6 +219,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Luma Photon Text-to-Image": AtlasLumaPhotonTextToImage,
     "AtlasCloud Luma Photon Flash Text-to-Image": AtlasLumaPhotonFlashTextToImage,
     "AtlasCloud Recraft V3 Text-to-Image": AtlasRecraftV3TextToImage,
+    "AtlasCloud Qwen Image Edit": AtlasQwenImageEdit,
+    "AtlasCloud Nano Banana Pro Text-to-Image": AtlasNanoBananaProTextToImage,
+    "AtlasCloud Nano Banana Pro Edit": AtlasNanoBananaProEdit,
     "AtlasCloud Qwen Image Edit Plus 20251215": AtlasQwenImageEditPlus20251215,
 }
 
@@ -215,14 +248,27 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.2 Text-to-Video 720p": "AtlasCloud WAN2.2 Text-to-Video 720p",
     "AtlasCloud VEO3.1 Text-to-Video": "AtlasCloud VEO3.1 Text-to-Video",
     "AtlasCloud Kling V2.6 Pro Text-to-Video": "AtlasCloud Kling V2.6 Pro Text-to-Video",
+    "AtlasCloud Kling V2.6 Pro Avatar": "AtlasCloud Kling V2.6 Pro Avatar",
+    "AtlasCloud Kling V2.6 Std Avatar": "AtlasCloud Kling V2.6 Std Avatar",
+    "AtlasCloud Kling V2.6 Pro Motion-Control": "AtlasCloud Kling V2.6 Pro Motion-Control",
+    "AtlasCloud Kling V2.6 Std Motion-Control": "AtlasCloud Kling V2.6 Std Motion-Control",
+    "AtlasCloud Kling V2.6 Pro Image-to-Video": "AtlasCloud Kling V2.6 Pro Image-to-Video",
     "AtlasCloud Kling Video O1 Text-to-Video": "AtlasCloud Kling Video O1 Text-to-Video",
+    "AtlasCloud Kling Video O1 Image-to-Video": "AtlasCloud Kling Video O1 Image-to-Video",
     "AtlasCloud Seedance V1 Pro Text-to-Video 1080p": "AtlasCloud Seedance V1 Pro Text-to-Video 1080p",
     "AtlasCloud Hailuo 2.3 Pro Text-to-Video": "AtlasCloud Hailuo 2.3 Pro Text-to-Video",
     "AtlasCloud Sora 2 Text-to-Video Pro": "AtlasCloud Sora 2 Text-to-Video Pro",
     "AtlasCloud Seedance V1.5 Pro Text-to-Video": "AtlasCloud Seedance V1.5 Pro Text-to-Video",
+    "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast": "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast",
+    "AtlasCloud Seedance V1.5 Pro Image-to-Video": "AtlasCloud Seedance V1.5 Pro Image-to-Video",
+    "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast": "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast",
     "AtlasCloud Seedream V4.5 Text-to-Image": "AtlasCloud Seedream V4.5 Text-to-Image",
+    "AtlasCloud Seedream V4.5 Edit": "AtlasCloud Seedream V4.5 Edit",
+    "AtlasCloud Seedream V4.5 Sequential Text-to-Image": "AtlasCloud Seedream V4.5 Sequential Text-to-Image",
+    "AtlasCloud Seedream V4.5 Edit Sequential": "AtlasCloud Seedream V4.5 Edit Sequential",
     "AtlasCloud Image Preview": "AtlasCloud Image Preview",
     "AtlasCloud ZImage Turbo Lora Text-to-Image": "AtlasCloud ZImage Turbo Lora Text-to-Image",
+    "AtlasCloud ZImage Turbo Text-to-Image": "AtlasCloud ZImage Turbo Text-to-Image",
     "AtlasCloud Nano Banana Pro Text-to-Image Ultra": "AtlasCloud Nano Banana Pro Text-to-Image Ultra",
     "AtlasCloud Flux2 Flex Text-to-Image": "AtlasCloud Flux2 Flex Text-to-Image",
     "AtlasCloud Video Preview": "AtlasCloud Video Preview",
@@ -277,6 +323,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Luma Photon Text-to-Image": "AtlasCloud Luma Photon Text-to-Image",
     "AtlasCloud Luma Photon Flash Text-to-Image": "AtlasCloud Luma Photon Flash Text-to-Image",
     "AtlasCloud Recraft V3 Text-to-Image": "AtlasCloud Recraft V3 Text-to-Image",
+    "AtlasCloud Qwen Image Edit": "AtlasCloud Qwen Image Edit",
+    "AtlasCloud Nano Banana Pro Text-to-Image": "AtlasCloud Nano Banana Pro Text-to-Image",
+    "AtlasCloud Nano Banana Pro Edit": "AtlasCloud Nano Banana Pro Edit",
     "AtlasCloud Qwen Image Edit Plus 20251215": "AtlasCloud Qwen Image Edit Plus 20251215",
 }
 

--- a/tests/test_new_nodes_2026_03_04.py
+++ b/tests/test_new_nodes_2026_03_04.py
@@ -1,0 +1,161 @@
+"""
+Metadata-only tests for newly added nodes (2026-03-04).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_kling_v26_pro_avatar_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v26_pro_avatar import AtlasKlingV26ProAvatar
+
+    assert "atlas_client" in AtlasKlingV26ProAvatar.INPUT_TYPES()["required"]
+    assert "audio" in AtlasKlingV26ProAvatar.INPUT_TYPES()["required"]
+    assert "image" in AtlasKlingV26ProAvatar.INPUT_TYPES()["required"]
+    assert AtlasKlingV26ProAvatar.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v26_std_avatar_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v26_std_avatar import AtlasKlingV26StdAvatar
+
+    assert "atlas_client" in AtlasKlingV26StdAvatar.INPUT_TYPES()["required"]
+    assert "audio" in AtlasKlingV26StdAvatar.INPUT_TYPES()["required"]
+    assert "image" in AtlasKlingV26StdAvatar.INPUT_TYPES()["required"]
+    assert AtlasKlingV26StdAvatar.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v26_pro_motion_control_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v26_pro_motion_control import AtlasKlingV26ProMotionControl
+
+    required = AtlasKlingV26ProMotionControl.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "video" in required
+    assert "character_orientation" in required
+    assert AtlasKlingV26ProMotionControl.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v26_std_motion_control_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v26_std_motion_control import AtlasKlingV26StdMotionControl
+
+    required = AtlasKlingV26StdMotionControl.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "video" in required
+    assert "character_orientation" in required
+    assert AtlasKlingV26StdMotionControl.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_v15_pro_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v import AtlasSeedanceV15ProImageToVideo
+
+    required = AtlasSeedanceV15ProImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasSeedanceV15ProImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_v15_pro_i2v_fast_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v_fast import AtlasSeedanceV15ProImageToVideoFast
+
+    required = AtlasSeedanceV15ProImageToVideoFast.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasSeedanceV15ProImageToVideoFast.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_v15_pro_t2v_fast_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v15_pro_t2v_fast import AtlasSeedanceV15ProTextToVideoFast
+
+    required = AtlasSeedanceV15ProTextToVideoFast.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasSeedanceV15ProTextToVideoFast.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_video_o1_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_video_o1_i2v import AtlasKlingVideoO1ImageToVideo
+
+    required = AtlasKlingVideoO1ImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasKlingVideoO1ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v26_pro_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v26_pro_i2v import AtlasKlingV26ProImageToVideo
+
+    required = AtlasKlingV26ProImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasKlingV26ProImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_zimage_turbo_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.zimage_turbo_t2i import AtlasZImageTurboTextToImage
+
+    required = AtlasZImageTurboTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "width" in required
+    assert "height" in required
+    assert AtlasZImageTurboTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v45_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v45_edit import AtlasSeedreamV45Edit
+
+    required = AtlasSeedreamV45Edit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert "prompt" in required
+    assert AtlasSeedreamV45Edit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v45_sequential_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v45_sequential_t2i import AtlasSeedreamV45SequentialTextToImage
+
+    required = AtlasSeedreamV45SequentialTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasSeedreamV45SequentialTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v45_edit_sequential_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v45_edit_sequential import AtlasSeedreamV45EditSequential
+
+    required = AtlasSeedreamV45EditSequential.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert "prompt" in required
+    assert AtlasSeedreamV45EditSequential.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_qwen_image_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_edit import AtlasQwenImageEdit
+
+    required = AtlasQwenImageEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasQwenImageEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_nano_banana_pro_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana_pro_t2i import AtlasNanoBananaProTextToImage
+
+    required = AtlasNanoBananaProTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasNanoBananaProTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_nano_banana_pro_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana_pro_edit import AtlasNanoBananaProEdit
+
+    required = AtlasNanoBananaProEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert "prompt" in required
+    assert AtlasNanoBananaProEdit.RETURN_TYPES == ("STRING", "STRING")


### PR DESCRIPTION
## Summary
Adds ComfyUI node support for 16 AtlasCloud visual models:

### Video
- Kling V2.6 Pro Avatar — kwaivgi/kling-v2.6-pro/avatar
- Kling V2.6 Std Avatar — kwaivgi/kling-v2.6-std/avatar
- Kling V2.6 Pro Motion-Control — kwaivgi/kling-v2.6-pro/motion-control
- Kling V2.6 Std Motion-Control — kwaivgi/kling-v2.6-std/motion-control
- Kling V2.6 Pro Image-to-Video — kwaivgi/kling-v2.6-pro/image-to-video
- Kling Video O1 Image-to-Video — kwaivgi/kling-video-o1/image-to-video
- Seedance V1.5 Pro Text-to-Video Fast — bytedance/seedance-v1.5-pro/text-to-video-fast
- Seedance V1.5 Pro Image-to-Video — bytedance/seedance-v1.5-pro/image-to-video
- Seedance V1.5 Pro Image-to-Video Fast — bytedance/seedance-v1.5-pro/image-to-video-fast

### Image
- ZImage Turbo Text-to-Image — z-image/turbo
- Seedream V4.5 Edit — bytedance/seedream-v4.5/edit
- Seedream V4.5 Sequential Text-to-Image — bytedance/seedream-v4.5/sequential
- Seedream V4.5 Edit Sequential — bytedance/seedream-v4.5/edit-sequential
- Qwen Image Edit — atlascloud/qwen-image/edit
- Nano Banana Pro Text-to-Image — google/nano-banana-pro/text-to-image
- Nano Banana Pro Edit — google/nano-banana-pro/edit

## Test plan
- [x] ruff check .
- [x] pytest tests/ -v (metadata-only tests; E2E skipped without key)

🤖 Generated with OpenClaw