### PR TITLE
feat: add 15 new AtlasCloud video model nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,11 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Pika V2.0 Turbo Text-to-Video | pika/v2.0-turbo-t2v |
 | AtlasCloud PixVerse V4.5 Text-to-Video | pixverse/pixverse-v4.5-t2v |
 | AtlasCloud Hailuo 02 T2V Pro | minimax/hailuo-02/t2v-pro |
+| AtlasCloud Hailuo 02 T2V Standard | minimax/hailuo-02/t2v-standard |
+| AtlasCloud Hailuo 02 Pro | minimax/hailuo-02/pro |
+| AtlasCloud Hailuo 02 Fast | minimax/hailuo-02/fast |
 | AtlasCloud Hailuo 2.3 Pro Text-to-Video | minimax/hailuo-2.3-pro/text-to-video |
+| AtlasCloud Hailuo 2.3 T2V Standard | minimax/hailuo-2.3/t2v-standard |
 | AtlasCloud Sora 2 Text-to-Video | openai/sora-2/text-to-video |
 | AtlasCloud Sora 2 Text-to-Video Pro | openai/sora-2/text-to-video-pro |
 | AtlasCloud Kling V3.0 Pro Text-to-Video | kwaivgi/kling-v3.0-pro/text-to-video |
@@ -106,6 +110,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V2.5 Turbo Pro Text-to-Video | kwaivgi/kling-v2.5-turbo-pro/text-to-video |
 | AtlasCloud Kling Video O1 Text-to-Video | kwaivgi/kling-video-o1/text-to-video |
 | AtlasCloud Seedance V1 Pro Text-to-Video 1080p | bytedance/seedance-v1-pro/text-to-video-1080p |
+| AtlasCloud Seedance V1 Lite T2V 1080p | bytedance/seedance-v1-lite-t2v-1080p |
+| AtlasCloud Seedance V1 Lite T2V 720p | bytedance/seedance-v1-lite-t2v-720p |
 | AtlasCloud Seedance V1.5 Pro Text-to-Video | bytedance/seedance-v1.5-pro/text-to-video |
 | AtlasCloud Seedance V1.5 Pro Text-to-Video Fast | bytedance/seedance-v1.5-pro/text-to-video-fast |
 | AtlasCloud Hunyuan Text-to-Video | atlascloud/hunyuan-video/t2v |
@@ -128,6 +134,11 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Vidu Reference-to-Video 2.0 | vidu/reference-to-video-2.0 |
 | AtlasCloud Vidu Start-End-to-Video 2.0 | vidu/start-end-to-video-2.0 |
 | AtlasCloud Kling V2.0 I2V Master | kwaivgi/kling-v2.0-i2v-master |
+| AtlasCloud Kling V2.1 I2V Master | kwaivgi/kling-v2.1-i2v-master |
+| AtlasCloud Kling V2.1 I2V Pro (Start/End Frame) | kwaivgi/kling-v2.1-i2v-pro/start-end-frame |
+| AtlasCloud Kling V1.6 Multi I2V Pro | kwaivgi/kling-v1.6-multi-i2v-pro |
+| AtlasCloud Kling V1.6 Multi I2V Standard | kwaivgi/kling-v1.6-multi-i2v-standard |
+| AtlasCloud Kling Effects | kwaivgi/kling-effects |
 | AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
 | AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |
@@ -138,6 +149,9 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Pika V2.1 Image-to-Video | pika/v2.1-i2v |
 | AtlasCloud PixVerse V4.5 Image-to-Video | pixverse/pixverse-v4.5-i2v |
 | AtlasCloud Hailuo 02 I2V Pro | minimax/hailuo-02/i2v-pro |
+| AtlasCloud Hailuo 2.3 I2V Standard | minimax/hailuo-2.3/i2v-standard |
+| AtlasCloud Hailuo 2.3 I2V Pro | minimax/hailuo-2.3/i2v-pro |
+| AtlasCloud Hailuo 2.3 Fast | minimax/hailuo-2.3/fast |
 | AtlasCloud Sora 2 Image-to-Video | openai/sora-2/image-to-video |
 | AtlasCloud Sora 2 Image-to-Video Pro | openai/sora-2/image-to-video-pro |
 | AtlasCloud Kling V3.0 Pro Image-to-Video | kwaivgi/kling-v3.0-pro/image-to-video |
@@ -145,6 +159,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V2.6 Pro Image-to-Video | kwaivgi/kling-v2.6-pro/image-to-video |
 | AtlasCloud Kling Video O1 Image-to-Video | kwaivgi/kling-video-o1/image-to-video |
 | AtlasCloud Seedance V1.5 Pro Image-to-Video | bytedance/seedance-v1.5-pro/image-to-video |
+| AtlasCloud Seedance V1 Lite I2V 1080p | bytedance/seedance-v1-lite-i2v-1080p |
 | AtlasCloud Seedance V1.5 Pro Image-to-Video Fast | bytedance/seedance-v1.5-pro/image-to-video-fast |
 | AtlasCloud Kling V2.5 Turbo Pro Image-to-Video | kwaivgi/kling-v2.5-turbo-pro/image-to-video |
 | AtlasCloud Vidu Q3 Text-to-Video | vidu/q3/text-to-video |

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_fast.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_fast.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHailuo02Fast:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'image': ('STRING', {'default': 'https://static.atlascloud.ai/media/images/1751883836278138425_vVeazvso.jpeg', 'tooltip': 'The model generates video with the picture passed in as the first frame.Base64 encoded strings in data:image/jpeg; base64,{data} format for incoming images, or URLs accessible via the public network. The uploaded image needs to meet the following conditions: Format is JPG/JPEG/PNG; The aspect ratio is greater than 2:5 and less than 5:2; Short side pixels greater than 300px; The image file size cannot exceed 20MB.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Generate a description of the video.'}),
+                'duration': ([6, 10], {'default': 6, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'enable_prompt_expansion': ('BOOLEAN', {'default': False, 'tooltip': 'The model automatically optimizes incoming prompts to enhance output quality. This also activates the safety checker, which ensures content safety by detecting and filtering potential risks.'}),
+                'go_fast': ('BOOLEAN', {'default': True, 'tooltip': 'Prioritize faster video generation speed with a moderate trade-off in visual quality'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = 'The girl in the image begins performing a graceful ballet solo on a grand theater stage, she twirls and lifts one leg into an arabesque, soft spotlight follows her every move, cinematic lighting, slow camera pan from left to right, elegant and fluid motion',
+        duration: int = 6,
+        enable_prompt_expansion: bool = False,
+        go_fast: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Hailuo-02 Fast")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'minimax/hailuo-02/fast',
+            "image": image,
+        }
+
+        if (prompt or "").strip():
+            payload["prompt"] = prompt
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        payload["enable_prompt_expansion"] = bool(enable_prompt_expansion)
+
+        payload["go_fast"] = bool(go_fast)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_pro.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHailuo02Pro:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Generate a description of the video.(Note: Maximum support 2000 characters).'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'image': ('STRING', {'default': '', 'tooltip': 'The model generates video with the picture passed in as the first frame.Base64 encoded strings in data:image/jpeg; base64,{data} format for incoming images, or URLs accessible via the public network. The uploaded image needs to meet the following conditions: Format is JPG/JPEG/PNG; The aspect ratio is greater than 2:5 and less than 5:2; Short side pixels greater than 300px; The image file size cannot exceed 20MB.'}),
+                'duration': ([6], {'default': 6, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'enable_prompt_expansion': ('BOOLEAN', {'default': False, 'tooltip': 'The model automatically optimizes incoming prompts to enhance output quality. This also activates the safety checker, which ensures content safety by detecting and filtering potential risks.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str = '',
+        duration: int = 6,
+        enable_prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'minimax/hailuo-02/pro',
+            "prompt": prompt,
+        }
+
+        if (image or "").strip():
+            payload["image"] = image
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        payload["enable_prompt_expansion"] = bool(enable_prompt_expansion)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_t2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_t2v_standard.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHailuo02T2VStandard:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Generate a description of the video.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'duration': ([6, 10], {'default': 6, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'enable_prompt_expansion': ('BOOLEAN', {'default': False, 'tooltip': 'The model automatically optimizes incoming prompts to enhance output quality. This also activates the safety checker, which ensures content safety by detecting and filtering potential risks.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 6,
+        enable_prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'minimax/hailuo-02/t2v-standard',
+            "prompt": prompt,
+        }
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        payload["enable_prompt_expansion"] = bool(enable_prompt_expansion)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_fast.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_fast.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHailuo23Fast:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'image': ('STRING', {'default': '', 'tooltip': 'The model generates video with the picture passed in as the first frame.Base64 encoded strings in data:image/jpeg; base64,{data} format for incoming images, or URLs accessible via the public network. The uploaded image needs to meet the following conditions: Format is JPG/JPEG/PNG; The aspect ratio is greater than 2:5 and less than 5:2; Short side pixels greater than 300px; The image file size cannot exceed 20MB.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'The positive prompt for the generation.'}),
+                'duration': ([6, 10], {'default': 6, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'enable_prompt_expansion': ('BOOLEAN', {'default': True, 'tooltip': 'The model automatically optimizes incoming prompts to enhance output quality. This also activates the safety checker, which ensures content safety by detecting and filtering potential risks.'}),
+                'go_fast': ('BOOLEAN', {'default': True, 'tooltip': 'Prioritize faster video generation speed with a moderate trade-off in visual quality'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = '',
+        duration: int = 6,
+        enable_prompt_expansion: bool = True,
+        go_fast: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Hailuo-2.3 Fast")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'minimax/hailuo-2.3/fast',
+            "image": image,
+        }
+
+        if (prompt or "").strip():
+            payload["prompt"] = prompt
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        payload["enable_prompt_expansion"] = bool(enable_prompt_expansion)
+
+        payload["go_fast"] = bool(go_fast)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_pro.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHailuo23I2VPro:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'image': ('STRING', {'default': '', 'tooltip': 'The model generates video with the picture passed in as the first frame.Base64 encoded strings in data:image/jpeg; base64,{data} format for incoming images, or URLs accessible via the public network. The uploaded image needs to meet the following conditions: Format is JPG/JPEG/PNG; The aspect ratio is greater than 2:5 and less than 5:2; Short side pixels greater than 300px; The image file size cannot exceed 20MB.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'The positive prompt for the generation.'}),
+                'enable_prompt_expansion': ('BOOLEAN', {'default': True, 'tooltip': 'The model automatically optimizes incoming prompts to enhance output quality. This also activates the safety checker, which ensures content safety by detecting and filtering potential risks.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = '',
+        enable_prompt_expansion: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Hailuo-2.3 I2V Pro")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'minimax/hailuo-2.3/i2v-pro',
+            "image": image,
+        }
+
+        if (prompt or "").strip():
+            payload["prompt"] = prompt
+
+        payload["enable_prompt_expansion"] = bool(enable_prompt_expansion)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_standard.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHailuo23I2VStandard:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'image': ('STRING', {'default': '', 'tooltip': 'The model generates video with the picture passed in as the first frame.Base64 encoded strings in data:image/jpeg; base64,{data} format for incoming images, or URLs accessible via the public network. The uploaded image needs to meet the following conditions: Format is JPG/JPEG/PNG; The aspect ratio is greater than 2:5 and less than 5:2; Short side pixels greater than 300px; The image file size cannot exceed 20MB.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'The positive prompt for the generation.'}),
+                'duration': ([6, 10], {'default': 6, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'enable_prompt_expansion': ('BOOLEAN', {'default': False, 'tooltip': 'The model automatically optimizes incoming prompts to enhance output quality. This also activates the safety checker, which ensures content safety by detecting and filtering potential risks.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = '',
+        duration: int = 6,
+        enable_prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Hailuo-2.3 I2V Standard")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'minimax/hailuo-2.3/i2v-standard',
+            "image": image,
+        }
+
+        if (prompt or "").strip():
+            payload["prompt"] = prompt
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        payload["enable_prompt_expansion"] = bool(enable_prompt_expansion)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_t2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_t2v_standard.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHailuo23T2VStandard:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'The positive prompt for the generation.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'duration': ([6, 10], {'default': 6, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'enable_prompt_expansion': ('BOOLEAN', {'default': True, 'tooltip': 'The model automatically optimizes incoming prompts to enhance output quality. This also activates the safety checker, which ensures content safety by detecting and filtering potential risks.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 6,
+        enable_prompt_expansion: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'minimax/hailuo-2.3/t2v-standard',
+            "prompt": prompt,
+        }
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        payload["enable_prompt_expansion"] = bool(enable_prompt_expansion)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_effects.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_effects.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingEffects:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'image': ('STRING', {'default': '', 'tooltip': 'Image URL or Base64 encoding, in the format of data:image/png;base64,... '}),
+                'effect_scene': (['firework_2026', 'glamour_photo_shoot', 'box_of_joy', 'first_toast_of_the_year', 'my_santa_pic', 'santa_gift', 'steampunk_christmas', 'snowglobe', 'ornament_crash', 'santa_express', 'instant_christmas', 'particle_santa_surround', 'coronation_of_frost', 'building_sweater', 'spark_in_the_snow', 'scarlet_and_snow', 'cozy_toon_wrap', 'bullet_time_lite', 'magic_cloak', 'balloon_parade', 'jumping_ginger_joy', 'bullet_time', 'c4d_cartoon_pro', 'pure_white_wings', 'black_wings', 'golden_wing', 'pink_pink_wings', 'venomous_spider', 'throne_of_king', 'luminous_elf', 'woodland_elf', 'japanese_anime_1', 'american_comics', 'guardian_spirit', 'swish_swish', 'snowboarding', 'witch_transform', 'vampire_transform', 'pumpkin_head_transform', 'demon_transform', 'mummy_transform', 'zombie_transform', 'cute_pumpkin_transform', 'cute_ghost_transform', 'knock_knock_halloween', 'halloween_escape', 'baseball', 'inner_voice', 'a_list_look', 'memory_alive', 'trampoline', 'trampoline_night', 'pucker_up', 'guess_what', 'feed_mooncake', 'rampage_ape', 'flyer', 'dishwasher', 'pet_chinese_opera', 'gallery_ring', 'muscle_pet', 'squeeze_scream', 'running_man', 'disappear', 'mythic_style', 'steampunk', 'c4d_cartoon', '3d_cartoon_1', '3d_cartoon_2', 'eagle_snatch', 'hug_from_past', 'firework', 'hug', 'kiss', 'heart_gesture', 'fight', 'emoji', "let's_ride", 'let’s_ride', 'snatched', 'magic_broom', 'felt_felt', 'jumpdrop', 'celebration', 'splashsplash', 'hula', 'surfsurf', 'fairy_wing', 'angel_wing', 'dark_wing', 'skateskate', 'plushcut', 'jelly_press', 'jelly_slice', 'jelly_squish', 'jelly_jiggle', 'pixelpixel', 'yearbook', 'instant_film', 'anime_figure', 'rocketrocket', 'bloombloom', 'dizzydizzy', 'fuzzyfuzzy', 'squish', 'expansion', 'santa_gifts', 'santa_hug', 'girlfriend', 'boyfriend', 'boylfriend', 'heart_gesture_1', 'pet_wizard', 'pet_lion', 'smoke_smoke', 'thumbs_up', 'pet_chef', 'pet_delivery', 'instant_kid', 'dollar_rain', 'cry_cry', 'building_collapse', 'gun_shot', 'mushroom', 'double_gun', 'pet_warrior', 'lightning_power', 'jesus_hug', 'magic_fireball', 'shark_alert', 'long_hair', 'lie_flat', 'polar_bear_hug', 'brown_bear_hug', 'jazz_jazz', 'office_escape_plow', 'offic_escape_plow', 'fly_fly', 'watermelon_bomb', 'pet_dance', 'boss_coming', 'wool_curly', 'iron_warrior', 'pet_moto_rider', 'pet_bee', 'marry_me', 'swing_swing', 'day_to_night', 'piggy_morph', 'wig_out', 'car_explosion', 'ski_ski', 'tiger_hug', 'siblings', 'construction_worker', 'media_interview'], {'default': 'firework_2026', 'tooltip': 'Effect scene'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        effect_scene: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Kling Effects")
+
+        effect_scene = (effect_scene or "").strip()
+        if not effect_scene:
+            raise RuntimeError("effect_scene is required for AtlasCloud Kling Effects")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'kwaivgi/kling-effects',
+            "image": image,
+            "effect_scene": effect_scene,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_pro.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV16MultiI2VPro:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'The positive prompt for the generation. max length 2500'}),
+                'images': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'A list of images to use as style references.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'duration': ([5, 10], {'default': 5, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'aspect_ratio': (['1:1', '16:9', '9:16'], {'default': '1:1', 'tooltip': 'The aspect ratio of the generated media.'}),
+                'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'The negative prompt for the generation.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        duration: int = 5,
+        aspect_ratio: str = '1:1',
+        negative_prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required for AtlasCloud Kling v1.6 Multi I2V Pro (one URL per line)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'kwaivgi/kling-v1.6-multi-i2v-pro',
+            "prompt": prompt,
+            "images": image_list,
+        }
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        if str(aspect_ratio).strip():
+            payload["aspect_ratio"] = aspect_ratio
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_standard.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV16MultiI2VStandard:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'The positive prompt for the generation. max length 2500'}),
+                'images': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'A list of images to use as style references.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'duration': ([5, 10], {'default': 5, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'aspect_ratio': (['1:1', '16:9', '9:16'], {'default': '1:1', 'tooltip': 'The aspect ratio of the generated media.'}),
+                'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'The negative prompt for the generation.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        duration: int = 5,
+        aspect_ratio: str = '1:1',
+        negative_prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required for AtlasCloud Kling v1.6 Multi I2V Standard (one URL per line)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'kwaivgi/kling-v1.6-multi-i2v-standard',
+            "prompt": prompt,
+            "images": image_list,
+        }
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        if str(aspect_ratio).strip():
+            payload["aspect_ratio"] = aspect_ratio
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_master.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_master.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV21I2VMaster:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt for generation; Positive text prompt; Cannot exceed 2500 characters.'}),
+                'image': ('STRING', {'default': 'https://static.atlascloud.ai/media/images/1749522950129341275_kHvrnkgd.jpeg', 'tooltip': 'First frame of the video; Supported image formats include.jpg/.jpeg/.png; The image file size cannot exceed 10MB, and the image resolution should not be less than 300*300px.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'duration': (['5', '10'], {'default': '5', 'tooltip': 'The duration of the generated media in seconds.'}),
+                'guidance_scale': ('FLOAT', {'default': 0.5, 'min': 0.0, 'max': 1.0, 'step': 0.1, 'tooltip': 'The guidance scale to use for the generation.'}),
+                'negative_prompt': ('STRING', {'multiline': True, 'default': 'blur, distort, and low quality', 'tooltip': 'Negative text prompt; Cannot exceed 2500 characters.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        duration: str = '5',
+        guidance_scale: float = 0.5,
+        negative_prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Kling v2.1 I2V Master")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'kwaivgi/kling-v2.1-i2v-master',
+            "prompt": prompt,
+            "image": image,
+        }
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        payload["guidance_scale"] = float(guidance_scale)
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_pro_start_end_frame.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_pro_start_end_frame.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV21I2VProStartEndFrame:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'The positive prompt for the generation. max length 2500'}),
+                'image': ('STRING', {'default': '', 'tooltip': 'First frame of the video; Supported image formats include.jpg/.jpeg/.png; The image file size cannot exceed 10MB, and the image resolution should not be less than 300*300px.'}),
+                'end_image': ('STRING', {'default': '', 'tooltip': 'Last frame of the video; Supported image formats include.jpg/.jpeg/.png; The image file size cannot exceed 10MB, and the image resolution should not be less than 300*300px.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'duration': ([5, 10], {'default': 5, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'guidance_scale': ('FLOAT', {'default': 0.5, 'min': 0.0, 'max': 1.0, 'step': 0.1, 'tooltip': 'The guidance scale to use for the generation.'}),
+                'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'The negative prompt for the generation.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        end_image: str,
+        duration: int = 5,
+        guidance_scale: float = 0.5,
+        negative_prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Kling v2.1 I2V Pro (Start/End Frame)")
+
+        end_image = (end_image or "").strip()
+        if not end_image:
+            raise RuntimeError("end_image is required for AtlasCloud Kling v2.1 I2V Pro (Start/End Frame)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'kwaivgi/kling-v2.1-i2v-pro/start-end-frame',
+            "prompt": prompt,
+            "image": image,
+            "end_image": end_image,
+        }
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        payload["guidance_scale"] = float(guidance_scale)
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_i2v_1080p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_i2v_1080p.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV1LiteI2V1080p:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'image': ('STRING', {'default': 'https://static.atlascloud.ai/media/images/1750082346497865541_Xl0XTQMK.jpg', 'tooltip': 'Input image supports both URL and Base64 format; The image file size cannot exceed 30MB, and the image resolution should not be less than 300*300px.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.'}),
+                'duration': ('INT', {'default': 5, 'min': 1, 'max': 120, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'aspect_ratio': (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {'default': '16:9', 'tooltip': 'The aspect ratio of the generated video.'}),
+                'camera_fixed': ('BOOLEAN', {'default': False, 'tooltip': 'Whether to fix the camera position.'}),
+                'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'The random seed to use for the generation. -1 means a random seed will be used.'}),
+                'last_image': ('STRING', {'default': '', 'tooltip': 'URL of the ending image.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = 'Slow zoom on twitching paws dreaming, cut to wide shot as owner gently places a chew toy beside it',
+        duration: int = 5,
+        aspect_ratio: str = '16:9',
+        camera_fixed: bool = False,
+        seed: int = -1,
+        last_image: str = '',
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Seedance v1 Lite I2V 1080p")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'bytedance/seedance-v1-lite-i2v-1080p',
+            "image": image,
+        }
+
+        if (prompt or "").strip():
+            payload["prompt"] = prompt
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        if str(aspect_ratio).strip():
+            payload["aspect_ratio"] = aspect_ratio
+
+        payload["camera_fixed"] = bool(camera_fixed)
+
+        payload["seed"] = int(seed)
+
+        last = (last_image or "").strip()
+        if last:
+            payload["last_image"] = last
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_1080p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_1080p.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV1LiteT2V1080p:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'duration': ('INT', {'default': 5, 'min': 1, 'max': 120, 'tooltip': 'The duration of the generated media in seconds.'}),
+                'aspect_ratio': (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {'default': '16:9', 'tooltip': 'The aspect ratio of the generated video.'}),
+                'camera_fixed': ('BOOLEAN', {'default': False, 'tooltip': 'Whether to fix the camera position.'}),
+                'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'The random seed to use for the generation. -1 means a random seed will be used.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 5,
+        aspect_ratio: str = '16:9',
+        camera_fixed: bool = False,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'bytedance/seedance-v1-lite-t2v-1080p',
+            "prompt": prompt,
+        }
+
+        if str(duration).strip():
+            payload["duration"] = duration
+
+        if str(aspect_ratio).strip():
+            payload["aspect_ratio"] = aspect_ratio
+
+        payload["camera_fixed"] = bool(camera_fixed)
+
+        payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_720p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_720p.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV1LiteT2V720p:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                'atlas_client': ('ATLAS_CLIENT',),
+                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.'}),
+                'duration': ('INT', {'default': 5, 'min': 1, 'max': 120, 'tooltip': 'The duration of the generated media in seconds.'}),
+            },
+            "optional": {
+                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
+                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
+                'aspect_ratio': (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {'default': '16:9', 'tooltip': 'The aspect ratio of the generated video.'}),
+                'camera_fixed': ('BOOLEAN', {'default': False, 'tooltip': 'Whether to fix the camera position.'}),
+                'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'The random seed to use for the generation. -1 means a random seed will be used.'}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int,
+        aspect_ratio: str = '16:9',
+        camera_fixed: bool = False,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": 'bytedance/seedance-v1-lite-t2v-720p',
+            "prompt": prompt,
+            "duration": duration,
+        }
+
+        if str(aspect_ratio).strip():
+            payload["aspect_ratio"] = aspect_ratio
+
+        payload["camera_fixed"] = bool(camera_fixed)
+
+        payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -132,6 +132,24 @@ from atlascloud_comfyui.nodes.video.vidu_start_end_to_video_v2 import AtlasViduS
 from atlascloud_comfyui.nodes.video.kling_v20_i2v_master import AtlasKlingV20I2VMaster
 from atlascloud_comfyui.nodes.video.veo3_fast_i2v import AtlasVeo3FastImageToVideo
 from atlascloud_comfyui.nodes.video.kling_v21_t2v_master import AtlasKlingV21T2VMaster
+from atlascloud_comfyui.nodes.video.kling_v21_i2v_master import AtlasKlingV21I2VMaster
+from atlascloud_comfyui.nodes.video.kling_v21_i2v_pro_start_end_frame import AtlasKlingV21I2VProStartEndFrame
+from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_pro import AtlasKlingV16MultiI2VPro
+from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_standard import AtlasKlingV16MultiI2VStandard
+from atlascloud_comfyui.nodes.video.kling_effects import AtlasKlingEffects
+
+from atlascloud_comfyui.nodes.video.hailuo_23_t2v_standard import AtlasHailuo23T2VStandard
+from atlascloud_comfyui.nodes.video.hailuo_23_i2v_standard import AtlasHailuo23I2VStandard
+from atlascloud_comfyui.nodes.video.hailuo_23_i2v_pro import AtlasHailuo23I2VPro
+from atlascloud_comfyui.nodes.video.hailuo_23_fast import AtlasHailuo23Fast
+from atlascloud_comfyui.nodes.video.hailuo_02_fast import AtlasHailuo02Fast
+from atlascloud_comfyui.nodes.video.hailuo_02_pro import AtlasHailuo02Pro
+from atlascloud_comfyui.nodes.video.hailuo_02_t2v_standard import AtlasHailuo02T2VStandard
+
+from atlascloud_comfyui.nodes.video.seedance_v1_lite_t2v_1080p import AtlasSeedanceV1LiteT2V1080p
+from atlascloud_comfyui.nodes.video.seedance_v1_lite_t2v_720p import AtlasSeedanceV1LiteT2V720p
+from atlascloud_comfyui.nodes.video.seedance_v1_lite_i2v_1080p import AtlasSeedanceV1LiteI2V1080p
+
 from atlascloud_comfyui.nodes.video.kling_v20_t2v_master import AtlasKlingV20T2VMaster
 
 from atlascloud_comfyui.nodes.utils.image_preview import AtlasImagePreviewURL
@@ -254,6 +272,25 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Kling V2.0 I2V Master": AtlasKlingV20I2VMaster,
     "AtlasCloud VEO3 Fast Image-to-Video": AtlasVeo3FastImageToVideo,
     "AtlasCloud Kling V2.1 T2V Master": AtlasKlingV21T2VMaster,
+    "AtlasCloud Kling V2.1 I2V Master": AtlasKlingV21I2VMaster,
+    "AtlasCloud Kling V2.1 I2V Pro (Start/End Frame)": AtlasKlingV21I2VProStartEndFrame,
+    "AtlasCloud Kling V1.6 Multi I2V Pro": AtlasKlingV16MultiI2VPro,
+    "AtlasCloud Kling V1.6 Multi I2V Standard": AtlasKlingV16MultiI2VStandard,
+    "AtlasCloud Kling Effects": AtlasKlingEffects,
+
+    "AtlasCloud Hailuo 2.3 T2V Standard": AtlasHailuo23T2VStandard,
+    "AtlasCloud Hailuo 2.3 I2V Standard": AtlasHailuo23I2VStandard,
+    "AtlasCloud Hailuo 2.3 I2V Pro": AtlasHailuo23I2VPro,
+    "AtlasCloud Hailuo 2.3 Fast": AtlasHailuo23Fast,
+
+    "AtlasCloud Hailuo 02 Fast": AtlasHailuo02Fast,
+    "AtlasCloud Hailuo 02 Pro": AtlasHailuo02Pro,
+    "AtlasCloud Hailuo 02 T2V Standard": AtlasHailuo02T2VStandard,
+
+    "AtlasCloud Seedance V1 Lite T2V 1080p": AtlasSeedanceV1LiteT2V1080p,
+    "AtlasCloud Seedance V1 Lite T2V 720p": AtlasSeedanceV1LiteT2V720p,
+    "AtlasCloud Seedance V1 Lite I2V 1080p": AtlasSeedanceV1LiteI2V1080p,
+
     "AtlasCloud Kling V2.0 T2V Master": AtlasKlingV20T2VMaster,
 }
 
@@ -374,6 +411,25 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Kling V2.0 I2V Master": "AtlasCloud Kling V2.0 I2V Master",
     "AtlasCloud VEO3 Fast Image-to-Video": "AtlasCloud VEO3 Fast Image-to-Video",
     "AtlasCloud Kling V2.1 T2V Master": "AtlasCloud Kling V2.1 T2V Master",
+    "AtlasCloud Kling V2.1 I2V Master": "AtlasCloud Kling V2.1 I2V Master",
+    "AtlasCloud Kling V2.1 I2V Pro (Start/End Frame)": "AtlasCloud Kling V2.1 I2V Pro (Start/End Frame)",
+    "AtlasCloud Kling V1.6 Multi I2V Pro": "AtlasCloud Kling V1.6 Multi I2V Pro",
+    "AtlasCloud Kling V1.6 Multi I2V Standard": "AtlasCloud Kling V1.6 Multi I2V Standard",
+    "AtlasCloud Kling Effects": "AtlasCloud Kling Effects",
+
+    "AtlasCloud Hailuo 2.3 T2V Standard": "AtlasCloud Hailuo 2.3 T2V Standard",
+    "AtlasCloud Hailuo 2.3 I2V Standard": "AtlasCloud Hailuo 2.3 I2V Standard",
+    "AtlasCloud Hailuo 2.3 I2V Pro": "AtlasCloud Hailuo 2.3 I2V Pro",
+    "AtlasCloud Hailuo 2.3 Fast": "AtlasCloud Hailuo 2.3 Fast",
+
+    "AtlasCloud Hailuo 02 Fast": "AtlasCloud Hailuo 02 Fast",
+    "AtlasCloud Hailuo 02 Pro": "AtlasCloud Hailuo 02 Pro",
+    "AtlasCloud Hailuo 02 T2V Standard": "AtlasCloud Hailuo 02 T2V Standard",
+
+    "AtlasCloud Seedance V1 Lite T2V 1080p": "AtlasCloud Seedance V1 Lite T2V 1080p",
+    "AtlasCloud Seedance V1 Lite T2V 720p": "AtlasCloud Seedance V1 Lite T2V 720p",
+    "AtlasCloud Seedance V1 Lite I2V 1080p": "AtlasCloud Seedance V1 Lite I2V 1080p",
+
     "AtlasCloud Kling V2.0 T2V Master": "AtlasCloud Kling V2.0 T2V Master",
 }
 

--- a/tests/test_new_nodes_2026_03_05.py
+++ b/tests/test_new_nodes_2026_03_05.py
@@ -1,0 +1,147 @@
+"""
+Metadata-only tests for newly added nodes (2026-03-05).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_hailuo_23_t2v_standard_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.hailuo_23_t2v_standard import AtlasHailuo23T2VStandard
+
+    required = AtlasHailuo23T2VStandard.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasHailuo23T2VStandard.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_hailuo_23_i2v_standard_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.hailuo_23_i2v_standard import AtlasHailuo23I2VStandard
+
+    required = AtlasHailuo23I2VStandard.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasHailuo23I2VStandard.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_hailuo_23_i2v_pro_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.hailuo_23_i2v_pro import AtlasHailuo23I2VPro
+
+    required = AtlasHailuo23I2VPro.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasHailuo23I2VPro.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_hailuo_23_fast_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.hailuo_23_fast import AtlasHailuo23Fast
+
+    required = AtlasHailuo23Fast.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasHailuo23Fast.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_hailuo_02_fast_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.hailuo_02_fast import AtlasHailuo02Fast
+
+    required = AtlasHailuo02Fast.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasHailuo02Fast.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_hailuo_02_pro_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.hailuo_02_pro import AtlasHailuo02Pro
+
+    required = AtlasHailuo02Pro.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasHailuo02Pro.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_hailuo_02_t2v_standard_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.hailuo_02_t2v_standard import AtlasHailuo02T2VStandard
+
+    required = AtlasHailuo02T2VStandard.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasHailuo02T2VStandard.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v21_i2v_master_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v21_i2v_master import AtlasKlingV21I2VMaster
+
+    required = AtlasKlingV21I2VMaster.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasKlingV21I2VMaster.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v21_i2v_pro_start_end_frame_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v21_i2v_pro_start_end_frame import AtlasKlingV21I2VProStartEndFrame
+
+    required = AtlasKlingV21I2VProStartEndFrame.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "end_image" in required
+    assert "prompt" in required
+    assert AtlasKlingV21I2VProStartEndFrame.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v16_multi_i2v_pro_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_pro import AtlasKlingV16MultiI2VPro
+
+    required = AtlasKlingV16MultiI2VPro.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert "prompt" in required
+    assert AtlasKlingV16MultiI2VPro.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v16_multi_i2v_standard_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_standard import AtlasKlingV16MultiI2VStandard
+
+    required = AtlasKlingV16MultiI2VStandard.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert "prompt" in required
+    assert AtlasKlingV16MultiI2VStandard.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_effects_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_effects import AtlasKlingEffects
+
+    required = AtlasKlingEffects.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "effect_scene" in required
+    assert AtlasKlingEffects.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_v1_lite_t2v_1080p_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v1_lite_t2v_1080p import AtlasSeedanceV1LiteT2V1080p
+
+    required = AtlasSeedanceV1LiteT2V1080p.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasSeedanceV1LiteT2V1080p.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_v1_lite_t2v_720p_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v1_lite_t2v_720p import AtlasSeedanceV1LiteT2V720p
+
+    required = AtlasSeedanceV1LiteT2V720p.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "duration" in required
+    assert AtlasSeedanceV1LiteT2V720p.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_v1_lite_i2v_1080p_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v1_lite_i2v_1080p import AtlasSeedanceV1LiteI2V1080p
+
+    required = AtlasSeedanceV1LiteI2V1080p.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasSeedanceV1LiteI2V1080p.RETURN_TYPES == ("STRING", "STRING")


### PR DESCRIPTION
## Summary\n- Add node support for 15 AtlasCloud video models discovered via /api/v1/models + schema URLs\n\n### Added models\n- minimax/hailuo-2.3/t2v-standard\n- minimax/hailuo-2.3/i2v-standard\n- minimax/hailuo-2.3/i2v-pro\n- minimax/hailuo-2.3/fast\n- minimax/hailuo-02/fast\n- minimax/hailuo-02/pro\n- minimax/hailuo-02/t2v-standard\n- kwaivgi/kling-v2.1-i2v-master\n- kwaivgi/kling-v2.1-i2v-pro/start-end-frame\n- kwaivgi/kling-v1.6-multi-i2v-pro\n- kwaivgi/kling-v1.6-multi-i2v-standard\n- kwaivgi/kling-effects\n- bytedance/seedance-v1-lite-t2v-1080p\n- bytedance/seedance-v1-lite-t2v-720p\n- bytedance/seedance-v1-lite-i2v-1080p\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/ -v\n- [x] E2E baseline: pytest tests/test_e2e.py -v -s (PYTHONPATH=ComfyUI)\n- [x] E2E new models suite: pytest tests/test_e2e_new_models.py -v -s (PYTHONPATH=ComfyUI)\n\n🤖 Generated with OpenClaw