### PR TITLE
feat: add Vidu Q3-Turbo + Q3-Pro start-end nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Vidu Q3 Image-to-Video | vidu/image-to-video-2.0 |
 | AtlasCloud Vidu Q3 Image-to-Video (Q3 API) | vidu/q3/image-to-video |
 | AtlasCloud Vidu Q3-Pro Image-to-Video | vidu/q3-pro/image-to-video |
+| AtlasCloud Vidu Q3-Pro Start-End-to-Video | vidu/q3-pro/start-end-to-video |
+| AtlasCloud Vidu Q3-Turbo Text-to-Video | vidu/q3-turbo/text-to-video |
+| AtlasCloud Vidu Q3-Turbo Image-to-Video | vidu/q3-turbo/image-to-video |
+| AtlasCloud Vidu Q3-Turbo Start-End-to-Video | vidu/q3-turbo/start-end-to-video |
 | AtlasCloud WAN2.2 Spicy Image-to-Video | alibaba/wan-2.2-spicy/image-to-video |
 | AtlasCloud WAN2.2 Spicy Image-to-Video LoRA | alibaba/wan-2.2-spicy/image-to-video-lora |
 | AtlasCloud Hunyuan Image-to-Video | atlascloud/hunyuan-video/i2v |

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_pro_start_end_to_video.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_pro_start_end_to_video.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3ProStartEndToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "End image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 16, "step": 1, "tooltip": "Duration (seconds)"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement intensity"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        end_image: str,
+        prompt: str,
+        resolution: str = "720p",
+        duration: int = 5,
+        movement_amplitude: str = "auto",
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        end_image = (end_image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+        if not end_image:
+            raise RuntimeError("end_image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3-pro/start-end-to-video",
+            "image": image,
+            "end_image": end_image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_turbo_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_turbo_i2v.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3TurboImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 16, "step": 1, "tooltip": "Duration (seconds)"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement intensity"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str = "720p",
+        duration: int = 5,
+        movement_amplitude: str = "auto",
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3-turbo/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_turbo_start_end_to_video.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_turbo_start_end_to_video.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3TurboStartEndToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "End image URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 16, "step": 1, "tooltip": "Duration (seconds)"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement intensity"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        end_image: str,
+        prompt: str,
+        resolution: str = "720p",
+        duration: int = 5,
+        movement_amplitude: str = "auto",
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        end_image = (end_image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+        if not end_image:
+            raise RuntimeError("end_image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3-turbo/start-end-to-video",
+            "image": image,
+            "end_image": end_image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_turbo_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_turbo_t2v.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3TurboTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "style": (["general", "anime"], {"default": "general", "tooltip": "Output style"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 16, "step": 1, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16", "4:3", "3:4", "1:1"], {"default": "4:3", "tooltip": "Aspect ratio"}),
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement intensity"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        style: str = "general",
+        resolution: str = "720p",
+        duration: int = 5,
+        aspect_ratio: str = "4:3",
+        movement_amplitude: str = "auto",
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3-turbo/text-to-video",
+            "prompt": prompt,
+            "style": style,
+            "resolution": resolution,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -64,6 +64,10 @@ from atlascloud_comfyui.nodes.video.vidu_q3_i2v_v2 import AtlasViduQ3ImageToVide
 from atlascloud_comfyui.nodes.video.vidu_q3_t2v import AtlasViduQ3TextToVideo
 from atlascloud_comfyui.nodes.video.vidu_q3_pro_t2v import AtlasViduQ3ProTextToVideo
 from atlascloud_comfyui.nodes.video.vidu_q3_pro_i2v import AtlasViduQ3ProImageToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_turbo_t2v import AtlasViduQ3TurboTextToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_turbo_i2v import AtlasViduQ3TurboImageToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_turbo_start_end_to_video import AtlasViduQ3TurboStartEndToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_pro_start_end_to_video import AtlasViduQ3ProStartEndToVideo
 from atlascloud_comfyui.nodes.video.wan22_spicy_i2v import AtlasWan22SpicyImageToVideo
 from atlascloud_comfyui.nodes.video.wan22_spicy_i2v_lora import AtlasWan22SpicyImageToVideoLora
 from atlascloud_comfyui.nodes.video.veo3_fast_t2v import AtlasVeo3FastTextToVideo
@@ -281,6 +285,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)": AtlasViduQ3ImageToVideoV2,
     "AtlasCloud Vidu Q3-Pro Text-to-Video": AtlasViduQ3ProTextToVideo,
     "AtlasCloud Vidu Q3-Pro Image-to-Video": AtlasViduQ3ProImageToVideo,
+    "AtlasCloud Vidu Q3-Pro Start-End-to-Video": AtlasViduQ3ProStartEndToVideo,
+    "AtlasCloud Vidu Q3-Turbo Text-to-Video": AtlasViduQ3TurboTextToVideo,
+    "AtlasCloud Vidu Q3-Turbo Image-to-Video": AtlasViduQ3TurboImageToVideo,
+    "AtlasCloud Vidu Q3-Turbo Start-End-to-Video": AtlasViduQ3TurboStartEndToVideo,
     "AtlasCloud WAN2.2 Spicy Image-to-Video": AtlasWan22SpicyImageToVideo,
     "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": AtlasWan22SpicyImageToVideoLora,
     "AtlasCloud VEO3 Text-to-Video": AtlasVeo3TextToVideo,
@@ -467,6 +475,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)": "AtlasCloud Vidu Q3 Image-to-Video (Q3 API)",
     "AtlasCloud Vidu Q3-Pro Text-to-Video": "AtlasCloud Vidu Q3-Pro Text-to-Video",
     "AtlasCloud Vidu Q3-Pro Image-to-Video": "AtlasCloud Vidu Q3-Pro Image-to-Video",
+    "AtlasCloud Vidu Q3-Pro Start-End-to-Video": "AtlasCloud Vidu Q3-Pro Start-End-to-Video",
+    "AtlasCloud Vidu Q3-Turbo Text-to-Video": "AtlasCloud Vidu Q3-Turbo Text-to-Video",
+    "AtlasCloud Vidu Q3-Turbo Image-to-Video": "AtlasCloud Vidu Q3-Turbo Image-to-Video",
+    "AtlasCloud Vidu Q3-Turbo Start-End-to-Video": "AtlasCloud Vidu Q3-Turbo Start-End-to-Video",
     "AtlasCloud WAN2.2 Spicy Image-to-Video": "AtlasCloud WAN2.2 Spicy Image-to-Video",
     "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA",
     "AtlasCloud VEO3 Text-to-Video": "AtlasCloud VEO3 Text-to-Video",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -131,6 +131,43 @@ def test_vidu_q3_pro_i2v_node_metadata():
     assert "video_url" in AtlasViduQ3ProImageToVideo.RETURN_NAMES
 
 
+def test_vidu_q3_pro_start_end_to_video_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_pro_start_end_to_video import AtlasViduQ3ProStartEndToVideo
+
+    assert "atlas_client" in AtlasViduQ3ProStartEndToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasViduQ3ProStartEndToVideo.INPUT_TYPES()["required"]
+    assert "end_image" in AtlasViduQ3ProStartEndToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3ProStartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert "video_url" in AtlasViduQ3ProStartEndToVideo.RETURN_NAMES
+
+
+def test_vidu_q3_turbo_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_turbo_t2v import AtlasViduQ3TurboTextToVideo
+
+    assert "atlas_client" in AtlasViduQ3TurboTextToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3TurboTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert "video_url" in AtlasViduQ3TurboTextToVideo.RETURN_NAMES
+
+
+def test_vidu_q3_turbo_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_turbo_i2v import AtlasViduQ3TurboImageToVideo
+
+    assert "atlas_client" in AtlasViduQ3TurboImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasViduQ3TurboImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3TurboImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert "video_url" in AtlasViduQ3TurboImageToVideo.RETURN_NAMES
+
+
+def test_vidu_q3_turbo_start_end_to_video_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_turbo_start_end_to_video import AtlasViduQ3TurboStartEndToVideo
+
+    assert "atlas_client" in AtlasViduQ3TurboStartEndToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasViduQ3TurboStartEndToVideo.INPUT_TYPES()["required"]
+    assert "end_image" in AtlasViduQ3TurboStartEndToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3TurboStartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert "video_url" in AtlasViduQ3TurboStartEndToVideo.RETURN_NAMES
+
+
 def test_wan22_spicy_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.wan22_spicy_i2v import AtlasWan22SpicyImageToVideo
 


### PR DESCRIPTION
## Summary
- Add ComfyUI nodes for new AtlasCloud video models:
  - vidu/q3-turbo/text-to-video
  - vidu/q3-turbo/image-to-video
  - vidu/q3-turbo/start-end-to-video
  - vidu/q3-pro/start-end-to-video
- Update registry + README available nodes table
- Add metadata-only tests for new nodes

## Test plan
- [x] ruff check .
- [x] pytest tests/ -v
- [x] E2E baseline (tests/test_e2e_new_models.py) — pass; Kling O3 T2V tests skipped by design
- [!] E2E baseline (tests/test_e2e.py) — T2V timed out once locally (minimax/hailuo-02/t2v-pro); subsequent manual poll succeeded (likely transient queue).

🤖 Generated with OpenClaw