### PR TITLE
chore: deprecate legacy model nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 
 ## Available Nodes
 
+> Note: Some nodes are kept for **backward compatibility** even if their model id is no longer returned by AtlasCloud `/api/v1/models`. These nodes are marked as **Deprecated** and will raise an error at runtime unless you set `ATLAS_ALLOW_DEPRECATED_MODELS=1`.
+
 ### Common
 
 -   **AtlasCloud Client** — Stores your API key and base URL for all AtlasCloud nodes.
@@ -314,3 +316,33 @@ Please include:
 ## License
 
 [MIT](https://choosealicense.com/licenses/mit/)
+
+## Deprecated / Legacy Models
+These model ids are **not returned by AtlasCloud `/api/v1/models`** at the time of this release.
+They are kept in this repo so older ComfyUI workflows can still load, but they are considered **deprecated**.
+To force execution anyway (at your own risk), set `ATLAS_ALLOW_DEPRECATED_MODELS=1` in your environment before launching ComfyUI.
+
+| Model id | Status |
+|---|---|
+| `atlascloud/hunyuan-video/i2v` | Deprecated (not in `/api/v1/models`) |
+| `atlascloud/hunyuan-video/t2v` | Deprecated (not in `/api/v1/models`) |
+| `black-forest-labs/flux-2-flex/text-to-image` | Deprecated (not in `/api/v1/models`) |
+| `google/nano-banana-pro/text-to-image-ultra` | Deprecated (not in `/api/v1/models`) |
+| `ideogram-ai/ideogram-v3-quality` | Deprecated (not in `/api/v1/models`) |
+| `ideogram-ai/ideogram-v3-turbo` | Deprecated (not in `/api/v1/models`) |
+| `luma/photon` | Deprecated (not in `/api/v1/models`) |
+| `luma/photon-flash` | Deprecated (not in `/api/v1/models`) |
+| `luma/ray-2-flash-t2v` | Deprecated (not in `/api/v1/models`) |
+| `luma/ray-2-i2v` | Deprecated (not in `/api/v1/models`) |
+| `luma/ray-2-t2v` | Deprecated (not in `/api/v1/models`) |
+| `openai/sora-2/image-to-video` | Deprecated (not in `/api/v1/models`) |
+| `openai/sora-2/image-to-video-pro` | Deprecated (not in `/api/v1/models`) |
+| `openai/sora-2/text-to-video` | Deprecated (not in `/api/v1/models`) |
+| `openai/sora-2/text-to-video-pro` | Deprecated (not in `/api/v1/models`) |
+| `pika/v2.0-turbo-t2v` | Deprecated (not in `/api/v1/models`) |
+| `pika/v2.1-i2v` | Deprecated (not in `/api/v1/models`) |
+| `pika/v2.2-t2v` | Deprecated (not in `/api/v1/models`) |
+| `pixverse/pixverse-v4.5-i2v` | Deprecated (not in `/api/v1/models`) |
+| `pixverse/pixverse-v4.5-t2v` | Deprecated (not in `/api/v1/models`) |
+| `recraft-ai/recraft-v3` | Deprecated (not in `/api/v1/models`) |
+| `z-image/turbo-lora` | Deprecated (not in `/api/v1/models`) |

--- a/src/atlascloud_comfyui/nodes/image/flux2_flex_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/flux2_flex_t2i.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -42,6 +49,13 @@ class AtlasFlux2FlexTextToImage:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: black-forest-labs/flux-2-flex/text-to-image. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
         size = f"{width}*{height}"
 

--- a/src/atlascloud_comfyui/nodes/image/ideogram_v3_quality_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/ideogram_v3_quality_t2i.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -43,6 +50,13 @@ class AtlasIdeogramV3QualityTextToImage:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: ideogram-ai/ideogram-v3-quality. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/image/ideogram_v3_turbo_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/ideogram_v3_turbo_t2i.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -43,6 +50,13 @@ class AtlasIdeogramV3TurboTextToImage:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: ideogram-ai/ideogram-v3-turbo. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/image/luma_photon_flash_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/luma_photon_flash_t2i.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -33,6 +40,13 @@ class AtlasLumaPhotonFlashTextToImage:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: luma/photon-flash. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/image/luma_photon_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/luma_photon_t2i.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -33,6 +40,13 @@ class AtlasLumaPhotonTextToImage:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: luma/photon. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i_ultra.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i_ultra.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -46,6 +53,13 @@ class AtlasNanoBananaProTextToImageUltra:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: google/nano-banana-pro/text-to-image-ultra. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/image/recraft_v3_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/recraft_v3_t2i.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -61,6 +68,13 @@ class AtlasRecraftV3TextToImage:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: recraft-ai/recraft-v3. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/image/zimage_turbo_lora_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/zimage_turbo_lora_t2i.py
@@ -1,3 +1,10 @@
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 class AtlasZImageTurboLoraTextToImage:
     CATEGORY = "AtlasCloud/Image"
     FUNCTION = "run"
@@ -39,6 +46,13 @@ class AtlasZImageTurboLoraTextToImage:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ):
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: z-image/turbo-lora. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         import json
 
         client = atlas_client.client

--- a/src/atlascloud_comfyui/nodes/video/hunyuan_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/hunyuan_i2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -43,6 +50,13 @@ class AtlasHunyuanImageToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: atlascloud/hunyuan-video/i2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/hunyuan_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/hunyuan_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -39,6 +46,13 @@ class AtlasHunyuanTextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: atlascloud/hunyuan-video/t2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/luma_ray2_flash_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/luma_ray2_flash_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -35,6 +42,13 @@ class AtlasLumaRay2FlashTextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: luma/ray-2-flash-t2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/luma_ray2_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/luma_ray2_i2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -37,6 +44,13 @@ class AtlasLumaRay2ImageToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: luma/ray-2-i2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/luma_ray2_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/luma_ray2_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -35,6 +42,13 @@ class AtlasLumaRay2TextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: luma/ray-2-t2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/pika_v20_turbo_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/pika_v20_turbo_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -35,6 +42,13 @@ class AtlasPikaV20TurboTextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: pika/v2.0-turbo-t2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/pika_v21_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/pika_v21_i2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -37,6 +44,13 @@ class AtlasPikaV21ImageToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: pika/v2.1-i2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/pika_v22_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/pika_v22_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -35,6 +42,13 @@ class AtlasPikaV22TextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: pika/v2.2-t2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/pixverse_v45_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/pixverse_v45_i2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -41,6 +48,13 @@ class AtlasPixVerseV45ImageToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: pixverse/pixverse-v4.5-i2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/pixverse_v45_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/pixverse_v45_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -39,6 +46,13 @@ class AtlasPixVerseV45TextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: pixverse/pixverse-v4.5-t2v. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/sora2_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/sora2_i2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -35,6 +42,13 @@ class AtlasSora2ImageToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: openai/sora-2/image-to-video. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/sora2_i2v_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/sora2_i2v_pro.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -35,6 +42,13 @@ class AtlasSora2ImageToVideoPro:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: openai/sora-2/image-to-video-pro. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/sora2_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/sora2_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -33,6 +40,13 @@ class AtlasSora2TextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: openai/sora-2/text-to-video. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/sora2_t2v_pro.py
+++ b/src/atlascloud_comfyui/nodes/video/sora2_t2v_pro.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -35,6 +42,13 @@ class AtlasSora2TextToVideoPro:
         timeout_sec: int = 900,
         poll_interval_sec: float = 2.0,
     ) -> Tuple[str]:
+        # Deprecated model guard
+        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
+            raise RuntimeError(
+                "Deprecated model id: openai/sora-2/text-to-video-pro. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         prompt = (prompt or "").strip()
         if not prompt:
             raise RuntimeError("prompt is required")


### PR DESCRIPTION
This PR marks 22 nodes whose model ids are no longer returned by AtlasCloud /api/v1/models as deprecated (kept for backward compatibility).

Changes:
- Add DEPRECATED_MODEL_ID + DEPRECATION_REASON headers to each legacy node.
- Add runtime guard in node.run(): raises with clear error unless ATLAS_ALLOW_DEPRECATED_MODELS=1.
- Document all legacy model ids in README under 'Deprecated / Legacy Models'.

Legacy model ids (not returned by /api/v1/models at time of change):
- atlascloud/hunyuan-video/i2v
- atlascloud/hunyuan-video/t2v
- black-forest-labs/flux-2-flex/text-to-image
- google/nano-banana-pro/text-to-image-ultra
- ideogram-ai/ideogram-v3-quality
- ideogram-ai/ideogram-v3-turbo
- luma/photon
- luma/photon-flash
- luma/ray-2-flash-t2v
- luma/ray-2-i2v
- luma/ray-2-t2v
- openai/sora-2/image-to-video
- openai/sora-2/image-to-video-pro
- openai/sora-2/text-to-video
- openai/sora-2/text-to-video-pro
- pika/v2.0-turbo-t2v
- pika/v2.1-i2v
- pika/v2.2-t2v
- pixverse/pixverse-v4.5-i2v
- pixverse/pixverse-v4.5-t2v
- recraft-ai/recraft-v3
- z-image/turbo-lora

Tests:
- ruff check . (pass)
- pytest -k 'not e2e' (pass)