### PR TITLE
feat: sync 13 new AtlasCloud model nodes (2026-03-08)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V1.6 Multi I2V Pro | kwaivgi/kling-v1.6-multi-i2v-pro |
 | AtlasCloud Kling V1.6 Multi I2V Standard | kwaivgi/kling-v1.6-multi-i2v-standard |
 | AtlasCloud Kling V1.6 I2V Pro | kwaivgi/kling-v1.6-i2v-pro |
+| AtlasCloud Kling V1.6 I2V Standard | kwaivgi/kling-v1.6-i2v-standard |
 | AtlasCloud Kling Effects | kwaivgi/kling-effects |
 | AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
@@ -166,6 +167,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud PixVerse V4.5 Image-to-Video | pixverse/pixverse-v4.5-i2v |
 | AtlasCloud Hailuo 02 I2V Pro | minimax/hailuo-02/i2v-pro |
 | AtlasCloud Hailuo 02 I2V Standard | minimax/hailuo-02/i2v-standard |
+| AtlasCloud Hailuo 02 Standard | minimax/hailuo-02/standard |
 | AtlasCloud Hailuo 2.3 I2V Standard | minimax/hailuo-2.3/i2v-standard |
 | AtlasCloud Hailuo 2.3 I2V Pro | minimax/hailuo-2.3/i2v-pro |
 | AtlasCloud Hailuo 2.3 Fast | minimax/hailuo-2.3/fast |
@@ -196,10 +198,14 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Imagen4 Fast Text-to-Image | google/imagen4-fast |
 | AtlasCloud Imagen4 Ultra Text-to-Image | google/imagen4-ultra |
 | AtlasCloud Imagen3 Text-to-Image | google/imagen3 |
+| AtlasCloud Imagen3 Fast Text-to-Image | google/imagen3-fast |
 | AtlasCloud Nano Banana 2 Text-to-Image | google/nano-banana-2/text-to-image |
 | AtlasCloud Nano Banana 2 Text-to-Image Developer | google/nano-banana-2/text-to-image-developer |
 | AtlasCloud Nano Banana Pro Text-to-Image Ultra | google/nano-banana-pro/text-to-image-ultra |
 | AtlasCloud Nano Banana Pro Text-to-Image | google/nano-banana-pro/text-to-image |
+| AtlasCloud Nano Banana Pro Text-to-Image Developer | google/nano-banana-pro/text-to-image-developer |
+| AtlasCloud Nano Banana Text-to-Image | google/nano-banana/text-to-image |
+| AtlasCloud Nano Banana Text-to-Image Developer | google/nano-banana/text-to-image-developer |
 | AtlasCloud Seedream V5.0 Lite Text-to-Image | bytedance/seedream-v5.0-lite |
 | AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image | bytedance/seedream-v5.0-lite/sequential |
 | AtlasCloud Seedream V4 Text-to-Image | bytedance/seedream-v4 |
@@ -215,6 +221,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Flux2 Flex Text-to-Image | flux2/flex |
 | AtlasCloud Flux Dev Text-to-Image | black-forest-labs/flux-dev |
 | AtlasCloud Flux Dev LoRA Text-to-Image | black-forest-labs/flux-dev-lora |
+| AtlasCloud Flux Schnell Text-to-Image | black-forest-labs/flux-schnell |
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
@@ -235,6 +242,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |
 | AtlasCloud Seedream V5.0 Lite Edit Sequential | bytedance/seedream-v5.0-lite/edit-sequential |
 | AtlasCloud WAN2.6 Image-Edit | alibaba/wan-2.6/image-edit |
+| AtlasCloud WAN2.5 Image-Edit | alibaba/wan-2.5/image-edit |
 | AtlasCloud Seedream V4 Edit | bytedance/seedream-v4/edit |
 | AtlasCloud Seedream V4 Edit Sequential | bytedance/seedream-v4/edit-sequential |
 | AtlasCloud Seedream V4.5 Edit | bytedance/seedream-v4.5/edit |
@@ -243,6 +251,11 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Qwen Image Edit (Alibaba) | alibaba/qwen-image/edit |
 | AtlasCloud Qwen Image Edit Plus (Alibaba) | alibaba/qwen-image/edit-plus |
 | AtlasCloud Nano Banana Pro Edit | google/nano-banana-pro/edit |
+| AtlasCloud Nano Banana Pro Edit Developer | google/nano-banana-pro/edit-developer |
+| AtlasCloud Nano Banana Edit | google/nano-banana/edit |
+| AtlasCloud Nano Banana Edit Developer | google/nano-banana/edit-developer |
+| AtlasCloud Flux Kontext Dev Edit | black-forest-labs/flux-kontext-dev |
+| AtlasCloud Flux Kontext Dev LoRA Edit | black-forest-labs/flux-kontext-dev-lora |
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
 
 > Nodes are continuously expanded as new models are added to AtlasCloud.

--- a/src/atlascloud_comfyui/nodes/image/flux_kontext_dev_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/flux_kontext_dev_edit.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasFluxKontextDevEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL/base64"}),
+                "size": ("STRING", {"default": "1024*1024", "tooltip": "Output size (WIDTH*HEIGHT)"}),
+            },
+            "optional": {
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images"}),
+                "num_inference_steps": ("INT", {"default": 28, "min": 1, "max": 50, "tooltip": "Inference steps"}),
+                "guidance_scale": ("FLOAT", {"default": 2.5, "min": 1.0, "max": 20.0, "tooltip": "Guidance scale"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "enable_safety_checker": ("BOOLEAN", {"default": True, "tooltip": "Enable safety checker"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        size: str,
+        num_images: int = 1,
+        num_inference_steps: int = 28,
+        guidance_scale: float = 2.5,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_safety_checker: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required (URL or base64)")
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-kontext-dev",
+            "prompt": p,
+            "image": img,
+            "size": str(size).strip(),
+            "num_images": int(num_images),
+            "num_inference_steps": int(num_inference_steps),
+            "guidance_scale": float(guidance_scale),
+            "seed": int(seed),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_safety_checker": bool(enable_safety_checker),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/flux_kontext_dev_lora_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/flux_kontext_dev_lora_edit.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasFluxKontextDevLoraEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL/base64"}),
+                "size": ("STRING", {"default": "1024*1024", "tooltip": "Output size (WIDTH*HEIGHT)"}),
+            },
+            "optional": {
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images"}),
+                "num_inference_steps": ("INT", {"default": 28, "min": 1, "max": 50, "tooltip": "Inference steps"}),
+                "guidance_scale": ("FLOAT", {"default": 2.5, "min": 0.0, "max": 20.0, "tooltip": "Guidance scale"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array for loras. Example: [{"path":"https://.../lora.safetensors","scale":1.0}]',
+                    },
+                ),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "If true, server may try to return result synchronously"}),
+                "output_format": (["png", "jpeg"], {"default": "png", "tooltip": "Output image format"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        size: str,
+        num_images: int = 1,
+        num_inference_steps: int = 28,
+        guidance_scale: float = 2.5,
+        seed: int = -1,
+        loras_json: str = "[]",
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        output_format: str = "png",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required (URL or base64)")
+
+        import json
+
+        try:
+            loras = json.loads(loras_json) if (loras_json or "").strip() else []
+            if not isinstance(loras, list):
+                raise ValueError("loras_json must be a JSON array")
+        except Exception as e:
+            raise RuntimeError(f"Invalid loras_json. Must be a JSON array. Error: {e}") from e
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-kontext-dev-lora",
+            "prompt": p,
+            "image": img,
+            "size": str(size).strip(),
+            "num_images": int(num_images),
+            "num_inference_steps": int(num_inference_steps),
+            "guidance_scale": float(guidance_scale),
+            "seed": int(seed),
+            "loras": loras,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "output_format": output_format,
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/flux_schnell_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/flux_schnell_t2i.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasFluxSchnellTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "size": ("STRING", {"default": "1024*1024", "tooltip": "Output size (WIDTH*HEIGHT)"}),
+            },
+            "optional": {
+                "image": ("STRING", {"default": "", "tooltip": "Optional input image URL/base64"}),
+                "mask_image": ("STRING", {"default": "", "tooltip": "Optional mask image URL/base64"}),
+                "strength": ("FLOAT", {"default": 0.8, "min": 0.0, "max": 1.0, "tooltip": "Strength (image transform)"}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "If true, server may try to return result synchronously"}),
+                "enable_safety_checker": ("BOOLEAN", {"default": True, "tooltip": "Enable safety checker"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        image: str = "",
+        strength: float = 0.8,
+        mask_image: str = "",
+        num_images: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        enable_safety_checker: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-schnell",
+            "prompt": p,
+            "size": str(size).strip(),
+            "num_images": int(num_images),
+            "seed": int(seed),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_safety_checker": bool(enable_safety_checker),
+        }
+
+        img = (image or "").strip()
+        if img:
+            payload["image"] = img
+            payload["strength"] = float(strength)
+
+            m = (mask_image or "").strip()
+            if m:
+                payload["mask_image"] = m
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/imagen3_fast_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/imagen3_fast_t2i.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasImagen3FastTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images"}),
+                "aspect_ratio": (
+                    ["1:1", "16:9", "9:16", "4:3", "3:4"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k"], {"default": "1k", "tooltip": "Resolution preset"}),
+                "enable_prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Enable prompt optimizer"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        negative_prompt: str = "",
+        seed: int = -1,
+        num_images: int = 1,
+        aspect_ratio: str = "1:1",
+        resolution: str = "1k",
+        enable_prompt_expansion: bool = False,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "google/imagen3-fast",
+            "prompt": p,
+            "num_images": int(num_images),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        if seed >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_edit.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBananaEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+            },
+            "optional": {
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "output_format": (
+                    ["png", "jpeg"],
+                    {"default": "png", "tooltip": "Output image format"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        aspect_ratio: str,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        output_format: str = "png",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana/edit",
+            "images": image_list,
+            "prompt": p,
+            "aspect_ratio": aspect_ratio,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "output_format": output_format,
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_edit_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_edit_dev.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBananaEditDeveloper:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+            },
+            "optional": {
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        aspect_ratio: str,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana/edit-developer",
+            "images": image_list,
+            "prompt": p,
+            "aspect_ratio": aspect_ratio,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_pro_edit_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_pro_edit_dev.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBananaProEditDeveloper:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+            },
+            "optional": {
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        aspect_ratio: str,
+        resolution: str,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-pro/edit-developer",
+            "images": image_list,
+            "prompt": p,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i_dev.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBananaProTextToImageDeveloper:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": ("STRING", {"default": "1k", "tooltip": "Resolution preset"}),
+            },
+            "optional": {
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        resolution: str,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-pro/text-to-image-developer",
+            "prompt": p,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_t2i.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBananaTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+            },
+            "optional": {
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "output_format": (
+                    ["png", "jpeg"],
+                    {"default": "png", "tooltip": "Output image format"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        output_format: str = "png",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana/text-to-image",
+            "prompt": p,
+            "aspect_ratio": aspect_ratio,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "output_format": output_format,
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_t2i_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_t2i_dev.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBananaTextToImageDeveloper:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+            },
+            "optional": {
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana/text-to-image-developer",
+            "prompt": p,
+            "aspect_ratio": aspect_ratio,
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/wan25_image_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/wan25_image_edit.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan25ImageEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        sizes = [
+            "576*1344",
+            "720*1280",
+            "720*1680",
+            "768*1024",
+            "800*1200",
+            "816*1904",
+            "936*1664",
+            "960*1280",
+            "960*1440",
+            "1024*768",
+            "1024*1024",
+            "1040*1560",
+            "1104*1472",
+            "1200*800",
+            "1280*720",
+            "1280*960",
+            "1280*1280",
+            "1344*576",
+            "1440*960",
+            "1472*1104",
+            "1560*1040",
+            "1664*936",
+            "1680*720",
+            "1904*816",
+        ]
+
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-3 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "size": (sizes, {"default": "1280*1280", "tooltip": "Output size (WIDTH*HEIGHT)"}),
+                "enable_prompt_expansion": ("BOOLEAN", {"default": False, "tooltip": "Enable prompt optimizer"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        negative_prompt: str = "",
+        seed: int = -1,
+        size: str = "1280*1280",
+        enable_prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-3 lines)")
+        if len(image_list) > 3:
+            raise RuntimeError("images maxItems is 3")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.5/image-edit",
+            "images": image_list,
+            "prompt": p,
+            "size": size,
+            "seed": int(seed),
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/hailuo_02_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/hailuo_02_i2v_standard.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHailuo02I2VStandard:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "First frame image URL/base64",
+                    },
+                ),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "tooltip": "Generate a description of the video.",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": ([6, 10], {"default": 6, "tooltip": "Duration (seconds)"}),
+                "enable_prompt_expansion": (
+                    "BOOLEAN",
+                    {
+                        "default": False,
+                        "tooltip": "Enable prompt optimizer",
+                    },
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {
+                        "default": 2.0,
+                        "min": 0.5,
+                        "max": 10.0,
+                        "tooltip": "Polling interval (seconds)",
+                    },
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {
+                        "default": 900,
+                        "min": 30,
+                        "max": 7200,
+                        "tooltip": "Timeout (seconds)",
+                    },
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        duration: int = 6,
+        enable_prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required (URL or base64)")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/hailuo-02/standard",
+            "image": img,
+            "prompt": p,
+            "duration": int(duration),
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v16_i2v_standard.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v16_i2v_standard.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV16I2VStandard:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "The positive prompt for the generation. max length 2500"}),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL/base64"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "duration": ([5, 10], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "guidance_scale": (
+                    "FLOAT",
+                    {"default": 7.5, "min": 0.0, "max": 20.0, "tooltip": "Guidance scale"},
+                ),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        negative_prompt: str = "",
+        duration: int = 5,
+        guidance_scale: float = 7.5,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required (URL or base64)")
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v1.6-i2v-standard",
+            "prompt": prompt,
+            "image": img,
+            "duration": int(duration),
+            "guidance_scale": float(guidance_scale),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -76,6 +76,7 @@ from atlascloud_comfyui.nodes.video.pika_v21_i2v import AtlasPikaV21ImageToVideo
 from atlascloud_comfyui.nodes.video.pixverse_v45_i2v import AtlasPixVerseV45ImageToVideo
 from atlascloud_comfyui.nodes.video.hailuo_02_i2v_pro import AtlasHailuo02I2VPro
 from atlascloud_comfyui.nodes.video.minimax_hailuo_02_i2v_standard import AtlasMinimaxHailuo02I2VStandard
+from atlascloud_comfyui.nodes.video.hailuo_02_i2v_standard import AtlasHailuo02I2VStandard
 from atlascloud_comfyui.nodes.video.sora2_i2v_pro import AtlasSora2ImageToVideoPro
 from atlascloud_comfyui.nodes.video.sora2_t2v import AtlasSora2TextToVideo
 from atlascloud_comfyui.nodes.video.kling_v25_turbo_pro_i2v import AtlasKlingV25TurboProImageToVideo
@@ -124,7 +125,18 @@ from atlascloud_comfyui.nodes.image.imagen4_t2i import AtlasImagen4TextToImage
 from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import AtlasImagen4FastTextToImage
 from atlascloud_comfyui.nodes.image.imagen4_ultra_t2i import AtlasImagen4UltraTextToImage
 from atlascloud_comfyui.nodes.image.imagen3_t2i import AtlasImagen3TextToImage
+from atlascloud_comfyui.nodes.image.imagen3_fast_t2i import AtlasImagen3FastTextToImage
 from atlascloud_comfyui.nodes.image.wan25_t2i import AtlasWan25TextToImage
+from atlascloud_comfyui.nodes.image.wan25_image_edit import AtlasWan25ImageEdit
+from atlascloud_comfyui.nodes.image.nano_banana_t2i import AtlasNanoBananaTextToImage
+from atlascloud_comfyui.nodes.image.nano_banana_t2i_dev import AtlasNanoBananaTextToImageDeveloper
+from atlascloud_comfyui.nodes.image.nano_banana_edit import AtlasNanoBananaEdit
+from atlascloud_comfyui.nodes.image.nano_banana_edit_dev import AtlasNanoBananaEditDeveloper
+from atlascloud_comfyui.nodes.image.nano_banana_pro_t2i_dev import AtlasNanoBananaProTextToImageDeveloper
+from atlascloud_comfyui.nodes.image.nano_banana_pro_edit_dev import AtlasNanoBananaProEditDeveloper
+from atlascloud_comfyui.nodes.image.flux_kontext_dev_edit import AtlasFluxKontextDevEdit
+from atlascloud_comfyui.nodes.image.flux_kontext_dev_lora_edit import AtlasFluxKontextDevLoraEdit
+from atlascloud_comfyui.nodes.image.flux_schnell_t2i import AtlasFluxSchnellTextToImage
 from atlascloud_comfyui.nodes.image.ideogram_v3_quality_t2i import AtlasIdeogramV3QualityTextToImage
 from atlascloud_comfyui.nodes.image.ideogram_v3_turbo_t2i import AtlasIdeogramV3TurboTextToImage
 from atlascloud_comfyui.nodes.image.luma_photon_t2i import AtlasLumaPhotonTextToImage
@@ -156,6 +168,7 @@ from atlascloud_comfyui.nodes.video.kwaivgi_kling_v2_1_i2v_pro import AtlasKwaiv
 from atlascloud_comfyui.nodes.video.kwaivgi_kling_v2_1_i2v_standard import AtlasKwaivgiKlingV21I2VStandard
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_pro import AtlasKlingV16MultiI2VPro
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_standard import AtlasKlingV16MultiI2VStandard
+from atlascloud_comfyui.nodes.video.kling_v16_i2v_standard import AtlasKlingV16I2VStandard
 from atlascloud_comfyui.nodes.video.kling_effects import AtlasKlingEffects
 from atlascloud_comfyui.nodes.video.kwaivgi_kling_v1_6_t2v_standard import AtlasKwaivgiKlingV16T2VStandard
 from atlascloud_comfyui.nodes.video.kwaivgi_kling_v1_6_i2v_pro import AtlasKwaivgiKlingV16I2VPro
@@ -192,6 +205,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.6 Text-to-Video": AtlasWAN26TextToVideo,
     "AtlasCloud WAN2.6 Text-to-Image": AtlasWAN26TextToImage,
     "AtlasCloud WAN2.5 Text-to-Image": AtlasWan25TextToImage,
+    "AtlasCloud WAN2.5 Image-Edit": AtlasWan25ImageEdit,
     "AtlasCloud WAN2.6 Image-Edit": AtlasWAN26ImageEdit,
     "AtlasCloud WAN2.6 Image-to-Video": AtlasWAN26ImageToVideo,
     "AtlasCloud WAN2.6 Image-to-Video Flash": AtlasWAN26ImageToVideoFlash,
@@ -241,6 +255,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Flux2 Flex Text-to-Image": AtlasFlux2FlexTextToImage,
     "AtlasCloud Flux Dev Text-to-Image": AtlasFluxDevTextToImage,
     "AtlasCloud Flux Dev LoRA Text-to-Image": AtlasFluxDevLoraTextToImage,
+    "AtlasCloud Flux Schnell Text-to-Image": AtlasFluxSchnellTextToImage,
+    "AtlasCloud Flux Kontext Dev Edit": AtlasFluxKontextDevEdit,
+    "AtlasCloud Flux Kontext Dev LoRA Edit": AtlasFluxKontextDevLoraEdit,
     "AtlasCloud Image Preview": AtlasImagePreviewURL,
     "AtlasCloud Video Preview": AtlasVideoPreviewer,
     "AtlasCloud Kling V3.0 Pro Text-to-Video": AtlasKlingV30ProTextToVideo,
@@ -283,6 +300,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud PixVerse V4.5 Image-to-Video": AtlasPixVerseV45ImageToVideo,
     "AtlasCloud Hailuo 02 I2V Pro": AtlasHailuo02I2VPro,
     "AtlasCloud Hailuo 02 I2V Standard": AtlasMinimaxHailuo02I2VStandard,
+    "AtlasCloud Hailuo 02 Standard": AtlasHailuo02I2VStandard,
     "AtlasCloud Sora 2 Image-to-Video Pro": AtlasSora2ImageToVideoPro,
     "AtlasCloud Sora 2 Text-to-Video": AtlasSora2TextToVideo,
     "AtlasCloud Kling V2.5 Turbo Pro Image-to-Video": AtlasKlingV25TurboProImageToVideo,
@@ -294,6 +312,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.2 Animate Move": AtlasWan22AnimateMove,
     "AtlasCloud Imagen4 Ultra Text-to-Image": AtlasImagen4UltraTextToImage,
     "AtlasCloud Imagen3 Text-to-Image": AtlasImagen3TextToImage,
+    "AtlasCloud Imagen3 Fast Text-to-Image": AtlasImagen3FastTextToImage,
     "AtlasCloud Ideogram V3 Quality Text-to-Image": AtlasIdeogramV3QualityTextToImage,
     "AtlasCloud Ideogram V3 Turbo Text-to-Image": AtlasIdeogramV3TurboTextToImage,
     "AtlasCloud Luma Photon Text-to-Image": AtlasLumaPhotonTextToImage,
@@ -304,7 +323,13 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Qwen Image Edit (Alibaba)": AtlasAlibabaQwenImageEdit,
     "AtlasCloud Qwen Image Edit Plus (Alibaba)": AtlasAlibabaQwenImageEditPlus,
     "AtlasCloud Nano Banana Pro Text-to-Image": AtlasNanoBananaProTextToImage,
+    "AtlasCloud Nano Banana Pro Text-to-Image Developer": AtlasNanoBananaProTextToImageDeveloper,
     "AtlasCloud Nano Banana Pro Edit": AtlasNanoBananaProEdit,
+    "AtlasCloud Nano Banana Pro Edit Developer": AtlasNanoBananaProEditDeveloper,
+    "AtlasCloud Nano Banana Text-to-Image": AtlasNanoBananaTextToImage,
+    "AtlasCloud Nano Banana Text-to-Image Developer": AtlasNanoBananaTextToImageDeveloper,
+    "AtlasCloud Nano Banana Edit": AtlasNanoBananaEdit,
+    "AtlasCloud Nano Banana Edit Developer": AtlasNanoBananaEditDeveloper,
     "AtlasCloud Qwen Image Edit Plus 20251215": AtlasQwenImageEditPlus20251215,
     "AtlasCloud Qwen Image Text-to-Image Plus": AtlasQwenImageTextToImagePlus,
     "AtlasCloud Qwen Image Text-to-Image Max": AtlasQwenImageTextToImageMax,
@@ -334,6 +359,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Kling V2.1 I2V Standard": AtlasKwaivgiKlingV21I2VStandard,
     "AtlasCloud Kling V1.6 Multi I2V Pro": AtlasKlingV16MultiI2VPro,
     "AtlasCloud Kling V1.6 Multi I2V Standard": AtlasKlingV16MultiI2VStandard,
+    "AtlasCloud Kling V1.6 I2V Standard": AtlasKlingV16I2VStandard,
     "AtlasCloud Kling V1.6 T2V Standard": AtlasKwaivgiKlingV16T2VStandard,
     "AtlasCloud Kling V1.6 I2V Pro": AtlasKwaivgiKlingV16I2VPro,
     "AtlasCloud Kling Effects": AtlasKlingEffects,
@@ -360,6 +386,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.5 Text-to-Video": "AtlasCloud WAN2.5 Text-to-Video",
     "AtlasCloud WAN2.6 Text-to-Video": "AtlasCloud WAN2.6 Text-to-Video",
     "AtlasCloud WAN2.6 Text-to-Image": "AtlasCloud WAN2.6 Text-to-Image",
+    "AtlasCloud WAN2.5 Text-to-Image": "AtlasCloud WAN2.5 Text-to-Image",
+    "AtlasCloud WAN2.5 Image-Edit": "AtlasCloud WAN2.5 Image-Edit",
     "AtlasCloud WAN2.6 Image-Edit": "AtlasCloud WAN2.6 Image-Edit",
     "AtlasCloud WAN2.6 Image-to-Video": "AtlasCloud WAN2.6 Image-to-Video",
     "AtlasCloud WAN2.6 Image-to-Video Flash": "AtlasCloud WAN2.6 Image-to-Video Flash",
@@ -410,6 +438,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Flux2 Flex Text-to-Image": "AtlasCloud Flux2 Flex Text-to-Image",
     "AtlasCloud Flux Dev Text-to-Image": "AtlasCloud Flux Dev Text-to-Image",
     "AtlasCloud Flux Dev LoRA Text-to-Image": "AtlasCloud Flux Dev LoRA Text-to-Image",
+    "AtlasCloud Flux Schnell Text-to-Image": "AtlasCloud Flux Schnell Text-to-Image",
+    "AtlasCloud Flux Kontext Dev Edit": "AtlasCloud Flux Kontext Dev Edit",
+    "AtlasCloud Flux Kontext Dev LoRA Edit": "AtlasCloud Flux Kontext Dev LoRA Edit",
     "AtlasCloud Video Preview": "AtlasCloud Video Preview",
     "AtlasCloud Kling V3.0 Pro Text-to-Video": "AtlasCloud Kling V3.0 Pro Text-to-Video",
     "AtlasCloud Kling V3.0 Std Text-to-Video": "AtlasCloud Kling V3.0 Std Text-to-Video",
@@ -451,6 +482,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud PixVerse V4.5 Image-to-Video": "AtlasCloud PixVerse V4.5 Image-to-Video",
     "AtlasCloud Hailuo 02 I2V Pro": "AtlasCloud Hailuo 02 I2V Pro",
     "AtlasCloud Hailuo 02 I2V Standard": "AtlasCloud Hailuo 02 I2V Standard",
+    "AtlasCloud Hailuo 02 Standard": "AtlasCloud Hailuo 02 Standard",
     "AtlasCloud Sora 2 Image-to-Video Pro": "AtlasCloud Sora 2 Image-to-Video Pro",
     "AtlasCloud Sora 2 Text-to-Video": "AtlasCloud Sora 2 Text-to-Video",
     "AtlasCloud Kling V2.5 Turbo Pro Image-to-Video": "AtlasCloud Kling V2.5 Turbo Pro Image-to-Video",
@@ -462,6 +494,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.2 Animate Move": "AtlasCloud WAN2.2 Animate Move",
     "AtlasCloud Imagen4 Ultra Text-to-Image": "AtlasCloud Imagen4 Ultra Text-to-Image",
     "AtlasCloud Imagen3 Text-to-Image": "AtlasCloud Imagen3 Text-to-Image",
+    "AtlasCloud Imagen3 Fast Text-to-Image": "AtlasCloud Imagen3 Fast Text-to-Image",
     "AtlasCloud Ideogram V3 Quality Text-to-Image": "AtlasCloud Ideogram V3 Quality Text-to-Image",
     "AtlasCloud Ideogram V3 Turbo Text-to-Image": "AtlasCloud Ideogram V3 Turbo Text-to-Image",
     "AtlasCloud Luma Photon Text-to-Image": "AtlasCloud Luma Photon Text-to-Image",
@@ -472,7 +505,13 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Qwen Image Edit (Alibaba)": "AtlasCloud Qwen Image Edit (Alibaba)",
     "AtlasCloud Qwen Image Edit Plus (Alibaba)": "AtlasCloud Qwen Image Edit Plus (Alibaba)",
     "AtlasCloud Nano Banana Pro Text-to-Image": "AtlasCloud Nano Banana Pro Text-to-Image",
+    "AtlasCloud Nano Banana Pro Text-to-Image Developer": "AtlasCloud Nano Banana Pro Text-to-Image Developer",
     "AtlasCloud Nano Banana Pro Edit": "AtlasCloud Nano Banana Pro Edit",
+    "AtlasCloud Nano Banana Pro Edit Developer": "AtlasCloud Nano Banana Pro Edit Developer",
+    "AtlasCloud Nano Banana Text-to-Image": "AtlasCloud Nano Banana Text-to-Image",
+    "AtlasCloud Nano Banana Text-to-Image Developer": "AtlasCloud Nano Banana Text-to-Image Developer",
+    "AtlasCloud Nano Banana Edit": "AtlasCloud Nano Banana Edit",
+    "AtlasCloud Nano Banana Edit Developer": "AtlasCloud Nano Banana Edit Developer",
     "AtlasCloud Qwen Image Edit Plus 20251215": "AtlasCloud Qwen Image Edit Plus 20251215",
     "AtlasCloud Qwen Image Text-to-Image Plus": "AtlasCloud Qwen Image Text-to-Image Plus",
     "AtlasCloud Qwen Image Text-to-Image Max": "AtlasCloud Qwen Image Text-to-Image Max",
@@ -484,7 +523,6 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedance V1 Pro Image-to-Video 480p": "AtlasCloud Seedance V1 Pro Image-to-Video 480p",
     "AtlasCloud Seedance V1 Lite Image-to-Video 720p": "AtlasCloud Seedance V1 Lite Image-to-Video 720p",
     "AtlasCloud Seedance V1 Lite Image-to-Video 480p": "AtlasCloud Seedance V1 Lite Image-to-Video 480p",
-    "AtlasCloud WAN2.5 Text-to-Image": "AtlasCloud WAN2.5 Text-to-Image",
     "AtlasCloud WAN2.5 Text-to-Video Fast": "AtlasCloud WAN2.5 Text-to-Video Fast",
     "AtlasCloud WAN2.5 Image-to-Video Fast": "AtlasCloud WAN2.5 Image-to-Video Fast",
     "AtlasCloud Van-2.5 Text-to-Video": "AtlasCloud Van-2.5 Text-to-Video",
@@ -503,6 +541,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Kling V2.1 I2V Standard": "AtlasCloud Kling V2.1 I2V Standard",
     "AtlasCloud Kling V1.6 Multi I2V Pro": "AtlasCloud Kling V1.6 Multi I2V Pro",
     "AtlasCloud Kling V1.6 Multi I2V Standard": "AtlasCloud Kling V1.6 Multi I2V Standard",
+    "AtlasCloud Kling V1.6 I2V Standard": "AtlasCloud Kling V1.6 I2V Standard",
     "AtlasCloud Kling V1.6 T2V Standard": "AtlasCloud Kling V1.6 T2V Standard",
     "AtlasCloud Kling V1.6 I2V Pro": "AtlasCloud Kling V1.6 I2V Pro",
     "AtlasCloud Kling Effects": "AtlasCloud Kling Effects",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -376,6 +376,107 @@ def test_recraft_v3_t2i_node_metadata():
 # --- Batch 4: 2026-03-05 sync ---
 
 
+def test_imagen3_fast_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.imagen3_fast_t2i import AtlasImagen3FastTextToImage
+
+    assert "atlas_client" in AtlasImagen3FastTextToImage.INPUT_TYPES()["required"]
+    assert AtlasImagen3FastTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasImagen3FastTextToImage.RETURN_NAMES
+
+
+def test_nano_banana_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana_t2i import AtlasNanoBananaTextToImage
+
+    assert "atlas_client" in AtlasNanoBananaTextToImage.INPUT_TYPES()["required"]
+    assert AtlasNanoBananaTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasNanoBananaTextToImage.RETURN_NAMES
+
+
+def test_nano_banana_t2i_dev_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana_t2i_dev import AtlasNanoBananaTextToImageDeveloper
+
+    assert "atlas_client" in AtlasNanoBananaTextToImageDeveloper.INPUT_TYPES()["required"]
+    assert AtlasNanoBananaTextToImageDeveloper.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_nano_banana_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana_edit import AtlasNanoBananaEdit
+
+    assert "atlas_client" in AtlasNanoBananaEdit.INPUT_TYPES()["required"]
+    assert "images" in AtlasNanoBananaEdit.INPUT_TYPES()["required"]
+    assert AtlasNanoBananaEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_nano_banana_edit_dev_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana_edit_dev import AtlasNanoBananaEditDeveloper
+
+    assert "atlas_client" in AtlasNanoBananaEditDeveloper.INPUT_TYPES()["required"]
+    assert "images" in AtlasNanoBananaEditDeveloper.INPUT_TYPES()["required"]
+    assert AtlasNanoBananaEditDeveloper.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_nano_banana_pro_t2i_dev_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana_pro_t2i_dev import AtlasNanoBananaProTextToImageDeveloper
+
+    assert "atlas_client" in AtlasNanoBananaProTextToImageDeveloper.INPUT_TYPES()["required"]
+    assert AtlasNanoBananaProTextToImageDeveloper.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_nano_banana_pro_edit_dev_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana_pro_edit_dev import AtlasNanoBananaProEditDeveloper
+
+    assert "atlas_client" in AtlasNanoBananaProEditDeveloper.INPUT_TYPES()["required"]
+    assert "images" in AtlasNanoBananaProEditDeveloper.INPUT_TYPES()["required"]
+    assert AtlasNanoBananaProEditDeveloper.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_flux_schnell_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.flux_schnell_t2i import AtlasFluxSchnellTextToImage
+
+    assert "atlas_client" in AtlasFluxSchnellTextToImage.INPUT_TYPES()["required"]
+    assert AtlasFluxSchnellTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_flux_kontext_dev_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.flux_kontext_dev_edit import AtlasFluxKontextDevEdit
+
+    assert "atlas_client" in AtlasFluxKontextDevEdit.INPUT_TYPES()["required"]
+    assert "image" in AtlasFluxKontextDevEdit.INPUT_TYPES()["required"]
+    assert AtlasFluxKontextDevEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_flux_kontext_dev_lora_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.flux_kontext_dev_lora_edit import AtlasFluxKontextDevLoraEdit
+
+    assert "atlas_client" in AtlasFluxKontextDevLoraEdit.INPUT_TYPES()["required"]
+    assert "image" in AtlasFluxKontextDevLoraEdit.INPUT_TYPES()["required"]
+    assert AtlasFluxKontextDevLoraEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan25_image_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.wan25_image_edit import AtlasWan25ImageEdit
+
+    assert "atlas_client" in AtlasWan25ImageEdit.INPUT_TYPES()["required"]
+    assert "images" in AtlasWan25ImageEdit.INPUT_TYPES()["required"]
+    assert AtlasWan25ImageEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_kling_v16_i2v_standard_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v16_i2v_standard import AtlasKlingV16I2VStandard
+
+    assert "atlas_client" in AtlasKlingV16I2VStandard.INPUT_TYPES()["required"]
+    assert "image" in AtlasKlingV16I2VStandard.INPUT_TYPES()["required"]
+    assert AtlasKlingV16I2VStandard.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_hailuo_02_standard_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.hailuo_02_i2v_standard import AtlasHailuo02I2VStandard
+
+    assert "atlas_client" in AtlasHailuo02I2VStandard.INPUT_TYPES()["required"]
+    assert "image" in AtlasHailuo02I2VStandard.INPUT_TYPES()["required"]
+    assert AtlasHailuo02I2VStandard.RETURN_TYPES == ("STRING", "STRING")
+
+
 def test_qwen_image_t2i_plus_node_metadata():
     from src.atlascloud_comfyui.nodes.image.qwen_image_t2i_plus import AtlasQwenImageTextToImagePlus
 


### PR DESCRIPTION
## Summary
This PR syncs missing *visual* models from the AtlasCloud Models API into ComfyUI node support.

### Added nodes (13)
- Image
  - AtlasCloud Imagen3 Fast Text-to-Image → google/imagen3-fast
  - AtlasCloud Nano Banana Text-to-Image → google/nano-banana/text-to-image
  - AtlasCloud Nano Banana Text-to-Image Developer → google/nano-banana/text-to-image-developer
  - AtlasCloud Nano Banana Edit → google/nano-banana/edit
  - AtlasCloud Nano Banana Edit Developer → google/nano-banana/edit-developer
  - AtlasCloud Nano Banana Pro Text-to-Image Developer → google/nano-banana-pro/text-to-image-developer
  - AtlasCloud Nano Banana Pro Edit Developer → google/nano-banana-pro/edit-developer
  - AtlasCloud WAN2.5 Image-Edit → alibaba/wan-2.5/image-edit
  - AtlasCloud Flux Schnell Text-to-Image → black-forest-labs/flux-schnell
  - AtlasCloud Flux Kontext Dev Edit → black-forest-labs/flux-kontext-dev
  - AtlasCloud Flux Kontext Dev LoRA Edit → black-forest-labs/flux-kontext-dev-lora
- Video
  - AtlasCloud Kling V1.6 I2V Standard → kwaivgi/kling-v1.6-i2v-standard
  - AtlasCloud Hailuo 02 Standard → minimax/hailuo-02/standard

## Why
These models were present in `GET https://api.atlascloud.ai/api/v1/models` but did not have node support in this repo.

## Test plan
- [x] `ruff check .`
- [x] `pytest tests/ -v`
- [x] `PYTHONPATH=../ComfyUI ATLASCLOUD_API_KEY=... pytest tests/test_e2e.py -v -s`
- [x] `PYTHONPATH=../ComfyUI ATLASCLOUD_API_KEY=... pytest tests/test_e2e_new_models.py -v -s`

🤖 Generated with OpenClaw
