### PR TITLE
chore: normalize model id quoting

### DIFF
--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_fast.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_fast.py
@@ -46,7 +46,7 @@ class AtlasHailuo02Fast:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "minimax/hailuo-02/fast",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_fast.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_fast.py
@@ -46,7 +46,7 @@ class AtlasHailuo02Fast:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'minimax/hailuo-02/fast',
+            "model": "",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_pro.py
@@ -40,7 +40,7 @@ class AtlasHailuo02Pro:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "minimax/hailuo-02/pro",
             "prompt": prompt,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_pro.py
@@ -40,7 +40,7 @@ class AtlasHailuo02Pro:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'minimax/hailuo-02/pro',
+            "model": "",
             "prompt": prompt,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_t2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_t2v_standard.py
@@ -38,7 +38,7 @@ class AtlasHailuo02T2VStandard:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "minimax/hailuo-02/t2v-standard",
             "prompt": prompt,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_t2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_t2v_standard.py
@@ -38,7 +38,7 @@ class AtlasHailuo02T2VStandard:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'minimax/hailuo-02/t2v-standard',
+            "model": "",
             "prompt": prompt,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_fast.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_fast.py
@@ -46,7 +46,7 @@ class AtlasHailuo23Fast:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "minimax/hailuo-2.3/fast",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_fast.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_fast.py
@@ -46,7 +46,7 @@ class AtlasHailuo23Fast:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'minimax/hailuo-2.3/fast',
+            "model": "",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_pro.py
@@ -42,7 +42,7 @@ class AtlasHailuo23I2VPro:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'minimax/hailuo-2.3/i2v-pro',
+            "model": "",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_pro.py
@@ -42,7 +42,7 @@ class AtlasHailuo23I2VPro:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "minimax/hailuo-2.3/i2v-pro",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_standard.py
@@ -44,7 +44,7 @@ class AtlasHailuo23I2VStandard:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'minimax/hailuo-2.3/i2v-standard',
+            "model": "",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_i2v_standard.py
@@ -44,7 +44,7 @@ class AtlasHailuo23I2VStandard:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "minimax/hailuo-2.3/i2v-standard",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_t2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_t2v_standard.py
@@ -38,7 +38,7 @@ class AtlasHailuo23T2VStandard:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'minimax/hailuo-2.3/t2v-standard',
+            "model": "",
             "prompt": prompt,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/hailuo_23_t2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_23_t2v_standard.py
@@ -38,7 +38,7 @@ class AtlasHailuo23T2VStandard:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "minimax/hailuo-2.3/t2v-standard",
             "prompt": prompt,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/kling_effects.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_effects.py
@@ -44,7 +44,7 @@ class AtlasKlingEffects:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'kwaivgi/kling-effects',
+            "model": "",
             "image": image,
             "effect_scene": effect_scene,
         }

--- a/src/atlascloud_comfyui/nodes/video/kling_effects.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_effects.py
@@ -44,7 +44,7 @@ class AtlasKlingEffects:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "kwaivgi/kling-effects",
             "image": image,
             "effect_scene": effect_scene,
         }

--- a/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_pro.py
@@ -46,7 +46,7 @@ class AtlasKlingV16MultiI2VPro:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "kwaivgi/kling-v1.6-multi-i2v-pro",
             "prompt": prompt,
             "images": image_list,
         }

--- a/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_pro.py
@@ -46,7 +46,7 @@ class AtlasKlingV16MultiI2VPro:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'kwaivgi/kling-v1.6-multi-i2v-pro',
+            "model": "",
             "prompt": prompt,
             "images": image_list,
         }

--- a/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_standard.py
@@ -46,7 +46,7 @@ class AtlasKlingV16MultiI2VStandard:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "kwaivgi/kling-v1.6-multi-i2v-standard",
             "prompt": prompt,
             "images": image_list,
         }

--- a/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v16_multi_i2v_standard.py
@@ -46,7 +46,7 @@ class AtlasKlingV16MultiI2VStandard:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'kwaivgi/kling-v1.6-multi-i2v-standard',
+            "model": "",
             "prompt": prompt,
             "images": image_list,
         }

--- a/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_master.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_master.py
@@ -46,7 +46,7 @@ class AtlasKlingV21I2VMaster:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "kwaivgi/kling-v2.1-i2v-master",
             "prompt": prompt,
             "image": image,
         }

--- a/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_master.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_master.py
@@ -46,7 +46,7 @@ class AtlasKlingV21I2VMaster:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'kwaivgi/kling-v2.1-i2v-master',
+            "model": "",
             "prompt": prompt,
             "image": image,
         }

--- a/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_pro_start_end_frame.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_pro_start_end_frame.py
@@ -52,7 +52,7 @@ class AtlasKlingV21I2VProStartEndFrame:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "kwaivgi/kling-v2.1-i2v-pro/start-end-frame",
             "prompt": prompt,
             "image": image,
             "end_image": end_image,

--- a/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_pro_start_end_frame.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v21_i2v_pro_start_end_frame.py
@@ -52,7 +52,7 @@ class AtlasKlingV21I2VProStartEndFrame:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'kwaivgi/kling-v2.1-i2v-pro/start-end-frame',
+            "model": "",
             "prompt": prompt,
             "image": image,
             "end_image": end_image,

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_i2v_1080p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_i2v_1080p.py
@@ -50,7 +50,7 @@ class AtlasSeedanceV1LiteI2V1080p:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'bytedance/seedance-v1-lite-i2v-1080p',
+            "model": "",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_i2v_1080p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_i2v_1080p.py
@@ -50,7 +50,7 @@ class AtlasSeedanceV1LiteI2V1080p:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "bytedance/seedance-v1-lite-i2v-1080p",
             "image": image,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_1080p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_1080p.py
@@ -42,7 +42,7 @@ class AtlasSeedanceV1LiteT2V1080p:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "bytedance/seedance-v1-lite-t2v-1080p",
             "prompt": prompt,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_1080p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_1080p.py
@@ -42,7 +42,7 @@ class AtlasSeedanceV1LiteT2V1080p:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'bytedance/seedance-v1-lite-t2v-1080p',
+            "model": "",
             "prompt": prompt,
         }
 

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_720p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_720p.py
@@ -42,7 +42,7 @@ class AtlasSeedanceV1LiteT2V720p:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "",
+            "model": "bytedance/seedance-v1-lite-t2v-720p",
             "prompt": prompt,
             "duration": duration,
         }

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_720p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_720p.py
@@ -42,7 +42,7 @@ class AtlasSeedanceV1LiteT2V720p:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": 'bytedance/seedance-v1-lite-t2v-720p',
+            "model": "",
             "prompt": prompt,
             "duration": duration,
         }


### PR DESCRIPTION
## Why\nOur sync/diff step greps for payload "model" values using a double-quote matcher ("model": "..."). A few newly generated nodes used single quotes, which can cause false positives in model coverage checks.\n\n## Changes\n- Normalize payload model strings to double quotes across the newly added node modules.\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/ -q\n\n🤖 Generated with OpenClaw