### PR TITLE
feat: sync new AtlasCloud visual models (2026-03-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,12 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedance V1.5 Pro Image-to-Video Fast | bytedance/seedance-v1.5-pro/image-to-video-fast |
 | AtlasCloud Kling V2.5 Turbo Pro Image-to-Video | kwaivgi/kling-v2.5-turbo-pro/image-to-video |
 | AtlasCloud Vidu Q3 Text-to-Video | vidu/q3/text-to-video |
+| AtlasCloud Vidu Q3-Pro Text-to-Video | vidu/q3-pro/text-to-video |
 | AtlasCloud Vidu Q3 Image-to-Video | vidu/image-to-video-2.0 |
 | AtlasCloud Vidu Q3 Image-to-Video (Q3 API) | vidu/q3/image-to-video |
+| AtlasCloud Vidu Q3-Pro Image-to-Video | vidu/q3-pro/image-to-video |
+| AtlasCloud WAN2.2 Spicy Image-to-Video | alibaba/wan-2.2-spicy/image-to-video |
+| AtlasCloud WAN2.2 Spicy Image-to-Video LoRA | alibaba/wan-2.2-spicy/image-to-video-lora |
 | AtlasCloud Hunyuan Image-to-Video | atlascloud/hunyuan-video/i2v |
 
 ### Text-to-Image (T2I)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_pro_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_pro_i2v.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3ProImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "step": 1, "tooltip": "Duration (seconds)"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement intensity"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str = "720p",
+        duration: int = 5,
+        movement_amplitude: str = "auto",
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3-pro/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_pro_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_pro_t2v.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3ProTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "style": (["general", "anime"], {"default": "general", "tooltip": "Style"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "step": 1, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (
+                    ["16:9", "9:16", "4:3", "3:4", "1:1"],
+                    {"default": "4:3", "tooltip": "Aspect ratio"},
+                ),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement intensity"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        style: str = "general",
+        resolution: str = "720p",
+        duration: int = 5,
+        aspect_ratio: str = "4:3",
+        movement_amplitude: str = "auto",
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3-pro/text-to-video",
+            "prompt": prompt,
+            "style": style,
+            "resolution": resolution,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan22_spicy_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/wan22_spicy_i2v.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22SpicyImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Resolution"}),
+                "duration": ([5, 8], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+            },
+            "optional": {
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        duration: int,
+        seed: int,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.2-spicy/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan22_spicy_i2v_lora.py
+++ b/src/atlascloud_comfyui/nodes/video/wan22_spicy_i2v_lora.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22SpicyImageToVideoLora:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Resolution"}),
+                "duration": ([5, 8], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array of LoRA objects for `loras`. Example: [{"path":"https://.../lora.safetensors","scale":1.0}]',
+                    },
+                ),
+                "low_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array for `low_noise_loras`. Example: [{"path":"https://...","scale":1.0}]',
+                    },
+                ),
+                "high_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array for `high_noise_loras`. Example: [{"path":"https://...","scale":1.0}]',
+                    },
+                ),
+            },
+            "optional": {
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        duration: int,
+        seed: int,
+        loras_json: str = "[]",
+        low_noise_loras_json: str = "[]",
+        high_noise_loras_json: str = "[]",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        import json
+
+        def parse_array(s: str, name: str):
+            try:
+                arr = json.loads(s) if (s or "").strip() else []
+                if not isinstance(arr, list):
+                    raise ValueError(f"{name} must be a JSON array")
+                return arr
+            except Exception as e:
+                raise RuntimeError(f"Invalid {name}. Must be a JSON array. Error: {e}") from e
+
+        loras = parse_array(loras_json, "loras_json")
+        low_noise_loras = parse_array(low_noise_loras_json, "low_noise_loras_json")
+        high_noise_loras = parse_array(high_noise_loras_json, "high_noise_loras_json")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.2-spicy/image-to-video-lora",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "seed": int(seed),
+        }
+
+        if loras:
+            payload["loras"] = loras
+        if low_noise_loras:
+            payload["low_noise_loras"] = low_noise_loras
+        if high_noise_loras:
+            payload["high_noise_loras"] = high_noise_loras
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -62,6 +62,10 @@ from atlascloud_comfyui.nodes.video.hunyuan_t2v import AtlasHunyuanTextToVideo
 from atlascloud_comfyui.nodes.video.vidu_q3_i2v import AtlasViduQ3ImageToVideo
 from atlascloud_comfyui.nodes.video.vidu_q3_i2v_v2 import AtlasViduQ3ImageToVideoV2
 from atlascloud_comfyui.nodes.video.vidu_q3_t2v import AtlasViduQ3TextToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_pro_t2v import AtlasViduQ3ProTextToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_pro_i2v import AtlasViduQ3ProImageToVideo
+from atlascloud_comfyui.nodes.video.wan22_spicy_i2v import AtlasWan22SpicyImageToVideo
+from atlascloud_comfyui.nodes.video.wan22_spicy_i2v_lora import AtlasWan22SpicyImageToVideoLora
 from atlascloud_comfyui.nodes.video.veo3_fast_t2v import AtlasVeo3FastTextToVideo
 from atlascloud_comfyui.nodes.video.veo31_i2v import AtlasVeo31ImageToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_fast_t2v import AtlasVeo31FastTextToVideo
@@ -275,6 +279,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Vidu Q3 Text-to-Video": AtlasViduQ3TextToVideo,
     "AtlasCloud Vidu Q3 Image-to-Video": AtlasViduQ3ImageToVideo,
     "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)": AtlasViduQ3ImageToVideoV2,
+    "AtlasCloud Vidu Q3-Pro Text-to-Video": AtlasViduQ3ProTextToVideo,
+    "AtlasCloud Vidu Q3-Pro Image-to-Video": AtlasViduQ3ProImageToVideo,
+    "AtlasCloud WAN2.2 Spicy Image-to-Video": AtlasWan22SpicyImageToVideo,
+    "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": AtlasWan22SpicyImageToVideoLora,
     "AtlasCloud VEO3 Text-to-Video": AtlasVeo3TextToVideo,
     "AtlasCloud Imagen4 Text-to-Image": AtlasImagen4TextToImage,
     "AtlasCloud Imagen4 Fast Text-to-Image": AtlasImagen4FastTextToImage,
@@ -457,6 +465,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Vidu Q3 Text-to-Video": "AtlasCloud Vidu Q3 Text-to-Video",
     "AtlasCloud Vidu Q3 Image-to-Video": "AtlasCloud Vidu Q3 Image-to-Video",
     "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)": "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)",
+    "AtlasCloud Vidu Q3-Pro Text-to-Video": "AtlasCloud Vidu Q3-Pro Text-to-Video",
+    "AtlasCloud Vidu Q3-Pro Image-to-Video": "AtlasCloud Vidu Q3-Pro Image-to-Video",
+    "AtlasCloud WAN2.2 Spicy Image-to-Video": "AtlasCloud WAN2.2 Spicy Image-to-Video",
+    "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA",
     "AtlasCloud VEO3 Text-to-Video": "AtlasCloud VEO3 Text-to-Video",
     "AtlasCloud Imagen4 Text-to-Image": "AtlasCloud Imagen4 Text-to-Image",
     "AtlasCloud Imagen4 Fast Text-to-Image": "AtlasCloud Imagen4 Fast Text-to-Image",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -114,6 +114,40 @@ def test_vidu_q3_i2v_node_metadata():
     assert "video_url" in AtlasViduQ3ImageToVideo.RETURN_NAMES
 
 
+def test_vidu_q3_pro_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_pro_t2v import AtlasViduQ3ProTextToVideo
+
+    assert "atlas_client" in AtlasViduQ3ProTextToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3ProTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert "video_url" in AtlasViduQ3ProTextToVideo.RETURN_NAMES
+
+
+def test_vidu_q3_pro_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_pro_i2v import AtlasViduQ3ProImageToVideo
+
+    assert "atlas_client" in AtlasViduQ3ProImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasViduQ3ProImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3ProImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert "video_url" in AtlasViduQ3ProImageToVideo.RETURN_NAMES
+
+
+def test_wan22_spicy_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan22_spicy_i2v import AtlasWan22SpicyImageToVideo
+
+    assert "atlas_client" in AtlasWan22SpicyImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22SpicyImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan22SpicyImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan22_spicy_i2v_lora_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan22_spicy_i2v_lora import AtlasWan22SpicyImageToVideoLora
+
+    assert "atlas_client" in AtlasWan22SpicyImageToVideoLora.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22SpicyImageToVideoLora.INPUT_TYPES()["required"]
+    assert "loras_json" in AtlasWan22SpicyImageToVideoLora.INPUT_TYPES()["required"]
+    assert AtlasWan22SpicyImageToVideoLora.RETURN_TYPES == ("STRING", "STRING")
+
+
 # --- Batch 2: Recent HOT models ---
 
 


### PR DESCRIPTION
## Summary
Adds ComfyUI node support for newly listed AtlasCloud visual models found via /api/v1/models + repo diff.

### Added models
- vidu/q3-pro/text-to-video (T2V)
- vidu/q3-pro/image-to-video (I2V)
- alibaba/wan-2.2-spicy/image-to-video (I2V)
- alibaba/wan-2.2-spicy/image-to-video-lora (I2V + LoRA arrays via JSON inputs)

## Test plan
- [x] ruff check .
- [x] pytest tests/ -v
- [x] E2E ran as part of pytest suite with ATLASCLOUD_API_KEY set (Kling O3 long-queue tests skipped by design)
