### PR TITLE
Sync new AtlasCloud models (2026-03-07)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO2 Image-to-Video | google/veo2/image-to-video |
 | AtlasCloud WAN2.5 Image-to-Video | alibaba/wan-2.5/image-to-video |
 | AtlasCloud WAN2.5 Image-to-Video Fast | alibaba/wan-2.5/image-to-video-fast |
+| AtlasCloud Van-2.5 Text-to-Video | atlascloud/van-2.5/text-to-video |
+| AtlasCloud Van-2.5 Image-to-Video | atlascloud/van-2.5/image-to-video |
+| AtlasCloud Kling V2.1 I2V Standard | kwaivgi/kling-v2.1-i2v-standard |
+| AtlasCloud WAN2.2 Animate Mix | alibaba/wan-2.2/animate-mix |
+| AtlasCloud WAN2.2 Animate Move | alibaba/wan-2.2/animate-move |
 | AtlasCloud WAN2.2 Image-to-Video 720p | alibaba/wan-2.2/i2v-720p |
 | AtlasCloud WAN2.2 Image-to-Video 480p | alibaba/wan-2.2/i2v-480p |
 | AtlasCloud Van-2.6 Image-to-Video | atlascloud/van-2.6/image-to-video |
@@ -186,6 +191,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | Node | Model |
 |------|-------|
 | AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
+| AtlasCloud WAN2.5 Text-to-Image | alibaba/wan-2.5/text-to-image |
 | AtlasCloud Imagen4 Text-to-Image | google/imagen4 |
 | AtlasCloud Imagen4 Fast Text-to-Image | google/imagen4-fast |
 | AtlasCloud Imagen4 Ultra Text-to-Image | google/imagen4-ultra |
@@ -196,6 +202,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Nano Banana Pro Text-to-Image | google/nano-banana-pro/text-to-image |
 | AtlasCloud Seedream V5.0 Lite Text-to-Image | bytedance/seedream-v5.0-lite |
 | AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image | bytedance/seedream-v5.0-lite/sequential |
+| AtlasCloud Seedream V4 Text-to-Image | bytedance/seedream-v4 |
+| AtlasCloud Seedream V4 Sequential Text-to-Image | bytedance/seedream-v4/sequential |
 | AtlasCloud Seedream V4.5 Text-to-Image | bytedance/seedream-v4.5 |
 | AtlasCloud Seedream V4.5 Sequential Text-to-Image | bytedance/seedream-v4.5/sequential |
 | AtlasCloud ZImage Turbo Text-to-Image | z-image/turbo |
@@ -205,6 +213,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Luma Photon Flash Text-to-Image | luma/photon-flash |
 | AtlasCloud Recraft V3 Text-to-Image | recraft-ai/recraft-v3 |
 | AtlasCloud Flux2 Flex Text-to-Image | flux2/flex |
+| AtlasCloud Flux Dev Text-to-Image | black-forest-labs/flux-dev |
+| AtlasCloud Flux Dev LoRA Text-to-Image | black-forest-labs/flux-dev-lora |
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
@@ -225,9 +235,13 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |
 | AtlasCloud Seedream V5.0 Lite Edit Sequential | bytedance/seedream-v5.0-lite/edit-sequential |
 | AtlasCloud WAN2.6 Image-Edit | alibaba/wan-2.6/image-edit |
+| AtlasCloud Seedream V4 Edit | bytedance/seedream-v4/edit |
+| AtlasCloud Seedream V4 Edit Sequential | bytedance/seedream-v4/edit-sequential |
 | AtlasCloud Seedream V4.5 Edit | bytedance/seedream-v4.5/edit |
 | AtlasCloud Seedream V4.5 Edit Sequential | bytedance/seedream-v4.5/edit-sequential |
 | AtlasCloud Qwen Image Edit | atlascloud/qwen-image/edit |
+| AtlasCloud Qwen Image Edit (Alibaba) | alibaba/qwen-image/edit |
+| AtlasCloud Qwen Image Edit Plus (Alibaba) | alibaba/qwen-image/edit-plus |
 | AtlasCloud Nano Banana Pro Edit | google/nano-banana-pro/edit |
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
 

--- a/scripts/generate_nodes_2026_03_07.py
+++ b/scripts/generate_nodes_2026_03_07.py
@@ -1,0 +1,727 @@
+"""Generate ComfyUI nodes for a curated set of new AtlasCloud models.
+
+This is a one-off helper used by the daily sync job (2026-03-07).
+It reads schema URLs from the AtlasCloud models API and emits node modules
+that follow the repo's conventions (no comfy/folder_paths/requests at import).
+
+Safe to re-run: it will NOT overwrite existing files.
+
+Usage:
+  source .venv/bin/activate
+  ATLASCLOUD_API_KEY=... python scripts/generate_nodes_2026_03_07.py
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NODES_IMAGE_DIR = REPO_ROOT / "src" / "atlascloud_comfyui" / "nodes" / "image"
+NODES_VIDEO_DIR = REPO_ROOT / "src" / "atlascloud_comfyui" / "nodes" / "video"
+
+SELECTED_MODELS: List[str] = [
+    "alibaba/qwen-image/edit",
+    "alibaba/qwen-image/edit-plus",
+    "alibaba/wan-2.5/text-to-image",
+    "atlascloud/qwen-image/text-to-image",
+    "atlascloud/van-2.5/image-to-video",
+    "atlascloud/van-2.5/text-to-video",
+    "bytedance/seedream-v4",
+    "bytedance/seedream-v4/edit",
+    "bytedance/seedream-v4/edit-sequential",
+    "bytedance/seedream-v4/sequential",
+    "kwaivgi/kling-v2.1-i2v-standard",
+    "alibaba/wan-2.2/animate-mix",
+    "alibaba/wan-2.2/animate-move",
+    "black-forest-labs/flux-dev",
+    "black-forest-labs/flux-dev-lora",
+]
+
+
+def slugify_model_id(mid: str) -> str:
+    s = mid
+    s = s.replace("/", "_")
+    s = s.replace("-", "_")
+    s = s.replace(".", "_")
+    return s
+
+
+def pascal_from_model(mid: str) -> str:
+    parts = [p for p in re.split(r"[/\\\-\.]", mid) if p]
+
+    def cap(token: str) -> str:
+        # Keep already-all-caps segments as-is
+        if token.isupper():
+            return token
+        # Split underscores and title-case each
+        out = ""
+        for t in re.split(r"_+", token):
+            if not t:
+                continue
+            out += t[:1].upper() + t[1:]
+        return out
+
+    return "".join(cap(p) for p in parts)
+
+
+@dataclass
+class ModelInfo:
+    model: str
+    type: str  # "Image" or "Video"
+    tags: List[str]
+    schema: str
+
+
+def fetch_models() -> Dict[str, ModelInfo]:
+    key = os.environ.get("ATLASCLOUD_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError("ATLASCLOUD_API_KEY is not set")
+
+    r = requests.get(
+        "https://api.atlascloud.ai/api/v1/models",
+        headers={"Authorization": f"Bearer {key}"},
+        timeout=60,
+    )
+    r.raise_for_status()
+    data = r.json()
+    models = data.get("data")
+    if not isinstance(models, list):
+        raise RuntimeError(f"Unexpected models payload type: {type(models).__name__}")
+
+    out: Dict[str, ModelInfo] = {}
+    for m in models:
+        mid = m.get("model")
+        if not mid:
+            continue
+        out[mid] = ModelInfo(
+            model=mid,
+            type=m.get("type") or "",
+            tags=list(m.get("tags") or []),
+            schema=m.get("schema") or "",
+        )
+    return out
+
+
+def fetch_schema(url: str) -> Dict[str, Any]:
+    r = requests.get(url, timeout=60)
+    r.raise_for_status()
+    return r.json()
+
+
+def schema_input(schema: Dict[str, Any]) -> Tuple[List[str], Dict[str, Any]]:
+    comps = (schema.get("components") or {}).get("schemas") or {}
+    inp = comps.get("Input") or {}
+    req = list(inp.get("required") or [])
+    props = dict(inp.get("properties") or {})
+    return req, props
+
+
+def py_literal(obj: Any) -> str:
+    # For small dicts/lists/strings, repr() is fine.
+    return repr(obj)
+
+
+def make_image_node(model_id: str, req: List[str], props: Dict[str, Any]) -> Tuple[str, str, str]:
+    required = set(req)
+    is_edit = ("images" in required) or ("image" in required)
+
+    class_name = f"Atlas{pascal_from_model(model_id)}" + ("Edit" if is_edit else "TextToImage")
+    module_name = f"{slugify_model_id(model_id)}.py"
+
+    required_inputs: Dict[str, Any] = {"atlas_client": ("ATLAS_CLIENT",)}
+    optional_inputs: Dict[str, Any] = {}
+
+    # prompt is required for all these image models
+    required_inputs["prompt"] = ("STRING", {"multiline": True, "tooltip": "Text prompt"})
+
+    if "images" in props:
+        required_inputs["images"] = (
+            "STRING",
+            {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"},
+        )
+    if "image" in props and "images" not in props:
+        required_inputs["image"] = ("STRING", {"default": "", "tooltip": "Input image URL/base64"})
+
+    if "size" in props:
+        enum = props["size"].get("enum")
+        default = props["size"].get("default")
+        if enum:
+            required_inputs["size"] = (enum, {"default": default or enum[0], "tooltip": "Output size (WIDTH*HEIGHT)"})
+        else:
+            required_inputs["size"] = ("STRING", {"default": str(default or ""), "tooltip": "Output size (WIDTH*HEIGHT)"})
+
+    if "aspect_ratio" in props:
+        enum = props["aspect_ratio"].get("enum")
+        default = props["aspect_ratio"].get("default")
+        if enum:
+            required_inputs["aspect_ratio"] = (enum, {"default": default or enum[0], "tooltip": "Aspect ratio"})
+        else:
+            required_inputs["aspect_ratio"] = ("STRING", {"default": str(default or ""), "tooltip": "Aspect ratio"})
+
+    if "resolution" in props:
+        enum = props["resolution"].get("enum")
+        default = props["resolution"].get("default")
+        if enum:
+            required_inputs["resolution"] = (enum, {"default": default or enum[0], "tooltip": "Resolution preset"})
+
+    if "negative_prompt" in props:
+        optional_inputs["negative_prompt"] = ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"})
+
+    if "num_images" in props:
+        p = props["num_images"]
+        optional_inputs["num_images"] = (
+            "INT",
+            {
+                "default": int(p.get("default") or 1),
+                "min": int(p.get("minimum") or 1),
+                "max": int(p.get("maximum") or 6),
+                "tooltip": "Number of images",
+            },
+        )
+
+    if "max_images" in props:
+        p = props["max_images"]
+        optional_inputs["max_images"] = (
+            "INT",
+            {
+                "default": int(p.get("default") or 1),
+                "min": int(p.get("minimum") or 1),
+                "max": int(p.get("maximum") or 14),
+                "tooltip": "Max images",
+            },
+        )
+
+    if "prompt_extend" in props:
+        optional_inputs["prompt_extend"] = (
+            "BOOLEAN",
+            {"default": bool(props["prompt_extend"].get("default", False)), "tooltip": "Intelligent prompt rewriting"},
+        )
+
+    if "enable_prompt_expansion" in props:
+        optional_inputs["enable_prompt_expansion"] = (
+            "BOOLEAN",
+            {"default": bool(props["enable_prompt_expansion"].get("default", False)), "tooltip": "Enable prompt optimizer"},
+        )
+
+    if "strength" in props:
+        p = props["strength"]
+        optional_inputs["strength"] = (
+            "FLOAT",
+            {
+                "default": float(p.get("default") or 0.8),
+                "min": float(p.get("minimum") or 0.0),
+                "max": float(p.get("maximum") or 1.0),
+                "tooltip": "Strength (image transform)",
+            },
+        )
+
+    if "num_inference_steps" in props:
+        p = props["num_inference_steps"]
+        optional_inputs["num_inference_steps"] = (
+            "INT",
+            {
+                "default": int(p.get("default") or 28),
+                "min": int(p.get("minimum") or 1),
+                "max": int(p.get("maximum") or 50),
+                "tooltip": "Inference steps",
+            },
+        )
+
+    if "guidance_scale" in props:
+        p = props["guidance_scale"]
+        optional_inputs["guidance_scale"] = (
+            "FLOAT",
+            {"default": float(p.get("default") or 3.5), "min": 0.0, "max": 20.0, "tooltip": "Guidance scale"},
+        )
+
+    if "enable_safety_checker" in props:
+        optional_inputs["enable_safety_checker"] = (
+            "BOOLEAN",
+            {"default": bool(props["enable_safety_checker"].get("default", True)), "tooltip": "Enable safety checker"},
+        )
+
+    if "mask_image" in props:
+        optional_inputs["mask_image"] = ("STRING", {"default": "", "tooltip": "Mask image URL/base64 (optional)"})
+
+    if "seed" in props:
+        optional_inputs["seed"] = (
+            "INT",
+            {"default": int(props["seed"].get("default", -1)), "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+        )
+
+    if "enable_base64_output" in props:
+        optional_inputs["enable_base64_output"] = (
+            "BOOLEAN",
+            {"default": bool(props["enable_base64_output"].get("default", False)), "tooltip": "Return base64 instead of URL if supported"},
+        )
+
+    if "enable_sync_mode" in props:
+        optional_inputs["enable_sync_mode"] = (
+            "BOOLEAN",
+            {"default": bool(props["enable_sync_mode"].get("default", False)), "tooltip": "Try to return synchronously"},
+        )
+
+    if "output_format" in props and props["output_format"].get("enum"):
+        enum = props["output_format"].get("enum")
+        default = props["output_format"].get("default") or enum[0]
+        optional_inputs["output_format"] = (enum, {"default": default, "tooltip": "Output format"})
+
+    if "loras" in props:
+        optional_inputs["loras_json"] = ("STRING", {"default": "[]", "multiline": True, "tooltip": "JSON array for loras. Example: []"})
+
+    optional_inputs["poll_interval_sec"] = (
+        "FLOAT",
+        {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+    )
+    optional_inputs["timeout_sec"] = (
+        "INT",
+        {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+    )
+
+    # --- render file ---
+    required_inputs_py = py_literal(required_inputs)
+    optional_inputs_py = py_literal(optional_inputs)
+
+    # build run signature (required first, then optional)
+    run_args: List[str] = ["atlas_client: AtlasClientHandle", "prompt: str"]
+    if "images" in required_inputs:
+        run_args.append("images: str")
+    if "image" in required_inputs:
+        run_args.append("image: str")
+    for k in ("size", "aspect_ratio", "resolution"):
+        if k in required_inputs:
+            run_args.append(f"{k}: str")
+
+    # optionals
+    if "negative_prompt" in optional_inputs:
+        run_args.append("negative_prompt: str = \"\"")
+    if "num_images" in optional_inputs:
+        run_args.append("num_images: int = 1")
+    if "max_images" in optional_inputs:
+        run_args.append("max_images: int = 1")
+    if "prompt_extend" in optional_inputs:
+        run_args.append("prompt_extend: bool = False")
+    if "enable_prompt_expansion" in optional_inputs:
+        run_args.append("enable_prompt_expansion: bool = False")
+    if "strength" in optional_inputs:
+        run_args.append("strength: float = 0.8")
+    if "mask_image" in optional_inputs:
+        run_args.append("mask_image: str = \"\"")
+    if "num_inference_steps" in optional_inputs:
+        run_args.append("num_inference_steps: int = 28")
+    if "guidance_scale" in optional_inputs:
+        run_args.append("guidance_scale: float = 3.5")
+    if "enable_safety_checker" in optional_inputs:
+        run_args.append("enable_safety_checker: bool = True")
+    if "seed" in optional_inputs:
+        run_args.append("seed: int = -1")
+    if "enable_base64_output" in optional_inputs:
+        run_args.append("enable_base64_output: bool = False")
+    if "enable_sync_mode" in optional_inputs:
+        run_args.append("enable_sync_mode: bool = False")
+    if "output_format" in optional_inputs:
+        run_args.append("output_format: str = \"png\"")
+    if "loras_json" in optional_inputs:
+        run_args.append("loras_json: str = \"[]\"")
+
+    run_args.append("poll_interval_sec: float = 2.0")
+    run_args.append("timeout_sec: int = 300")
+
+    lines: List[str] = []
+    lines.append("from __future__ import annotations")
+    lines.append("")
+    lines.append("from typing import Any, Dict, List, Tuple")
+    lines.append("")
+    lines.append("from ..auth.atlas_client_node import AtlasClientHandle")
+    lines.append("")
+    lines.append("")
+    lines.append(f"class {class_name}:")
+    lines.append('    CATEGORY = "AtlasCloud/Image"')
+    lines.append('    FUNCTION = "run"')
+    lines.append('    RETURN_TYPES = ("STRING", "STRING")')
+    lines.append('    RETURN_NAMES = ("image_url", "prediction_id")')
+    lines.append("")
+    lines.append("    @classmethod")
+    lines.append("    def INPUT_TYPES(cls):")
+    lines.append("        return {")
+    lines.append(f"            \"required\": {required_inputs_py},")
+    lines.append(f"            \"optional\": {optional_inputs_py},")
+    lines.append("        }")
+    lines.append("")
+    lines.append("    def run(")
+    lines.append("        self,")
+    for arg in run_args:
+        lines.append(f"        {arg},")
+    lines.append("    ) -> Tuple[str, str]:")
+    lines.append("        client = atlas_client.client")
+    lines.append("")
+    lines.append("        p = (prompt or '').strip()")
+    lines.append("        if not p:")
+    lines.append("            raise RuntimeError('prompt is required')")
+    lines.append("")
+
+    if "images" in required_inputs:
+        lines.append("        image_list: List[str] = [v.strip() for v in (images or '').splitlines() if v.strip()]")
+        lines.append("        if not image_list:")
+        lines.append("            raise RuntimeError('images is required (1-10 lines)')")
+        lines.append("        if len(image_list) > 10:")
+        lines.append("            raise RuntimeError('images maxItems is 10')")
+        lines.append("")
+
+    if "image" in required_inputs:
+        lines.append("        image = (image or '').strip()")
+        lines.append("        if not image:")
+        lines.append("            raise RuntimeError('image is required (URL or base64)')")
+        lines.append("")
+
+    if "loras_json" in optional_inputs:
+        lines.append("        import json")
+        lines.append("        try:")
+        lines.append("            loras = json.loads(loras_json) if (loras_json or '').strip() else []")
+        lines.append("            if not isinstance(loras, list):")
+        lines.append("                raise ValueError('loras_json must be a JSON array')")
+        lines.append("        except Exception as e:")
+        lines.append("            raise RuntimeError(f'Invalid loras_json. Must be a JSON array. Error: {e}') from e")
+        lines.append("")
+
+    # payload
+    lines.append("        payload: Dict[str, Any] = {")
+    lines.append(f"            'model': '{model_id}',")
+    lines.append("            'prompt': p,")
+    if "images" in required_inputs:
+        lines.append("            'images': image_list,")
+    if "image" in required_inputs:
+        lines.append("            'image': image,")
+    for k in ("size", "aspect_ratio", "resolution"):
+        if k in required_inputs:
+            lines.append(f"            '{k}': {k},")
+
+    # optionals (safe defaults)
+    if "num_images" in optional_inputs:
+        lines.append("            'num_images': int(num_images),")
+    if "max_images" in optional_inputs:
+        lines.append("            'max_images': int(max_images),")
+    if "prompt_extend" in optional_inputs:
+        lines.append("            'prompt_extend': bool(prompt_extend),")
+    if "enable_prompt_expansion" in optional_inputs:
+        lines.append("            'enable_prompt_expansion': bool(enable_prompt_expansion),")
+    if "strength" in optional_inputs:
+        lines.append("            'strength': float(strength),")
+    if "mask_image" in optional_inputs:
+        lines.append("            'mask_image': (mask_image or '').strip(),")
+    if "num_inference_steps" in optional_inputs:
+        lines.append("            'num_inference_steps': int(num_inference_steps),")
+    if "guidance_scale" in optional_inputs:
+        lines.append("            'guidance_scale': float(guidance_scale),")
+    if "enable_safety_checker" in optional_inputs:
+        lines.append("            'enable_safety_checker': bool(enable_safety_checker),")
+    if "seed" in optional_inputs:
+        lines.append("            'seed': int(seed),")
+    if "enable_base64_output" in optional_inputs:
+        lines.append("            'enable_base64_output': bool(enable_base64_output),")
+    if "enable_sync_mode" in optional_inputs:
+        lines.append("            'enable_sync_mode': bool(enable_sync_mode),")
+    if "output_format" in optional_inputs:
+        lines.append("            'output_format': output_format,")
+    if "loras_json" in optional_inputs:
+        lines.append("            'loras': loras,")
+    lines.append("        }")
+    lines.append("")
+
+    if "negative_prompt" in optional_inputs:
+        lines.append("        neg = (negative_prompt or '').strip()")
+        lines.append("        if neg:")
+        lines.append("            payload['negative_prompt'] = neg")
+        lines.append("")
+
+    if "mask_image" in optional_inputs:
+        lines.append("        if not (payload.get('mask_image') or '').strip():")
+        lines.append("            payload.pop('mask_image', None)")
+        lines.append("")
+
+    lines.append("        prediction_id = client.generate_image(payload)")
+    lines.append("        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))")
+    lines.append("")
+    lines.append("        outputs = (result.get('data') or {}).get('outputs') or []")
+    lines.append("        if not outputs:")
+    lines.append("            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')")
+    lines.append("")
+    lines.append("        first = outputs[0]")
+    lines.append("        if isinstance(first, dict):")
+    lines.append("            url = first.get('url') or first.get('image') or first.get('output')")
+    lines.append("            if isinstance(url, str) and url.strip():")
+    lines.append("                return (url, prediction_id)")
+    lines.append("            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')")
+    lines.append("")
+    lines.append("        if not isinstance(first, str):")
+    lines.append("            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')")
+    lines.append("")
+    lines.append("        return (first, prediction_id)")
+    lines.append("")
+
+    return module_name, class_name, "\n".join(lines)
+
+
+def make_video_node(model_id: str, req: List[str], props: Dict[str, Any]) -> Tuple[str, str, str]:
+    required = set(req)
+
+    has_image = "image" in props
+    has_video = "video" in props
+    has_mode = "mode" in props
+
+    # classify
+    is_i2v = "image" in required
+    is_animate = model_id.startswith("alibaba/wan-2.2/animate") and has_image and has_video and has_mode
+
+    if is_i2v:
+        suffix = "I2V"
+    elif is_animate:
+        suffix = "ReferenceToVideo"
+    else:
+        suffix = "TextToVideo"
+
+    class_name = f"Atlas{pascal_from_model(model_id)}{suffix}"
+    module_name = f"{slugify_model_id(model_id)}.py"
+
+    required_inputs: Dict[str, Any] = {"atlas_client": ("ATLAS_CLIENT",)}
+    optional_inputs: Dict[str, Any] = {}
+
+    if "prompt" in props:
+        required_inputs["prompt"] = ("STRING", {"multiline": True, "tooltip": "Text prompt"})
+
+    if "image" in props and "image" in required:
+        required_inputs["image"] = ("STRING", {"default": "", "tooltip": "Input image URL/base64"})
+
+    if is_animate:
+        required_inputs["image"] = ("STRING", {"default": "", "tooltip": "Input image URL/base64"})
+        required_inputs["video"] = ("STRING", {"default": "", "tooltip": "Reference/input video URL"})
+
+        enum = props.get("mode", {}).get("enum")
+        default = props.get("mode", {}).get("default")
+        if enum:
+            required_inputs["mode"] = (enum, {"default": default or enum[0], "tooltip": "Mode"})
+        else:
+            required_inputs["mode"] = ("STRING", {"default": str(default or ""), "tooltip": "Mode"})
+
+    # van-2.5
+    if "resolution" in props and "resolution" in required:
+        enum = props["resolution"].get("enum")
+        default = props["resolution"].get("default")
+        if enum:
+            required_inputs["resolution"] = (enum, {"default": default or enum[0], "tooltip": "Resolution"})
+        else:
+            required_inputs["resolution"] = ("STRING", {"default": str(default or ""), "tooltip": "Resolution"})
+
+    if "size" in props and "size" in required:
+        enum = props["size"].get("enum")
+        default = props["size"].get("default")
+        if enum:
+            required_inputs["size"] = (enum, {"default": default or enum[0], "tooltip": "Size (WIDTH*HEIGHT)"})
+        else:
+            required_inputs["size"] = ("STRING", {"default": str(default or ""), "tooltip": "Size (WIDTH*HEIGHT)"})
+
+    if "negative_prompt" in props:
+        optional_inputs["negative_prompt"] = ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"})
+
+    if "duration" in props:
+        enum = props["duration"].get("enum")
+        default = int(props["duration"].get("default") or 5)
+        if enum:
+            optional_inputs["duration"] = (enum, {"default": default, "tooltip": "Duration (seconds)"})
+        else:
+            optional_inputs["duration"] = ("INT", {"default": default, "min": 1, "max": 120, "tooltip": "Duration (seconds)"})
+
+    if "audio" in props:
+        optional_inputs["audio"] = ("STRING", {"default": "", "tooltip": "Audio URL (optional)"})
+
+    if "enable_prompt_expansion" in props:
+        optional_inputs["enable_prompt_expansion"] = (
+            "BOOLEAN",
+            {"default": bool(props["enable_prompt_expansion"].get("default", False)), "tooltip": "Enable prompt expansion"},
+        )
+
+    if "seed" in props:
+        optional_inputs["seed"] = (
+            "INT",
+            {"default": int(props["seed"].get("default", -1)), "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+        )
+
+    optional_inputs["poll_interval_sec"] = (
+        "FLOAT",
+        {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+    )
+    optional_inputs["timeout_sec"] = (
+        "INT",
+        {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+    )
+
+    required_inputs_py = py_literal(required_inputs)
+    optional_inputs_py = py_literal(optional_inputs)
+
+    run_args: List[str] = ["atlas_client: AtlasClientHandle"]
+    if "prompt" in required_inputs:
+        run_args.append("prompt: str")
+    if "image" in required_inputs:
+        run_args.append("image: str")
+    if "video" in required_inputs:
+        run_args.append("video: str")
+    if "mode" in required_inputs:
+        run_args.append("mode: str")
+    if "resolution" in required_inputs:
+        run_args.append("resolution: str")
+    if "size" in required_inputs:
+        run_args.append("size: str")
+
+    # optionals
+    if "negative_prompt" in optional_inputs:
+        run_args.append("negative_prompt: str = \"\"")
+    if "duration" in optional_inputs:
+        run_args.append("duration: int = 5")
+    if "audio" in optional_inputs:
+        run_args.append("audio: str = \"\"")
+    if "enable_prompt_expansion" in optional_inputs:
+        run_args.append("enable_prompt_expansion: bool = False")
+    if "seed" in optional_inputs:
+        run_args.append("seed: int = -1")
+
+    run_args.append("poll_interval_sec: float = 2.0")
+    run_args.append("timeout_sec: int = 900")
+
+    lines: List[str] = []
+    lines.append("from __future__ import annotations")
+    lines.append("")
+    lines.append("from typing import Any, Dict, Tuple")
+    lines.append("")
+    lines.append("from ..auth.atlas_client_node import AtlasClientHandle")
+    lines.append("")
+    lines.append("")
+    lines.append(f"class {class_name}:")
+    lines.append('    CATEGORY = "AtlasCloud/Video"')
+    lines.append('    FUNCTION = "run"')
+    lines.append('    RETURN_TYPES = ("STRING", "STRING")')
+    lines.append('    RETURN_NAMES = ("video_url", "prediction_id")')
+    lines.append("")
+    lines.append("    @classmethod")
+    lines.append("    def INPUT_TYPES(cls):")
+    lines.append("        return {")
+    lines.append(f"            \"required\": {required_inputs_py},")
+    lines.append(f"            \"optional\": {optional_inputs_py},")
+    lines.append("        }")
+    lines.append("")
+    lines.append("    def run(")
+    lines.append("        self,")
+    for arg in run_args:
+        lines.append(f"        {arg},")
+    lines.append("    ) -> Tuple[str, str]:")
+    lines.append("        client = atlas_client.client")
+    lines.append("")
+
+    if "image" in required_inputs:
+        lines.append("        image = (image or '').strip()")
+        lines.append("        if not image:")
+        lines.append("            raise RuntimeError('image is required (URL or base64)')")
+        lines.append("")
+
+    if "video" in required_inputs:
+        lines.append("        video = (video or '').strip()")
+        lines.append("        if not video:")
+        lines.append("            raise RuntimeError('video is required (URL)')")
+        lines.append("")
+
+    # payload
+    lines.append("        payload: Dict[str, Any] = {")
+    lines.append(f"            'model': '{model_id}',")
+    if "prompt" in required_inputs:
+        lines.append("            'prompt': prompt,")
+    if "mode" in required_inputs:
+        lines.append("            'mode': mode,")
+    if "resolution" in required_inputs:
+        lines.append("            'resolution': resolution,")
+    if "size" in required_inputs:
+        lines.append("            'size': size,")
+    if "duration" in optional_inputs:
+        lines.append("            'duration': int(duration),")
+    if "enable_prompt_expansion" in optional_inputs:
+        lines.append("            'enable_prompt_expansion': bool(enable_prompt_expansion),")
+    if "seed" in optional_inputs:
+        lines.append("            'seed': int(seed),")
+    if "image" in required_inputs:
+        lines.append("            'image': image,")
+    if "video" in required_inputs:
+        lines.append("            'video': video,")
+    lines.append("        }")
+    lines.append("")
+
+    if "negative_prompt" in optional_inputs:
+        lines.append("        neg = (negative_prompt or '').strip()")
+        lines.append("        if neg:")
+        lines.append("            payload['negative_prompt'] = neg")
+        lines.append("")
+
+    if "audio" in optional_inputs:
+        lines.append("        a = (audio or '').strip()")
+        lines.append("        if a:")
+        lines.append("            payload['audio'] = a")
+        lines.append("")
+
+    lines.append("        prediction_id = client.generate_video(payload)")
+    lines.append("        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))")
+    lines.append("")
+    lines.append("        outputs = (result.get('data') or {}).get('outputs') or []")
+    lines.append("        if not outputs:")
+    lines.append("            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')")
+    lines.append("")
+    lines.append("        first = outputs[0]")
+    lines.append("        if not isinstance(first, str):")
+    lines.append("            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')")
+    lines.append("")
+    lines.append("        return (first, prediction_id)")
+    lines.append("")
+
+    return module_name, class_name, "\n".join(lines)
+
+
+def main() -> None:
+    models = fetch_models()
+
+    created: List[Tuple[str, str, str]] = []  # (model_id, file, class)
+
+    for mid in SELECTED_MODELS:
+        info = models.get(mid)
+        if not info:
+            raise RuntimeError(f"Model not found in API: {mid}")
+        if not info.schema:
+            raise RuntimeError(f"Model schema missing: {mid}")
+
+        schema = fetch_schema(info.schema)
+        req, props = schema_input(schema)
+
+        if info.type == "Image":
+            module_name, class_name, content = make_image_node(mid, req, props)
+            out_path = NODES_IMAGE_DIR / module_name
+        elif info.type == "Video":
+            module_name, class_name, content = make_video_node(mid, req, props)
+            out_path = NODES_VIDEO_DIR / module_name
+        else:
+            continue
+
+        if out_path.exists():
+            # Never overwrite
+            continue
+
+        out_path.write_text(content, encoding="utf-8")
+        created.append((mid, str(out_path.relative_to(REPO_ROOT)), class_name))
+
+    print(f"created={len(created)}")
+    for mid, fp, cls in created:
+        print(f"- {mid} -> {fp} ({cls})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/atlascloud_comfyui/nodes/image/flux_dev_lora_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/flux_dev_lora_t2i.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasFluxDevLoraTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'image': ('STRING', {'default': '', 'tooltip': 'Input image URL/base64'}), 'size': ('STRING', {'default': '1024*1024', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'num_images': ('INT', {'default': 1, 'min': 1, 'max': 4, 'tooltip': 'Number of images'}), 'strength': ('FLOAT', {'default': 0.8, 'min': 0.0, 'max': 1.0, 'tooltip': 'Strength (image transform)'}), 'guidance_scale': ('FLOAT', {'default': 3.5, 'min': 0.0, 'max': 20.0, 'tooltip': 'Guidance scale'}), 'mask_image': ('STRING', {'default': '', 'tooltip': 'Mask image URL/base64 (optional)'}), 'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'Random if -1'}), 'loras_json': ('STRING', {'default': '[]', 'multiline': True, 'tooltip': 'JSON array for loras. Example: []'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        size: str,
+        num_images: int = 1,
+        strength: float = 0.8,
+        mask_image: str = "",
+        guidance_scale: float = 3.5,
+        seed: int = -1,
+        loras_json: str = "[]",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        image = (image or '').strip()
+        if not image:
+            raise RuntimeError('image is required (URL or base64)')
+
+        import json
+        try:
+            loras = json.loads(loras_json) if (loras_json or '').strip() else []
+            if not isinstance(loras, list):
+                raise ValueError('loras_json must be a JSON array')
+        except Exception as e:
+            raise RuntimeError(f'Invalid loras_json. Must be a JSON array. Error: {e}') from e
+
+        payload: Dict[str, Any] = {
+            'model': 'black-forest-labs/flux-dev-lora',
+            'prompt': p,
+            'image': image,
+            'size': size,
+            'num_images': int(num_images),
+            'strength': float(strength),
+            'mask_image': (mask_image or '').strip(),
+            'guidance_scale': float(guidance_scale),
+            'seed': int(seed),
+            'loras': loras,
+        }
+
+        if not (payload.get('mask_image') or '').strip():
+            payload.pop('mask_image', None)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/flux_dev_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/flux_dev_t2i.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasFluxDevTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'image': ('STRING', {'default': '', 'tooltip': 'Input image URL/base64'}), 'size': ('STRING', {'default': '1024*1024', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'num_images': ('INT', {'default': 1, 'min': 1, 'max': 4, 'tooltip': 'Number of images'}), 'strength': ('FLOAT', {'default': 0.8, 'min': 0.0, 'max': 1.0, 'tooltip': 'Strength (image transform)'}), 'num_inference_steps': ('INT', {'default': 28, 'min': 1, 'max': 50, 'tooltip': 'Inference steps'}), 'guidance_scale': ('FLOAT', {'default': 3.5, 'min': 0.0, 'max': 20.0, 'tooltip': 'Guidance scale'}), 'enable_safety_checker': ('BOOLEAN', {'default': True, 'tooltip': 'Enable safety checker'}), 'mask_image': ('STRING', {'default': '', 'tooltip': 'Mask image URL/base64 (optional)'}), 'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'Random if -1'}), 'enable_base64_output': ('BOOLEAN', {'default': False, 'tooltip': 'Return base64 instead of URL if supported'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        size: str,
+        num_images: int = 1,
+        strength: float = 0.8,
+        mask_image: str = "",
+        num_inference_steps: int = 28,
+        guidance_scale: float = 3.5,
+        enable_safety_checker: bool = True,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        image = (image or '').strip()
+        if not image:
+            raise RuntimeError('image is required (URL or base64)')
+
+        payload: Dict[str, Any] = {
+            'model': 'black-forest-labs/flux-dev',
+            'prompt': p,
+            'image': image,
+            'size': size,
+            'num_images': int(num_images),
+            'strength': float(strength),
+            'mask_image': (mask_image or '').strip(),
+            'num_inference_steps': int(num_inference_steps),
+            'guidance_scale': float(guidance_scale),
+            'enable_safety_checker': bool(enable_safety_checker),
+            'seed': int(seed),
+            'enable_base64_output': bool(enable_base64_output),
+        }
+
+        if not (payload.get('mask_image') or '').strip():
+            payload.pop('mask_image', None)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_edit_alibaba.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_edit_alibaba.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasAlibabaQwenImageEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'images': ('STRING', {'multiline': True, 'default': '', 'tooltip': '1-10 image URLs/base64, one per line'})},
+            "optional": {'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'Negative prompt'}), 'num_images': ('INT', {'default': 1, 'min': 1, 'max': 1, 'tooltip': 'Number of images'}), 'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'Random if -1'}), 'enable_base64_output': ('BOOLEAN', {'default': False, 'tooltip': 'Return base64 instead of URL if supported'}), 'enable_sync_mode': ('BOOLEAN', {'default': False, 'tooltip': 'Try to return synchronously'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        negative_prompt: str = "",
+        num_images: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        image_list: List[str] = [v.strip() for v in (images or '').splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError('images is required (1-10 lines)')
+        if len(image_list) > 10:
+            raise RuntimeError('images maxItems is 10')
+
+        payload: Dict[str, Any] = {
+            'model': 'alibaba/qwen-image/edit',
+            'prompt': p,
+            'images': image_list,
+            'num_images': int(num_images),
+            'seed': int(seed),
+            'enable_base64_output': bool(enable_base64_output),
+            'enable_sync_mode': bool(enable_sync_mode),
+        }
+
+        neg = (negative_prompt or '').strip()
+        if neg:
+            payload['negative_prompt'] = neg
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_edit_plus_alibaba.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_edit_plus_alibaba.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasAlibabaQwenImageEditPlus:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'images': ('STRING', {'multiline': True, 'default': '', 'tooltip': '1-10 image URLs/base64, one per line'}), 'size': ('STRING', {'default': '', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'Negative prompt'}), 'num_images': ('INT', {'default': 1, 'min': 1, 'max': 6, 'tooltip': 'Number of images'}), 'prompt_extend': ('BOOLEAN', {'default': False, 'tooltip': 'Intelligent prompt rewriting'}), 'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'Random if -1'}), 'enable_base64_output': ('BOOLEAN', {'default': False, 'tooltip': 'Return base64 instead of URL if supported'}), 'enable_sync_mode': ('BOOLEAN', {'default': False, 'tooltip': 'Try to return synchronously'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str,
+        negative_prompt: str = "",
+        num_images: int = 1,
+        prompt_extend: bool = False,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        image_list: List[str] = [v.strip() for v in (images or '').splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError('images is required (1-10 lines)')
+        if len(image_list) > 10:
+            raise RuntimeError('images maxItems is 10')
+
+        payload: Dict[str, Any] = {
+            'model': 'alibaba/qwen-image/edit-plus',
+            'prompt': p,
+            'images': image_list,
+            'size': size,
+            'num_images': int(num_images),
+            'prompt_extend': bool(prompt_extend),
+            'seed': int(seed),
+            'enable_base64_output': bool(enable_base64_output),
+            'enable_sync_mode': bool(enable_sync_mode),
+        }
+
+        neg = (negative_prompt or '').strip()
+        if neg:
+            payload['negative_prompt'] = neg
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_t2i_atlascloud.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_t2i_atlascloud.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasAtlascloudQwenImageTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'size': ('STRING', {'default': '1024*1024', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'Random if -1'}), 'enable_base64_output': ('BOOLEAN', {'default': False, 'tooltip': 'Return base64 instead of URL if supported'}), 'enable_sync_mode': ('BOOLEAN', {'default': False, 'tooltip': 'Try to return synchronously'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        payload: Dict[str, Any] = {
+            'model': 'atlascloud/qwen-image/text-to-image',
+            'prompt': p,
+            'size': size,
+            'seed': int(seed),
+            'enable_base64_output': bool(enable_base64_output),
+            'enable_sync_mode': bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v4_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v4_edit.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV4Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'images': ('STRING', {'multiline': True, 'default': '', 'tooltip': '1-10 image URLs/base64, one per line'}), 'size': ('STRING', {'default': '2048*2048', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'enable_base64_output': ('BOOLEAN', {'default': False, 'tooltip': 'Return base64 instead of URL if supported'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        image_list: List[str] = [v.strip() for v in (images or '').splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError('images is required (1-10 lines)')
+        if len(image_list) > 10:
+            raise RuntimeError('images maxItems is 10')
+
+        payload: Dict[str, Any] = {
+            'model': 'bytedance/seedream-v4/edit',
+            'prompt': p,
+            'images': image_list,
+            'size': size,
+            'enable_base64_output': bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v4_edit_sequential.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v4_edit_sequential.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV4EditSequential:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'images': ('STRING', {'multiline': True, 'default': '', 'tooltip': '1-10 image URLs/base64, one per line'}), 'size': ('STRING', {'default': '2048*2048', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'max_images': ('INT', {'default': 1, 'min': 1, 'max': 14, 'tooltip': 'Max images'}), 'enable_base64_output': ('BOOLEAN', {'default': False, 'tooltip': 'Return base64 instead of URL if supported'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str,
+        max_images: int = 1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        image_list: List[str] = [v.strip() for v in (images or '').splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError('images is required (1-10 lines)')
+        if len(image_list) > 10:
+            raise RuntimeError('images maxItems is 10')
+
+        payload: Dict[str, Any] = {
+            'model': 'bytedance/seedream-v4/edit-sequential',
+            'prompt': p,
+            'images': image_list,
+            'size': size,
+            'max_images': int(max_images),
+            'enable_base64_output': bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v4_sequential_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v4_sequential_t2i.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV4SequentialTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'size': ('STRING', {'default': '2048*2048', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'max_images': ('INT', {'default': 1, 'min': 1, 'max': 14, 'tooltip': 'Max images'}), 'enable_base64_output': ('BOOLEAN', {'default': False, 'tooltip': 'Return base64 instead of URL if supported'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        max_images: int = 1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        payload: Dict[str, Any] = {
+            'model': 'bytedance/seedream-v4/sequential',
+            'prompt': p,
+            'size': size,
+            'max_images': int(max_images),
+            'enable_base64_output': bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v4_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v4_t2i.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV4TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'size': ('STRING', {'default': '2048*2048', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'enable_base64_output': ('BOOLEAN', {'default': False, 'tooltip': 'Return base64 instead of URL if supported'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        payload: Dict[str, Any] = {
+            'model': 'bytedance/seedream-v4',
+            'prompt': p,
+            'size': size,
+            'enable_base64_output': bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/wan25_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/wan25_t2i.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan25TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'size': (['576*1344', '720*1280', '720*1680', '768*1024', '800*1200', '936*2184', '960*1280', '960*1440', '1024*768', '1024*1024', '1080*1920', '1168*1752', '1200*800', '1200*1600', '1224*1632', '1280*720', '1280*960', '1280*1280', '1344*576', '1440*960', '1440*1440', '1600*1200', '1632*1224', '1680*720', '1752*1168', '1920*1080', '2184*936'], {'default': '1280*1280', 'tooltip': 'Output size (WIDTH*HEIGHT)'})},
+            "optional": {'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'Negative prompt'}), 'enable_prompt_expansion': ('BOOLEAN', {'default': False, 'tooltip': 'Enable prompt optimizer'}), 'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'Random if -1'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 300, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        negative_prompt: str = "",
+        enable_prompt_expansion: bool = False,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or '').strip()
+        if not p:
+            raise RuntimeError('prompt is required')
+
+        payload: Dict[str, Any] = {
+            'model': 'alibaba/wan-2.5/text-to-image',
+            'prompt': p,
+            'size': size,
+            'enable_prompt_expansion': bool(enable_prompt_expansion),
+            'seed': int(seed),
+        }
+
+        neg = (negative_prompt or '').strip()
+        if neg:
+            payload['negative_prompt'] = neg
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get('url') or first.get('image') or first.get('output')
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f'Unexpected output object for prediction {prediction_id}: {first}')
+
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kwaivgi_kling_v2_1_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/kwaivgi_kling_v2_1_i2v_standard.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKwaivgiKlingV21I2VStandard:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'image': ('STRING', {'default': '', 'tooltip': 'Input image URL/base64'})},
+            "optional": {'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'Negative prompt'}), 'duration': ([5, 10], {'default': 5, 'tooltip': 'Duration (seconds)'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        negative_prompt: str = "",
+        duration: int = 5,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image = (image or '').strip()
+        if not image:
+            raise RuntimeError('image is required (URL or base64)')
+
+        payload: Dict[str, Any] = {
+            'model': 'kwaivgi/kling-v2.1-i2v-standard',
+            'prompt': prompt,
+            'duration': int(duration),
+            'image': image,
+        }
+
+        neg = (negative_prompt or '').strip()
+        if neg:
+            payload['negative_prompt'] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/van25_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/van25_i2v.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasAtlascloudVan25ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'image': ('STRING', {'default': '', 'tooltip': 'Input image URL/base64'}), 'resolution': (['720p', '1080p'], {'default': '720p', 'tooltip': 'Resolution'})},
+            "optional": {'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'Negative prompt'}), 'duration': ([5, 10], {'default': 5, 'tooltip': 'Duration (seconds)'}), 'audio': ('STRING', {'default': '', 'tooltip': 'Audio URL (optional)'}), 'enable_prompt_expansion': ('BOOLEAN', {'default': False, 'tooltip': 'Enable prompt expansion'}), 'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'Random if -1'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        resolution: str,
+        negative_prompt: str = "",
+        duration: int = 5,
+        audio: str = "",
+        enable_prompt_expansion: bool = False,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image = (image or '').strip()
+        if not image:
+            raise RuntimeError('image is required (URL or base64)')
+
+        payload: Dict[str, Any] = {
+            'model': 'atlascloud/van-2.5/image-to-video',
+            'prompt': prompt,
+            'resolution': resolution,
+            'duration': int(duration),
+            'enable_prompt_expansion': bool(enable_prompt_expansion),
+            'seed': int(seed),
+            'image': image,
+        }
+
+        neg = (negative_prompt or '').strip()
+        if neg:
+            payload['negative_prompt'] = neg
+
+        a = (audio or '').strip()
+        if a:
+            payload['audio'] = a
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/van25_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/van25_t2v.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasAtlascloudVan25TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt'}), 'size': (['1280*720', '720*1280', '1920*1080', '1080*1920'], {'default': '1280*720', 'tooltip': 'Size (WIDTH*HEIGHT)'})},
+            "optional": {'negative_prompt': ('STRING', {'multiline': True, 'default': '', 'tooltip': 'Negative prompt'}), 'duration': ([5, 10], {'default': 5, 'tooltip': 'Duration (seconds)'}), 'audio': ('STRING', {'default': '', 'tooltip': 'Audio URL (optional)'}), 'enable_prompt_expansion': ('BOOLEAN', {'default': False, 'tooltip': 'Enable prompt expansion'}), 'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'Random if -1'}), 'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        negative_prompt: str = "",
+        duration: int = 5,
+        audio: str = "",
+        enable_prompt_expansion: bool = False,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            'model': 'atlascloud/van-2.5/text-to-video',
+            'prompt': prompt,
+            'size': size,
+            'duration': int(duration),
+            'enable_prompt_expansion': bool(enable_prompt_expansion),
+            'seed': int(seed),
+        }
+
+        neg = (negative_prompt or '').strip()
+        if neg:
+            payload['negative_prompt'] = neg
+
+        a = (audio or '').strip()
+        if a:
+            payload['audio'] = a
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan22_animate_mix.py
+++ b/src/atlascloud_comfyui/nodes/video/wan22_animate_mix.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22AnimateMix:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'image': ('STRING', {'default': '', 'tooltip': 'Input image URL/base64'}), 'video': ('STRING', {'default': '', 'tooltip': 'Reference/input video URL'}), 'mode': (['wan-std', 'wan-pro'], {'default': 'wan-pro', 'tooltip': 'Mode'})},
+            "optional": {'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        video: str,
+        mode: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image = (image or '').strip()
+        if not image:
+            raise RuntimeError('image is required (URL or base64)')
+
+        video = (video or '').strip()
+        if not video:
+            raise RuntimeError('video is required (URL)')
+
+        payload: Dict[str, Any] = {
+            'model': 'alibaba/wan-2.2/animate-mix',
+            'mode': mode,
+            'image': image,
+            'video': video,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan22_animate_move.py
+++ b/src/atlascloud_comfyui/nodes/video/wan22_animate_move.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22AnimateMove:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {'atlas_client': ('ATLAS_CLIENT',), 'image': ('STRING', {'default': '', 'tooltip': 'Input image URL/base64'}), 'video': ('STRING', {'default': '', 'tooltip': 'Reference/input video URL'}), 'mode': (['wan-std', 'wan-pro'], {'default': 'wan-pro', 'tooltip': 'Mode'})},
+            "optional": {'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}), 'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'})},
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        video: str,
+        mode: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image = (image or '').strip()
+        if not image:
+            raise RuntimeError('image is required (URL or base64)')
+
+        video = (video or '').strip()
+        if not video:
+            raise RuntimeError('video is required (URL)')
+
+        payload: Dict[str, Any] = {
+            'model': 'alibaba/wan-2.2/animate-move',
+            'mode': mode,
+            'image': image,
+            'video': video,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get('data') or {}).get('outputs') or []
+        if not outputs:
+            raise RuntimeError(f'No outputs returned for prediction {prediction_id}: {result}')
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f'Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}')
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -96,13 +96,22 @@ from atlascloud_comfyui.nodes.image.seedream_v45_t2i import AtlasSeedreamV45Text
 from atlascloud_comfyui.nodes.image.seedream_v45_edit import AtlasSeedreamV45Edit
 from atlascloud_comfyui.nodes.image.seedream_v45_sequential_t2i import AtlasSeedreamV45SequentialTextToImage
 from atlascloud_comfyui.nodes.image.seedream_v45_edit_sequential import AtlasSeedreamV45EditSequential
+from atlascloud_comfyui.nodes.image.seedream_v4_t2i import AtlasSeedreamV4TextToImage
+from atlascloud_comfyui.nodes.image.seedream_v4_sequential_t2i import AtlasSeedreamV4SequentialTextToImage
+from atlascloud_comfyui.nodes.image.seedream_v4_edit import AtlasSeedreamV4Edit
+from atlascloud_comfyui.nodes.image.seedream_v4_edit_sequential import AtlasSeedreamV4EditSequential
 from atlascloud_comfyui.nodes.image.zimage_turbo_lora_t2i import AtlasZImageTurboLoraTextToImage
 from atlascloud_comfyui.nodes.image.zimage_turbo_t2i import AtlasZImageTurboTextToImage
 from atlascloud_comfyui.nodes.image.qwen_image_edit import AtlasQwenImageEdit
+from atlascloud_comfyui.nodes.image.qwen_image_edit_alibaba import AtlasAlibabaQwenImageEdit
+from atlascloud_comfyui.nodes.image.qwen_image_edit_plus_alibaba import AtlasAlibabaQwenImageEditPlus
+from atlascloud_comfyui.nodes.image.qwen_image_t2i_atlascloud import AtlasAtlascloudQwenImageTextToImage
 from atlascloud_comfyui.nodes.image.nano_banana_pro_t2i_ultra import AtlasNanoBananaProTextToImageUltra
 from atlascloud_comfyui.nodes.image.nano_banana_pro_t2i import AtlasNanoBananaProTextToImage
 from atlascloud_comfyui.nodes.image.nano_banana_pro_edit import AtlasNanoBananaProEdit
 from atlascloud_comfyui.nodes.image.flux2_flex_t2i import AtlasFlux2FlexTextToImage
+from atlascloud_comfyui.nodes.image.flux_dev_t2i import AtlasFluxDevTextToImage
+from atlascloud_comfyui.nodes.image.flux_dev_lora_t2i import AtlasFluxDevLoraTextToImage
 from atlascloud_comfyui.nodes.image.nano_banana2_t2i import AtlasNanoBanana2TextToImage
 from atlascloud_comfyui.nodes.image.nano_banana2_t2i_dev import AtlasNanoBanana2TextToImageDev
 from atlascloud_comfyui.nodes.image.nano_banana2_edit import AtlasNanoBanana2Edit
@@ -115,6 +124,7 @@ from atlascloud_comfyui.nodes.image.imagen4_t2i import AtlasImagen4TextToImage
 from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import AtlasImagen4FastTextToImage
 from atlascloud_comfyui.nodes.image.imagen4_ultra_t2i import AtlasImagen4UltraTextToImage
 from atlascloud_comfyui.nodes.image.imagen3_t2i import AtlasImagen3TextToImage
+from atlascloud_comfyui.nodes.image.wan25_t2i import AtlasWan25TextToImage
 from atlascloud_comfyui.nodes.image.ideogram_v3_quality_t2i import AtlasIdeogramV3QualityTextToImage
 from atlascloud_comfyui.nodes.image.ideogram_v3_turbo_t2i import AtlasIdeogramV3TurboTextToImage
 from atlascloud_comfyui.nodes.image.luma_photon_t2i import AtlasLumaPhotonTextToImage
@@ -128,6 +138,10 @@ from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_t2v import AtlasSeedanc
 from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_i2v import AtlasSeedanceV1ProFastImageToVideo
 from atlascloud_comfyui.nodes.video.wan25_fast_t2v import AtlasWAN25TextToVideoFast
 from atlascloud_comfyui.nodes.video.wan25_fast_i2v import AtlasWAN25ImageToVideoFast
+from atlascloud_comfyui.nodes.video.wan22_animate_mix import AtlasWan22AnimateMix
+from atlascloud_comfyui.nodes.video.wan22_animate_move import AtlasWan22AnimateMove
+from atlascloud_comfyui.nodes.video.van25_t2v import AtlasAtlascloudVan25TextToVideo
+from atlascloud_comfyui.nodes.video.van25_i2v import AtlasAtlascloudVan25ImageToVideo
 from atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
 from atlascloud_comfyui.nodes.video.van26_i2v import AtlasVan26ImageToVideo
 from atlascloud_comfyui.nodes.video.vidu_reference_to_video_q1 import AtlasViduReferenceToVideoQ1
@@ -139,6 +153,7 @@ from atlascloud_comfyui.nodes.video.kling_v21_t2v_master import AtlasKlingV21T2V
 from atlascloud_comfyui.nodes.video.kling_v21_i2v_master import AtlasKlingV21I2VMaster
 from atlascloud_comfyui.nodes.video.kling_v21_i2v_pro_start_end_frame import AtlasKlingV21I2VProStartEndFrame
 from atlascloud_comfyui.nodes.video.kwaivgi_kling_v2_1_i2v_pro import AtlasKwaivgiKlingV21I2VPro
+from atlascloud_comfyui.nodes.video.kwaivgi_kling_v2_1_i2v_standard import AtlasKwaivgiKlingV21I2VStandard
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_pro import AtlasKlingV16MultiI2VPro
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_standard import AtlasKlingV16MultiI2VStandard
 from atlascloud_comfyui.nodes.video.kling_effects import AtlasKlingEffects
@@ -176,6 +191,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.5 Text-to-Video": AtlasWAN25TextToVideo,
     "AtlasCloud WAN2.6 Text-to-Video": AtlasWAN26TextToVideo,
     "AtlasCloud WAN2.6 Text-to-Image": AtlasWAN26TextToImage,
+    "AtlasCloud WAN2.5 Text-to-Image": AtlasWan25TextToImage,
     "AtlasCloud WAN2.6 Image-Edit": AtlasWAN26ImageEdit,
     "AtlasCloud WAN2.6 Image-to-Video": AtlasWAN26ImageToVideo,
     "AtlasCloud WAN2.6 Image-to-Video Flash": AtlasWAN26ImageToVideoFlash,
@@ -211,6 +227,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast": AtlasSeedanceV15ProTextToVideoFast,
     "AtlasCloud Seedance V1.5 Pro Image-to-Video": AtlasSeedanceV15ProImageToVideo,
     "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast": AtlasSeedanceV15ProImageToVideoFast,
+    "AtlasCloud Seedream V4 Text-to-Image": AtlasSeedreamV4TextToImage,
+    "AtlasCloud Seedream V4 Sequential Text-to-Image": AtlasSeedreamV4SequentialTextToImage,
+    "AtlasCloud Seedream V4 Edit": AtlasSeedreamV4Edit,
+    "AtlasCloud Seedream V4 Edit Sequential": AtlasSeedreamV4EditSequential,
     "AtlasCloud Seedream V4.5 Text-to-Image": AtlasSeedreamV45TextToImage,
     "AtlasCloud Seedream V4.5 Edit": AtlasSeedreamV45Edit,
     "AtlasCloud Seedream V4.5 Sequential Text-to-Image": AtlasSeedreamV45SequentialTextToImage,
@@ -219,6 +239,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud ZImage Turbo Text-to-Image": AtlasZImageTurboTextToImage,
     "AtlasCloud Nano Banana Pro Text-to-Image Ultra": AtlasNanoBananaProTextToImageUltra,
     "AtlasCloud Flux2 Flex Text-to-Image": AtlasFlux2FlexTextToImage,
+    "AtlasCloud Flux Dev Text-to-Image": AtlasFluxDevTextToImage,
+    "AtlasCloud Flux Dev LoRA Text-to-Image": AtlasFluxDevLoraTextToImage,
     "AtlasCloud Image Preview": AtlasImagePreviewURL,
     "AtlasCloud Video Preview": AtlasVideoPreviewer,
     "AtlasCloud Kling V3.0 Pro Text-to-Video": AtlasKlingV30ProTextToVideo,
@@ -268,6 +290,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.5 Image-to-Video": AtlasWAN25ImageToVideo,
     "AtlasCloud WAN2.2 Image-to-Video 720p": AtlasAlibabaWan22I2V720p,
     "AtlasCloud WAN2.2 Image-to-Video 480p": AtlasAlibabaWan22I2V480p,
+    "AtlasCloud WAN2.2 Animate Mix": AtlasWan22AnimateMix,
+    "AtlasCloud WAN2.2 Animate Move": AtlasWan22AnimateMove,
     "AtlasCloud Imagen4 Ultra Text-to-Image": AtlasImagen4UltraTextToImage,
     "AtlasCloud Imagen3 Text-to-Image": AtlasImagen3TextToImage,
     "AtlasCloud Ideogram V3 Quality Text-to-Image": AtlasIdeogramV3QualityTextToImage,
@@ -276,6 +300,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Luma Photon Flash Text-to-Image": AtlasLumaPhotonFlashTextToImage,
     "AtlasCloud Recraft V3 Text-to-Image": AtlasRecraftV3TextToImage,
     "AtlasCloud Qwen Image Edit": AtlasQwenImageEdit,
+    "AtlasCloud Qwen Image Text-to-Image (AtlasCloud)": AtlasAtlascloudQwenImageTextToImage,
+    "AtlasCloud Qwen Image Edit (Alibaba)": AtlasAlibabaQwenImageEdit,
+    "AtlasCloud Qwen Image Edit Plus (Alibaba)": AtlasAlibabaQwenImageEditPlus,
     "AtlasCloud Nano Banana Pro Text-to-Image": AtlasNanoBananaProTextToImage,
     "AtlasCloud Nano Banana Pro Edit": AtlasNanoBananaProEdit,
     "AtlasCloud Qwen Image Edit Plus 20251215": AtlasQwenImageEditPlus20251215,
@@ -291,6 +318,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Seedance V1 Lite Image-to-Video 480p": AtlasBytedanceSeedanceV1LiteI2V480p,
     "AtlasCloud WAN2.5 Text-to-Video Fast": AtlasWAN25TextToVideoFast,
     "AtlasCloud WAN2.5 Image-to-Video Fast": AtlasWAN25ImageToVideoFast,
+    "AtlasCloud Van-2.5 Text-to-Video": AtlasAtlascloudVan25TextToVideo,
+    "AtlasCloud Van-2.5 Image-to-Video": AtlasAtlascloudVan25ImageToVideo,
     "AtlasCloud Van-2.6 Text-to-Video": AtlasVan26TextToVideo,
     "AtlasCloud Van-2.6 Image-to-Video": AtlasVan26ImageToVideo,
     "AtlasCloud Vidu Reference-to-Video Q1": AtlasViduReferenceToVideoQ1,
@@ -302,6 +331,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Kling V2.1 I2V Master": AtlasKlingV21I2VMaster,
     "AtlasCloud Kling V2.1 I2V Pro (Start/End Frame)": AtlasKlingV21I2VProStartEndFrame,
     "AtlasCloud Kling V2.1 I2V Pro": AtlasKwaivgiKlingV21I2VPro,
+    "AtlasCloud Kling V2.1 I2V Standard": AtlasKwaivgiKlingV21I2VStandard,
     "AtlasCloud Kling V1.6 Multi I2V Pro": AtlasKlingV16MultiI2VPro,
     "AtlasCloud Kling V1.6 Multi I2V Standard": AtlasKlingV16MultiI2VStandard,
     "AtlasCloud Kling V1.6 T2V Standard": AtlasKwaivgiKlingV16T2VStandard,
@@ -365,6 +395,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast": "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast",
     "AtlasCloud Seedance V1.5 Pro Image-to-Video": "AtlasCloud Seedance V1.5 Pro Image-to-Video",
     "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast": "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast",
+    "AtlasCloud Seedream V4 Text-to-Image": "AtlasCloud Seedream V4 Text-to-Image",
+    "AtlasCloud Seedream V4 Sequential Text-to-Image": "AtlasCloud Seedream V4 Sequential Text-to-Image",
+    "AtlasCloud Seedream V4 Edit": "AtlasCloud Seedream V4 Edit",
+    "AtlasCloud Seedream V4 Edit Sequential": "AtlasCloud Seedream V4 Edit Sequential",
     "AtlasCloud Seedream V4.5 Text-to-Image": "AtlasCloud Seedream V4.5 Text-to-Image",
     "AtlasCloud Seedream V4.5 Edit": "AtlasCloud Seedream V4.5 Edit",
     "AtlasCloud Seedream V4.5 Sequential Text-to-Image": "AtlasCloud Seedream V4.5 Sequential Text-to-Image",
@@ -374,6 +408,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud ZImage Turbo Text-to-Image": "AtlasCloud ZImage Turbo Text-to-Image",
     "AtlasCloud Nano Banana Pro Text-to-Image Ultra": "AtlasCloud Nano Banana Pro Text-to-Image Ultra",
     "AtlasCloud Flux2 Flex Text-to-Image": "AtlasCloud Flux2 Flex Text-to-Image",
+    "AtlasCloud Flux Dev Text-to-Image": "AtlasCloud Flux Dev Text-to-Image",
+    "AtlasCloud Flux Dev LoRA Text-to-Image": "AtlasCloud Flux Dev LoRA Text-to-Image",
     "AtlasCloud Video Preview": "AtlasCloud Video Preview",
     "AtlasCloud Kling V3.0 Pro Text-to-Video": "AtlasCloud Kling V3.0 Pro Text-to-Video",
     "AtlasCloud Kling V3.0 Std Text-to-Video": "AtlasCloud Kling V3.0 Std Text-to-Video",
@@ -422,6 +458,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.5 Image-to-Video": "AtlasCloud WAN2.5 Image-to-Video",
     "AtlasCloud WAN2.2 Image-to-Video 720p": "AtlasCloud WAN2.2 Image-to-Video 720p",
     "AtlasCloud WAN2.2 Image-to-Video 480p": "AtlasCloud WAN2.2 Image-to-Video 480p",
+    "AtlasCloud WAN2.2 Animate Mix": "AtlasCloud WAN2.2 Animate Mix",
+    "AtlasCloud WAN2.2 Animate Move": "AtlasCloud WAN2.2 Animate Move",
     "AtlasCloud Imagen4 Ultra Text-to-Image": "AtlasCloud Imagen4 Ultra Text-to-Image",
     "AtlasCloud Imagen3 Text-to-Image": "AtlasCloud Imagen3 Text-to-Image",
     "AtlasCloud Ideogram V3 Quality Text-to-Image": "AtlasCloud Ideogram V3 Quality Text-to-Image",
@@ -430,6 +468,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Luma Photon Flash Text-to-Image": "AtlasCloud Luma Photon Flash Text-to-Image",
     "AtlasCloud Recraft V3 Text-to-Image": "AtlasCloud Recraft V3 Text-to-Image",
     "AtlasCloud Qwen Image Edit": "AtlasCloud Qwen Image Edit",
+    "AtlasCloud Qwen Image Text-to-Image (AtlasCloud)": "AtlasCloud Qwen Image Text-to-Image (AtlasCloud)",
+    "AtlasCloud Qwen Image Edit (Alibaba)": "AtlasCloud Qwen Image Edit (Alibaba)",
+    "AtlasCloud Qwen Image Edit Plus (Alibaba)": "AtlasCloud Qwen Image Edit Plus (Alibaba)",
     "AtlasCloud Nano Banana Pro Text-to-Image": "AtlasCloud Nano Banana Pro Text-to-Image",
     "AtlasCloud Nano Banana Pro Edit": "AtlasCloud Nano Banana Pro Edit",
     "AtlasCloud Qwen Image Edit Plus 20251215": "AtlasCloud Qwen Image Edit Plus 20251215",
@@ -443,8 +484,11 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedance V1 Pro Image-to-Video 480p": "AtlasCloud Seedance V1 Pro Image-to-Video 480p",
     "AtlasCloud Seedance V1 Lite Image-to-Video 720p": "AtlasCloud Seedance V1 Lite Image-to-Video 720p",
     "AtlasCloud Seedance V1 Lite Image-to-Video 480p": "AtlasCloud Seedance V1 Lite Image-to-Video 480p",
+    "AtlasCloud WAN2.5 Text-to-Image": "AtlasCloud WAN2.5 Text-to-Image",
     "AtlasCloud WAN2.5 Text-to-Video Fast": "AtlasCloud WAN2.5 Text-to-Video Fast",
     "AtlasCloud WAN2.5 Image-to-Video Fast": "AtlasCloud WAN2.5 Image-to-Video Fast",
+    "AtlasCloud Van-2.5 Text-to-Video": "AtlasCloud Van-2.5 Text-to-Video",
+    "AtlasCloud Van-2.5 Image-to-Video": "AtlasCloud Van-2.5 Image-to-Video",
     "AtlasCloud Van-2.6 Text-to-Video": "AtlasCloud Van-2.6 Text-to-Video",
     "AtlasCloud Van-2.6 Image-to-Video": "AtlasCloud Van-2.6 Image-to-Video",
     "AtlasCloud Vidu Reference-to-Video Q1": "AtlasCloud Vidu Reference-to-Video Q1",
@@ -456,6 +500,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Kling V2.1 I2V Master": "AtlasCloud Kling V2.1 I2V Master",
     "AtlasCloud Kling V2.1 I2V Pro (Start/End Frame)": "AtlasCloud Kling V2.1 I2V Pro (Start/End Frame)",
     "AtlasCloud Kling V2.1 I2V Pro": "AtlasCloud Kling V2.1 I2V Pro",
+    "AtlasCloud Kling V2.1 I2V Standard": "AtlasCloud Kling V2.1 I2V Standard",
     "AtlasCloud Kling V1.6 Multi I2V Pro": "AtlasCloud Kling V1.6 Multi I2V Pro",
     "AtlasCloud Kling V1.6 Multi I2V Standard": "AtlasCloud Kling V1.6 Multi I2V Standard",
     "AtlasCloud Kling V1.6 T2V Standard": "AtlasCloud Kling V1.6 T2V Standard",

--- a/tests/test_e2e_new_models_2026_03_07.py
+++ b/tests/test_e2e_new_models_2026_03_07.py
@@ -1,0 +1,131 @@
+"""End-to-end smoke tests for nodes added on 2026-03-07.
+
+Requires ATLASCLOUD_API_KEY environment variable.
+Run:
+  ATLASCLOUD_API_KEY=... PYTHONPATH=../ComfyUI pytest tests/test_e2e_new_models_2026_03_07.py -v -s
+
+Notes:
+- These tests are designed to be optional in CI (skip if no key).
+- Video models can be slow/queue; keep timeouts conservative.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+_HAS_KEY = bool(os.getenv("ATLASCLOUD_API_KEY", "").strip())
+skip_no_key = pytest.mark.skipif(not _HAS_KEY, reason="ATLASCLOUD_API_KEY not set")
+
+from atlascloud_comfyui.client.atlas_client import AtlasClient
+from atlascloud_comfyui.nodes.auth.atlas_client_node import AtlasClientHandle
+
+
+def make_client() -> AtlasClientHandle:
+    client = AtlasClient.from_env()
+    return AtlasClientHandle(client=client)
+
+
+_seedream_v4_image_url: str | None = None
+
+
+@skip_no_key
+def test_seedream_v4_t2i():
+    """Seedream V4 text-to-image should return a URL."""
+    global _seedream_v4_image_url
+
+    from atlascloud_comfyui.nodes.image.seedream_v4_t2i import AtlasSeedreamV4TextToImage
+
+    node = AtlasSeedreamV4TextToImage()
+    handle = make_client()
+
+    start = time.time()
+    image_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A product photo of a glass bottle on a white background",
+        size="2048*2048",
+        enable_base64_output=False,
+        poll_interval_sec=2.0,
+        timeout_sec=240,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  image_url:     {image_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert image_url
+    assert image_url.startswith("http") or image_url.startswith("data:"), image_url[:80]
+
+    _seedream_v4_image_url = image_url
+
+
+@skip_no_key
+def test_van25_i2v_uses_seedream_image():
+    """Van-2.5 image-to-video should work using the Seedream V4 image as input."""
+    from atlascloud_comfyui.nodes.video.van25_i2v import AtlasAtlascloudVan25ImageToVideo
+
+    image_url = _seedream_v4_image_url
+    if not image_url:
+        pytest.skip("No image available (test_seedream_v4_t2i must run first)")
+
+    node = AtlasAtlascloudVan25ImageToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="The bottle slowly rotates with soft studio lighting",
+        image=image_url,
+        resolution="720p",
+        duration=5,
+        enable_prompt_expansion=False,
+        seed=-1,
+        poll_interval_sec=3.0,
+        timeout_sec=600,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]
+
+
+@skip_no_key
+def test_wan25_t2i_smoke():
+    """WAN2.5 text-to-image should return a URL."""
+    from atlascloud_comfyui.nodes.image.wan25_t2i import AtlasWan25TextToImage
+
+    node = AtlasWan25TextToImage()
+    handle = make_client()
+
+    start = time.time()
+    image_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A minimalist icon of a camera on a pastel background",
+        size="1024*1024",
+        enable_prompt_expansion=False,
+        seed=-1,
+        poll_interval_sec=2.0,
+        timeout_sec=240,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  image_url:     {image_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert image_url
+    assert image_url.startswith("http") or image_url.startswith("data:"), image_url[:80]

--- a/tests/test_new_nodes_2026_03_07.py
+++ b/tests/test_new_nodes_2026_03_07.py
@@ -1,0 +1,162 @@
+"""Metadata-only tests for newly added nodes (2026-03-07).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_wan25_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.wan25_t2i import AtlasWan25TextToImage
+
+    required = AtlasWan25TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "size" in required
+    assert AtlasWan25TextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_atlascloud_qwen_image_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_t2i_atlascloud import AtlasAtlascloudQwenImageTextToImage
+
+    required = AtlasAtlascloudQwenImageTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "size" in required
+    assert AtlasAtlascloudQwenImageTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_alibaba_qwen_image_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_edit_alibaba import AtlasAlibabaQwenImageEdit
+
+    required = AtlasAlibabaQwenImageEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasAlibabaQwenImageEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_alibaba_qwen_image_edit_plus_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_edit_plus_alibaba import AtlasAlibabaQwenImageEditPlus
+
+    required = AtlasAlibabaQwenImageEditPlus.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert "size" in required
+    assert AtlasAlibabaQwenImageEditPlus.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v4_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v4_t2i import AtlasSeedreamV4TextToImage
+
+    required = AtlasSeedreamV4TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "size" in required
+    assert AtlasSeedreamV4TextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v4_sequential_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v4_sequential_t2i import AtlasSeedreamV4SequentialTextToImage
+
+    required = AtlasSeedreamV4SequentialTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "size" in required
+    assert AtlasSeedreamV4SequentialTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v4_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v4_edit import AtlasSeedreamV4Edit
+
+    required = AtlasSeedreamV4Edit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert "size" in required
+    assert AtlasSeedreamV4Edit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedream_v4_edit_sequential_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v4_edit_sequential import AtlasSeedreamV4EditSequential
+
+    required = AtlasSeedreamV4EditSequential.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert "size" in required
+    assert AtlasSeedreamV4EditSequential.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_flux_dev_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.flux_dev_t2i import AtlasFluxDevTextToImage
+
+    required = AtlasFluxDevTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert "size" in required
+    assert AtlasFluxDevTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_flux_dev_lora_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.flux_dev_lora_t2i import AtlasFluxDevLoraTextToImage
+
+    required = AtlasFluxDevLoraTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert "size" in required
+    assert AtlasFluxDevLoraTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_van25_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.van25_t2v import AtlasAtlascloudVan25TextToVideo
+
+    required = AtlasAtlascloudVan25TextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "size" in required
+    assert AtlasAtlascloudVan25TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_van25_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.van25_i2v import AtlasAtlascloudVan25ImageToVideo
+
+    required = AtlasAtlascloudVan25ImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert "resolution" in required
+    assert AtlasAtlascloudVan25ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan22_animate_mix_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan22_animate_mix import AtlasWan22AnimateMix
+
+    required = AtlasWan22AnimateMix.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "video" in required
+    assert "mode" in required
+    assert AtlasWan22AnimateMix.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan22_animate_move_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan22_animate_move import AtlasWan22AnimateMove
+
+    required = AtlasWan22AnimateMove.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "video" in required
+    assert "mode" in required
+    assert AtlasWan22AnimateMove.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v21_i2v_standard_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kwaivgi_kling_v2_1_i2v_standard import AtlasKwaivgiKlingV21I2VStandard
+
+    required = AtlasKwaivgiKlingV21I2VStandard.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert AtlasKwaivgiKlingV21I2VStandard.RETURN_TYPES == ("STRING", "STRING")


### PR DESCRIPTION
## Summary\nThis PR adds ComfyUI node support for newly discovered *visual* models from the AtlasCloud models API (2026-03-07 sync).\n\n### Added nodes (model id → file)\n- alibaba/wan-2.5/text-to-image → src/atlascloud_comfyui/nodes/image/wan25_t2i.py\n- atlascloud/qwen-image/text-to-image → src/atlascloud_comfyui/nodes/image/qwen_image_t2i_atlascloud.py\n- alibaba/qwen-image/edit → src/atlascloud_comfyui/nodes/image/qwen_image_edit_alibaba.py\n- alibaba/qwen-image/edit-plus → src/atlascloud_comfyui/nodes/image/qwen_image_edit_plus_alibaba.py\n- bytedance/seedream-v4 → src/atlascloud_comfyui/nodes/image/seedream_v4_t2i.py\n- bytedance/seedream-v4/sequential → src/atlascloud_comfyui/nodes/image/seedream_v4_sequential_t2i.py\n- bytedance/seedream-v4/edit → src/atlascloud_comfyui/nodes/image/seedream_v4_edit.py\n- bytedance/seedream-v4/edit-sequential → src/atlascloud_comfyui/nodes/image/seedream_v4_edit_sequential.py\n- black-forest-labs/flux-dev → src/atlascloud_comfyui/nodes/image/flux_dev_t2i.py\n- black-forest-labs/flux-dev-lora → src/atlascloud_comfyui/nodes/image/flux_dev_lora_t2i.py\n- atlascloud/van-2.5/text-to-video → src/atlascloud_comfyui/nodes/video/van25_t2v.py\n- atlascloud/van-2.5/image-to-video → src/atlascloud_comfyui/nodes/video/van25_i2v.py\n- kwaivgi/kling-v2.1-i2v-standard → src/atlascloud_comfyui/nodes/video/kwaivgi_kling_v2_1_i2v_standard.py\n- alibaba/wan-2.2/animate-mix → src/atlascloud_comfyui/nodes/video/wan22_animate_mix.py\n- alibaba/wan-2.2/animate-move → src/atlascloud_comfyui/nodes/video/wan22_animate_move.py\n\n## Updates\n- registry.py: imports + NODE_CLASS_MAPPINGS + NODE_DISPLAY_NAME_MAPPINGS\n- README: Available Nodes tables updated\n- tests: metadata-only tests + optional E2E tests for new models\n\n## Test\n- ruff check . (pass)\n- pytest tests/ (pass)\n- E2E baseline: pytest tests/test_e2e.py (pass, local)\n- E2E new models: pytest tests/test_e2e_new_models_2026_03_07.py (pass, local)\n\n## Notes\n- HOT/NEW fields are not reliably exposed in the API response; selection prioritized *visual* models missing from repo (tag-based priority is **待验证**).\n