### PR TITLE
chore: daily AtlasCloud model sync (2026-03-19)

### DIFF
--- a/reports/model_sync/2026-03-19.md
+++ b/reports/model_sync/2026-03-19.md
@@ -1,0 +1,19 @@
+# AtlasCloud→ComfyUI Node Sync — 2026-03-19
+
+## Summary
+Daily sync run against AtlasCloud `/api/v1/models` and repo node coverage.
+
+- API total models: **269**
+- Repo supported model IDs (detected by grepping node payload `model` values): **164** (legacy/deprecated included; not all API models are visual)
+- Missing visual models (Image/Video) from API that repo does not support: **0**
+
+## Notes
+- Many missing IDs are **Text** (LLM) models and intentionally out of scope.
+- Repo includes some **deprecated** model IDs not present in API (for backward compatibility), which is expected.
+
+## Local test status
+- `ruff check .` — **PASS**
+- `pytest tests/ -v` — **PASS** (172 passed, 4 skipped)
+
+## CI / PR
+- No code changes required → **no PR created** (GitHub blocks PR creation when there are no commits).


### PR DESCRIPTION
## Summary\n- Daily sync against https://api.atlascloud.ai/api/v1/models\n- Visual model coverage diff: **0** (all Image/Video model IDs already supported)\n- Added a report file for auditability: reports/model_sync/2026-03-19.md\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/ -v (includes E2E; uses ATLASCLOUD_API_KEY)\n\nNotes\n- This PR intentionally contains no node code changes.