### PR TITLE
feat: sync AtlasCloud visual model nodes (2026-03-05)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling Video O3 Pro Text-to-Video | kwaivgi/kling-video-o3-pro/text-to-video |
 | AtlasCloud Kling Video O3 Std Text-to-Video | kwaivgi/kling-video-o3-std/text-to-video |
 | AtlasCloud WAN2.5 Text-to-Video | alibaba/wan-2.5/text-to-video |
+| AtlasCloud WAN2.5 Text-to-Video Fast | alibaba/wan-2.5/text-to-video-fast |
+| AtlasCloud Van-2.6 Text-to-Video | atlascloud/van-2.6/text-to-video |
+| AtlasCloud Seedance V1 Pro Fast Text-to-Video | bytedance/seedance-v1-pro-fast/text-to-video |
+| AtlasCloud Kling V2.1 T2V Master | kwaivgi/kling-v2.1-t2v-master |
+| AtlasCloud Kling V2.0 T2V Master | kwaivgi/kling-v2.0-t2v-master |
 | AtlasCloud WAN2.2 Text-to-Video 720p | alibaba/wan-2.2/text-to-video-720p |
 | AtlasCloud Luma Ray 2 Text-to-Video | luma/ray-2-t2v |
 | AtlasCloud Luma Ray 2 Flash Text-to-Video | luma/ray-2-flash-t2v |
@@ -110,11 +115,19 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | Node | Model |
 |------|-------|
 | AtlasCloud VEO3 Image-to-Video | google/veo3/image-to-video |
+| AtlasCloud VEO3 Fast Image-to-Video | google/veo3-fast/image-to-video |
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
 | AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |
 | AtlasCloud VEO3.1 Image-to-Video | google/veo3.1/image-to-video |
 | AtlasCloud VEO2 Image-to-Video | google/veo2/image-to-video |
 | AtlasCloud WAN2.5 Image-to-Video | alibaba/wan-2.5/image-to-video |
+| AtlasCloud WAN2.5 Image-to-Video Fast | alibaba/wan-2.5/image-to-video-fast |
+| AtlasCloud Van-2.6 Image-to-Video | atlascloud/van-2.6/image-to-video |
+| AtlasCloud Seedance V1 Pro Fast Image-to-Video | bytedance/seedance-v1-pro-fast/image-to-video |
+| AtlasCloud Vidu Reference-to-Video Q1 | vidu/reference-to-video-q1 |
+| AtlasCloud Vidu Reference-to-Video 2.0 | vidu/reference-to-video-2.0 |
+| AtlasCloud Vidu Start-End-to-Video 2.0 | vidu/start-end-to-video-2.0 |
+| AtlasCloud Kling V2.0 I2V Master | kwaivgi/kling-v2.0-i2v-master |
 | AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
 | AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |
@@ -164,6 +177,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Recraft V3 Text-to-Image | recraft-ai/recraft-v3 |
 | AtlasCloud Flux2 Flex Text-to-Image | flux2/flex |
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
+| AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
+| AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
 
 ### Video Edit
 

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_t2i_max.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_t2i_max.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasQwenImageTextToImageMax:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "size": (
+                    [
+                        "1664*928",
+                        "1472*1104",
+                        "1328*1328",
+                        "1104*1472",
+                        "928*1664",
+                    ],
+                    {"default": "1664*928", "tooltip": "Size (width*height)"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "enable_prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Enable prompt optimizer"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        negative_prompt: str = "",
+        enable_prompt_expansion: bool = False,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/qwen-image/text-to-image-max",
+            "prompt": prompt,
+            "size": size,
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "seed": int(seed),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_t2i_plus.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_t2i_plus.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasQwenImageTextToImagePlus:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "size": (
+                    [
+                        "1664*928",
+                        "1472*1104",
+                        "1328*1328",
+                        "1104*1472",
+                        "928*1664",
+                    ],
+                    {"default": "1664*928", "tooltip": "Size (width*height)"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "enable_prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Enable prompt optimizer"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        negative_prompt: str = "",
+        enable_prompt_expansion: bool = False,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/qwen-image/text-to-image-plus",
+            "prompt": prompt,
+            "size": size,
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "seed": int(seed),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v20_i2v_master.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v20_i2v_master.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV20I2VMaster:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "duration": ([5, 10], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "guidance_scale": (
+                    "FLOAT",
+                    {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01, "tooltip": "Guidance scale"},
+                ),
+            },
+            "optional": {
+                "end_image": ("STRING", {"default": "", "tooltip": "Optional tail frame image URL/base64"}),
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        duration: int,
+        guidance_scale: float,
+        end_image: str = "",
+        negative_prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v2.0-i2v-master",
+            "image": image,
+            "prompt": prompt,
+            "duration": int(duration),
+            "guidance_scale": float(guidance_scale),
+        }
+
+        end_image = (end_image or "").strip()
+        if end_image:
+            payload["end_image"] = end_image
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v20_t2v_master.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v20_t2v_master.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV20T2VMaster:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "duration": (["5", "10"], {"default": "5", "tooltip": "Duration (seconds)"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        duration: str,
+        negative_prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v2.0-t2v-master",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": duration,
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v21_t2v_master.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v21_t2v_master.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV21T2VMaster:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "duration": (["5", "10"], {"default": "5", "tooltip": "Duration (seconds)"}),
+                "guidance_scale": (
+                    "FLOAT",
+                    {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.1, "tooltip": "Guidance scale"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        duration: str,
+        guidance_scale: float,
+        negative_prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v2.1-t2v-master",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": duration,
+            "guidance_scale": float(guidance_scale),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_pro_fast_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_pro_fast_i2v.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV1ProFastImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["480p", "720p", "1080p"], {"default": "480p", "tooltip": "Resolution"}),
+                "duration": (
+                    [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    {"default": 5, "tooltip": "Duration (seconds)"},
+                ),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Fix camera position"}),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+            },
+            "optional": {
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        duration: int,
+        aspect_ratio: str,
+        camera_fixed: bool,
+        seed: int,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-v1-pro-fast/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "camera_fixed": bool(camera_fixed),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_pro_fast_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_pro_fast_t2v.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV1ProFastTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["480p", "720p", "1080p"], {"default": "480p", "tooltip": "Resolution"}),
+                "duration": (
+                    [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                    {"default": 5, "tooltip": "Duration (seconds)"},
+                ),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Fix camera position"}),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+            },
+            "optional": {
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str,
+        duration: int,
+        aspect_ratio: str,
+        camera_fixed: bool,
+        seed: int,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-v1-pro-fast/text-to-video",
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "camera_fixed": bool(camera_fixed),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/van26_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/van26_i2v.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVan26ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["1080p"], {"default": "1080p", "tooltip": "Resolution"}),
+                "shot_type": (["multi", "single"], {"default": "multi", "tooltip": "Shot type"}),
+                "enable_prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Enable prompt optimizer"},
+                ),
+                "generate_audio": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Whether to automatically add audio"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Audio URL (optional)"}),
+                "duration": ([5, 10, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        shot_type: str,
+        enable_prompt_expansion: bool,
+        generate_audio: bool,
+        seed: int,
+        negative_prompt: str = "",
+        audio: str = "",
+        duration: int = 5,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        if shot_type == "multi" and not enable_prompt_expansion:
+            raise RuntimeError("shot_type='multi' requires enable_prompt_expansion=True")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/van-2.6/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "shot_type": shot_type,
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "generate_audio": bool(generate_audio),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        aud = (audio or "").strip()
+        if aud:
+            payload["audio"] = aud
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/van26_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/van26_t2v.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVan26TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "size": (
+                    [
+                        "1920*1080",
+                        "1080*1920",
+                        "1440*1440",
+                        "1632*1248",
+                        "1248*1632",
+                    ],
+                    {"default": "1920*1080", "tooltip": "Size (width*height)"},
+                ),
+                "duration": ([5, 10, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "shot_type": (["multi", "single"], {"default": "multi", "tooltip": "Shot type"}),
+                "enable_prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Enable prompt optimizer"},
+                ),
+                "generate_audio": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Whether to automatically add audio"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Audio URL (optional)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        duration: int,
+        shot_type: str,
+        enable_prompt_expansion: bool,
+        generate_audio: bool,
+        seed: int,
+        negative_prompt: str = "",
+        audio: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        # NOTE: Schema enforces enable_prompt_expansion==true when shot_type==multi.
+        if shot_type == "multi" and not enable_prompt_expansion:
+            raise RuntimeError("shot_type='multi' requires enable_prompt_expansion=True")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/van-2.6/text-to-video",
+            "prompt": prompt,
+            "size": size,
+            "duration": int(duration),
+            "shot_type": shot_type,
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "generate_audio": bool(generate_audio),
+            "seed": int(seed),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        aud = (audio or "").strip()
+        if aud:
+            payload["audio"] = aud
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/veo3_fast_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veo3_fast_i2v.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeo3FastImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "duration": ([8, 6, 4], {"default": 8, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "generate_audio": ("BOOLEAN", {"default": False, "tooltip": "Generate audio"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Seed"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        aspect_ratio: str,
+        duration: int,
+        resolution: str,
+        generate_audio: bool,
+        negative_prompt: str = "",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/veo3-fast/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "resolution": resolution,
+            "generate_audio": bool(generate_audio),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_reference_to_video_q1.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_reference_to_video_q1.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduReferenceToVideoQ1:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "tooltip": "1-3 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement amplitude"},
+                ),
+            },
+            "optional": {
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "Seed"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        aspect_ratio: str,
+        movement_amplitude: str,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
+        if not imgs:
+            raise RuntimeError("images is required (provide 1-3 lines)")
+        if len(imgs) > 3:
+            raise RuntimeError("Vidu Reference-to-Video supports up to 3 images")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/reference-to-video-q1",
+            "images": imgs,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "movement_amplitude": movement_amplitude,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_reference_to_video_v2.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_reference_to_video_v2.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduReferenceToVideoV2:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "tooltip": "1-3 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement amplitude"},
+                ),
+            },
+            "optional": {
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "Seed"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        aspect_ratio: str,
+        movement_amplitude: str,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
+        if not imgs:
+            raise RuntimeError("images is required (provide 1-3 lines)")
+        if len(imgs) > 3:
+            raise RuntimeError("Vidu Reference-to-Video supports up to 3 images")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/reference-to-video-2.0",
+            "images": imgs,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "movement_amplitude": movement_amplitude,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_start_end_to_video_v2.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_start_end_to_video_v2.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduStartEndToVideoV2:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "start_image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "End image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "duration": ([4, 8], {"default": 4, "tooltip": "Duration (seconds)"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement amplitude"},
+                ),
+            },
+            "optional": {
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "Seed"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        start_image: str,
+        end_image: str,
+        prompt: str,
+        duration: int,
+        movement_amplitude: str,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        start_image = (start_image or "").strip()
+        end_image = (end_image or "").strip()
+        if not start_image:
+            raise RuntimeError("start_image is required")
+        if not end_image:
+            raise RuntimeError("end_image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/start-end-to-video-2.0",
+            "images": [start_image, end_image],
+            "prompt": prompt,
+            "duration": int(duration),
+            "movement_amplitude": movement_amplitude,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_start_end_to_video_v2.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_start_end_to_video_v2.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
 

--- a/src/atlascloud_comfyui/nodes/video/wan25_fast_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/wan25_fast_i2v.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWAN25ImageToVideoFast:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Audio URL (optional)"}),
+                "duration": (
+                    [5, 10],
+                    {"default": 5, "tooltip": "Duration (seconds)"},
+                ),
+                "enable_prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Enable prompt optimizer"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        negative_prompt: str = "",
+        audio: str = "",
+        duration: int = 5,
+        enable_prompt_expansion: bool = False,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.5/image-to-video-fast",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        aud = (audio or "").strip()
+        if aud:
+            payload["audio"] = aud
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan25_fast_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/wan25_fast_t2v.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWAN25TextToVideoFast:
+    """
+    AtlasCloud WAN 2.5 Text-to-Video Fast
+    """
+
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "size": (
+                    [
+                        "1280*720",
+                        "720*1280",
+                        "1920*1080",
+                        "1080*1920",
+                    ],
+                    {"default": "1280*720", "tooltip": "Size (width*height)"},
+                ),
+                "duration": ([5, 10], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "enable_prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Enable prompt optimizer"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Audio URL (optional)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        duration: int,
+        enable_prompt_expansion: bool,
+        seed: int,
+        negative_prompt: str = "",
+        audio: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.5/text-to-video-fast",
+            "prompt": prompt,
+            "size": size,
+            "duration": int(duration),
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "seed": int(seed),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        aud = (audio or "").strip()
+        if aud:
+            payload["audio"] = aud
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -117,6 +117,22 @@ from atlascloud_comfyui.nodes.image.luma_photon_t2i import AtlasLumaPhotonTextTo
 from atlascloud_comfyui.nodes.image.luma_photon_flash_t2i import AtlasLumaPhotonFlashTextToImage
 from atlascloud_comfyui.nodes.image.recraft_v3_t2i import AtlasRecraftV3TextToImage
 from atlascloud_comfyui.nodes.image.qwen_image_edit_plus_20251215 import AtlasQwenImageEditPlus20251215
+from atlascloud_comfyui.nodes.image.qwen_image_t2i_plus import AtlasQwenImageTextToImagePlus
+from atlascloud_comfyui.nodes.image.qwen_image_t2i_max import AtlasQwenImageTextToImageMax
+
+from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_t2v import AtlasSeedanceV1ProFastTextToVideo
+from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_i2v import AtlasSeedanceV1ProFastImageToVideo
+from atlascloud_comfyui.nodes.video.wan25_fast_t2v import AtlasWAN25TextToVideoFast
+from atlascloud_comfyui.nodes.video.wan25_fast_i2v import AtlasWAN25ImageToVideoFast
+from atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
+from atlascloud_comfyui.nodes.video.van26_i2v import AtlasVan26ImageToVideo
+from atlascloud_comfyui.nodes.video.vidu_reference_to_video_q1 import AtlasViduReferenceToVideoQ1
+from atlascloud_comfyui.nodes.video.vidu_reference_to_video_v2 import AtlasViduReferenceToVideoV2
+from atlascloud_comfyui.nodes.video.vidu_start_end_to_video_v2 import AtlasViduStartEndToVideoV2
+from atlascloud_comfyui.nodes.video.kling_v20_i2v_master import AtlasKlingV20I2VMaster
+from atlascloud_comfyui.nodes.video.veo3_fast_i2v import AtlasVeo3FastImageToVideo
+from atlascloud_comfyui.nodes.video.kling_v21_t2v_master import AtlasKlingV21T2VMaster
+from atlascloud_comfyui.nodes.video.kling_v20_t2v_master import AtlasKlingV20T2VMaster
 
 from atlascloud_comfyui.nodes.utils.image_preview import AtlasImagePreviewURL
 from atlascloud_comfyui.nodes.utils.video_previewer import AtlasVideoPreviewer
@@ -223,6 +239,22 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Nano Banana Pro Text-to-Image": AtlasNanoBananaProTextToImage,
     "AtlasCloud Nano Banana Pro Edit": AtlasNanoBananaProEdit,
     "AtlasCloud Qwen Image Edit Plus 20251215": AtlasQwenImageEditPlus20251215,
+    "AtlasCloud Qwen Image Text-to-Image Plus": AtlasQwenImageTextToImagePlus,
+    "AtlasCloud Qwen Image Text-to-Image Max": AtlasQwenImageTextToImageMax,
+
+    "AtlasCloud Seedance V1 Pro Fast Text-to-Video": AtlasSeedanceV1ProFastTextToVideo,
+    "AtlasCloud Seedance V1 Pro Fast Image-to-Video": AtlasSeedanceV1ProFastImageToVideo,
+    "AtlasCloud WAN2.5 Text-to-Video Fast": AtlasWAN25TextToVideoFast,
+    "AtlasCloud WAN2.5 Image-to-Video Fast": AtlasWAN25ImageToVideoFast,
+    "AtlasCloud Van-2.6 Text-to-Video": AtlasVan26TextToVideo,
+    "AtlasCloud Van-2.6 Image-to-Video": AtlasVan26ImageToVideo,
+    "AtlasCloud Vidu Reference-to-Video Q1": AtlasViduReferenceToVideoQ1,
+    "AtlasCloud Vidu Reference-to-Video 2.0": AtlasViduReferenceToVideoV2,
+    "AtlasCloud Vidu Start-End-to-Video 2.0": AtlasViduStartEndToVideoV2,
+    "AtlasCloud Kling V2.0 I2V Master": AtlasKlingV20I2VMaster,
+    "AtlasCloud VEO3 Fast Image-to-Video": AtlasVeo3FastImageToVideo,
+    "AtlasCloud Kling V2.1 T2V Master": AtlasKlingV21T2VMaster,
+    "AtlasCloud Kling V2.0 T2V Master": AtlasKlingV20T2VMaster,
 }
 
 
@@ -327,6 +359,22 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Nano Banana Pro Text-to-Image": "AtlasCloud Nano Banana Pro Text-to-Image",
     "AtlasCloud Nano Banana Pro Edit": "AtlasCloud Nano Banana Pro Edit",
     "AtlasCloud Qwen Image Edit Plus 20251215": "AtlasCloud Qwen Image Edit Plus 20251215",
+    "AtlasCloud Qwen Image Text-to-Image Plus": "AtlasCloud Qwen Image Text-to-Image Plus",
+    "AtlasCloud Qwen Image Text-to-Image Max": "AtlasCloud Qwen Image Text-to-Image Max",
+
+    "AtlasCloud Seedance V1 Pro Fast Text-to-Video": "AtlasCloud Seedance V1 Pro Fast Text-to-Video",
+    "AtlasCloud Seedance V1 Pro Fast Image-to-Video": "AtlasCloud Seedance V1 Pro Fast Image-to-Video",
+    "AtlasCloud WAN2.5 Text-to-Video Fast": "AtlasCloud WAN2.5 Text-to-Video Fast",
+    "AtlasCloud WAN2.5 Image-to-Video Fast": "AtlasCloud WAN2.5 Image-to-Video Fast",
+    "AtlasCloud Van-2.6 Text-to-Video": "AtlasCloud Van-2.6 Text-to-Video",
+    "AtlasCloud Van-2.6 Image-to-Video": "AtlasCloud Van-2.6 Image-to-Video",
+    "AtlasCloud Vidu Reference-to-Video Q1": "AtlasCloud Vidu Reference-to-Video Q1",
+    "AtlasCloud Vidu Reference-to-Video 2.0": "AtlasCloud Vidu Reference-to-Video 2.0",
+    "AtlasCloud Vidu Start-End-to-Video 2.0": "AtlasCloud Vidu Start-End-to-Video 2.0",
+    "AtlasCloud Kling V2.0 I2V Master": "AtlasCloud Kling V2.0 I2V Master",
+    "AtlasCloud VEO3 Fast Image-to-Video": "AtlasCloud VEO3 Fast Image-to-Video",
+    "AtlasCloud Kling V2.1 T2V Master": "AtlasCloud Kling V2.1 T2V Master",
+    "AtlasCloud Kling V2.0 T2V Master": "AtlasCloud Kling V2.0 T2V Master",
 }
 
 

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -371,3 +371,121 @@ def test_recraft_v3_t2i_node_metadata():
 
     assert "atlas_client" in AtlasRecraftV3TextToImage.INPUT_TYPES()["required"]
     assert AtlasRecraftV3TextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+# --- Batch 4: 2026-03-05 sync ---
+
+
+def test_qwen_image_t2i_plus_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_t2i_plus import AtlasQwenImageTextToImagePlus
+
+    assert "atlas_client" in AtlasQwenImageTextToImagePlus.INPUT_TYPES()["required"]
+    assert AtlasQwenImageTextToImagePlus.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasQwenImageTextToImagePlus.RETURN_NAMES
+
+
+def test_qwen_image_t2i_max_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_t2i_max import AtlasQwenImageTextToImageMax
+
+    assert "atlas_client" in AtlasQwenImageTextToImageMax.INPUT_TYPES()["required"]
+    assert AtlasQwenImageTextToImageMax.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasQwenImageTextToImageMax.RETURN_NAMES
+
+
+def test_seedance_v1_pro_fast_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_t2v import AtlasSeedanceV1ProFastTextToVideo
+
+    assert "atlas_client" in AtlasSeedanceV1ProFastTextToVideo.INPUT_TYPES()["required"]
+    assert AtlasSeedanceV1ProFastTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert "video_url" in AtlasSeedanceV1ProFastTextToVideo.RETURN_NAMES
+
+
+def test_seedance_v1_pro_fast_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_i2v import AtlasSeedanceV1ProFastImageToVideo
+
+    assert "atlas_client" in AtlasSeedanceV1ProFastImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasSeedanceV1ProFastImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasSeedanceV1ProFastImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan25_fast_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan25_fast_t2v import AtlasWAN25TextToVideoFast
+
+    assert "atlas_client" in AtlasWAN25TextToVideoFast.INPUT_TYPES()["required"]
+    assert AtlasWAN25TextToVideoFast.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan25_fast_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan25_fast_i2v import AtlasWAN25ImageToVideoFast
+
+    assert "atlas_client" in AtlasWAN25ImageToVideoFast.INPUT_TYPES()["required"]
+    assert "image" in AtlasWAN25ImageToVideoFast.INPUT_TYPES()["required"]
+    assert AtlasWAN25ImageToVideoFast.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_van26_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
+
+    assert "atlas_client" in AtlasVan26TextToVideo.INPUT_TYPES()["required"]
+    assert AtlasVan26TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_van26_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.van26_i2v import AtlasVan26ImageToVideo
+
+    assert "atlas_client" in AtlasVan26ImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasVan26ImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasVan26ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_reference_to_video_q1_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_reference_to_video_q1 import AtlasViduReferenceToVideoQ1
+
+    assert "atlas_client" in AtlasViduReferenceToVideoQ1.INPUT_TYPES()["required"]
+    assert AtlasViduReferenceToVideoQ1.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_reference_to_video_v2_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_reference_to_video_v2 import AtlasViduReferenceToVideoV2
+
+    assert "atlas_client" in AtlasViduReferenceToVideoV2.INPUT_TYPES()["required"]
+    assert AtlasViduReferenceToVideoV2.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_start_end_to_video_v2_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_start_end_to_video_v2 import AtlasViduStartEndToVideoV2
+
+    assert "atlas_client" in AtlasViduStartEndToVideoV2.INPUT_TYPES()["required"]
+    assert "start_image" in AtlasViduStartEndToVideoV2.INPUT_TYPES()["required"]
+    assert "end_image" in AtlasViduStartEndToVideoV2.INPUT_TYPES()["required"]
+    assert AtlasViduStartEndToVideoV2.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v20_i2v_master_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v20_i2v_master import AtlasKlingV20I2VMaster
+
+    assert "atlas_client" in AtlasKlingV20I2VMaster.INPUT_TYPES()["required"]
+    assert "image" in AtlasKlingV20I2VMaster.INPUT_TYPES()["required"]
+    assert AtlasKlingV20I2VMaster.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_veo3_fast_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.veo3_fast_i2v import AtlasVeo3FastImageToVideo
+
+    assert "atlas_client" in AtlasVeo3FastImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasVeo3FastImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeo3FastImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v21_t2v_master_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v21_t2v_master import AtlasKlingV21T2VMaster
+
+    assert "atlas_client" in AtlasKlingV21T2VMaster.INPUT_TYPES()["required"]
+    assert AtlasKlingV21T2VMaster.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v20_t2v_master_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v20_t2v_master import AtlasKlingV20T2VMaster
+
+    assert "atlas_client" in AtlasKlingV20T2VMaster.INPUT_TYPES()["required"]
+    assert AtlasKlingV20T2VMaster.RETURN_TYPES == ("STRING", "STRING")


### PR DESCRIPTION
## Summary
Adds ComfyUI node support for additional AtlasCloud visual models.

### Video
- bytedance/seedance-v1-pro-fast/text-to-video
- bytedance/seedance-v1-pro-fast/image-to-video
- alibaba/wan-2.5/text-to-video-fast
- alibaba/wan-2.5/image-to-video-fast
- atlascloud/van-2.6/text-to-video
- atlascloud/van-2.6/image-to-video
- vidu/reference-to-video-q1
- vidu/reference-to-video-2.0
- vidu/start-end-to-video-2.0
- kwaivgi/kling-v2.0-t2v-master
- kwaivgi/kling-v2.0-i2v-master
- kwaivgi/kling-v2.1-t2v-master
- google/veo3-fast/image-to-video

### Image
- alibaba/qwen-image/text-to-image-plus
- alibaba/qwen-image/text-to-image-max

Also updates , README tables, and adds metadata-only tests.

## Test plan
- [ ] ruff check .
- [ ] pytest tests/ -v
- [ ] E2E (optional; requires ATLASCLOUD_API_KEY + ComfyUI PYTHONPATH)

🤖 Generated with OpenClaw