### PR TITLE
feat: sync new AtlasCloud vision models (2026-03-20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V2.6 Pro Image-to-Video | kwaivgi/kling-v2.6-pro/image-to-video |
 | AtlasCloud Kling Video O1 Image-to-Video | kwaivgi/kling-video-o1/image-to-video |
 | AtlasCloud Seedance V1.5 Pro Image-to-Video | bytedance/seedance-v1.5-pro/image-to-video |
+| AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy) | bytedance/seedance-v1.5-pro/image-to-video-spicy |
 | AtlasCloud Seedance V1 Lite I2V 1080p | bytedance/seedance-v1-lite-i2v-1080p |
 | AtlasCloud Seedance V1 Lite I2V 720p | bytedance/seedance-v1-lite-i2v-720p |
 | AtlasCloud Seedance V1 Lite I2V 480p | bytedance/seedance-v1-lite-i2v-480p |
@@ -197,6 +198,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Vidu Q3-Turbo Image-to-Video | vidu/q3-turbo/image-to-video |
 | AtlasCloud Vidu Q3-Turbo Start-End-to-Video | vidu/q3-turbo/start-end-to-video |
 | AtlasCloud WAN2.2 Spicy Image-to-Video | alibaba/wan-2.2-spicy/image-to-video |
+| AtlasCloud WAN2.2 Turbo Spicy Image-to-Video | atlascloud/wan-2.2-turbo-spicy/image-to-video |
 | AtlasCloud WAN2.2 Spicy Image-to-Video LoRA | alibaba/wan-2.2-spicy/image-to-video-lora |
 | AtlasCloud Hunyuan Image-to-Video | atlascloud/hunyuan-video/i2v |
 

--- a/src/atlascloud_comfyui/nodes/video/seedance_v15_pro_i2v_spicy.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v15_pro_i2v_spicy.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedanceV15ProImageToVideoSpicy:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"}),
+                "resolution": (
+                    ["720p", "480p", "1080p"],
+                    {"default": "720p", "tooltip": "Resolution preset"},
+                ),
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional prompt"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+            },
+            "optional": {
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Fixed camera"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "last_image": ("STRING", {"default": "", "tooltip": "Optional last image URL/base64"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        aspect_ratio: str,
+        duration: int,
+        resolution: str,
+        prompt: str,
+        seed: int,
+        camera_fixed: bool = False,
+        generate_audio: bool = True,
+        last_image: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Seedance V1.5 Pro Image-to-Video (Spicy)")
+
+        client = atlas_client.client
+
+        payload = {
+            "model": "bytedance/seedance-v1.5-pro/image-to-video-spicy",
+            "image": (image or "").strip(),
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+            "camera_fixed": bool(camera_fixed),
+            "generate_audio": bool(generate_audio),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/wan22_turbo_spicy_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/wan22_turbo_spicy_i2v.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22TurboSpicyImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["480p", "720p", "1080p"], {"default": "480p", "tooltip": "Resolution"}),
+                "duration": ([5, 8], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+            },
+            "optional": {
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        duration: int,
+        seed: int,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2-turbo-spicy/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -69,6 +69,7 @@ from atlascloud_comfyui.nodes.video.vidu_q3_turbo_i2v import AtlasViduQ3TurboIma
 from atlascloud_comfyui.nodes.video.vidu_q3_turbo_start_end_to_video import AtlasViduQ3TurboStartEndToVideo
 from atlascloud_comfyui.nodes.video.vidu_q3_pro_start_end_to_video import AtlasViduQ3ProStartEndToVideo
 from atlascloud_comfyui.nodes.video.wan22_spicy_i2v import AtlasWan22SpicyImageToVideo
+from atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v import AtlasWan22TurboSpicyImageToVideo
 from atlascloud_comfyui.nodes.video.wan22_spicy_i2v_lora import AtlasWan22SpicyImageToVideoLora
 from atlascloud_comfyui.nodes.video.veo3_fast_t2v import AtlasVeo3FastTextToVideo
 from atlascloud_comfyui.nodes.video.veo31_i2v import AtlasVeo31ImageToVideo
@@ -96,6 +97,7 @@ from atlascloud_comfyui.nodes.video.kling_v26_std_avatar import AtlasKlingV26Std
 from atlascloud_comfyui.nodes.video.kling_v26_pro_motion_control import AtlasKlingV26ProMotionControl
 from atlascloud_comfyui.nodes.video.kling_v26_std_motion_control import AtlasKlingV26StdMotionControl
 from atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v import AtlasSeedanceV15ProImageToVideo
+from atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v_spicy import AtlasSeedanceV15ProImageToVideoSpicy
 from atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v_fast import AtlasSeedanceV15ProImageToVideoFast
 from atlascloud_comfyui.nodes.video.seedance_v15_pro_t2v_fast import AtlasSeedanceV15ProTextToVideoFast
 from atlascloud_comfyui.nodes.video.kling_video_o1_i2v import AtlasKlingVideoO1ImageToVideo
@@ -251,6 +253,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Seedance V1.5 Pro Text-to-Video": AtlasSeedanceV15ProTextToVideo,
     "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast": AtlasSeedanceV15ProTextToVideoFast,
     "AtlasCloud Seedance V1.5 Pro Image-to-Video": AtlasSeedanceV15ProImageToVideo,
+    "AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy)": AtlasSeedanceV15ProImageToVideoSpicy,
     "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast": AtlasSeedanceV15ProImageToVideoFast,
     "AtlasCloud Seedream V4 Text-to-Image": AtlasSeedreamV4TextToImage,
     "AtlasCloud Seedream V4 Sequential Text-to-Image": AtlasSeedreamV4SequentialTextToImage,
@@ -293,6 +296,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Vidu Q3-Turbo Image-to-Video": AtlasViduQ3TurboImageToVideo,
     "AtlasCloud Vidu Q3-Turbo Start-End-to-Video": AtlasViduQ3TurboStartEndToVideo,
     "AtlasCloud WAN2.2 Spicy Image-to-Video": AtlasWan22SpicyImageToVideo,
+    "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video": AtlasWan22TurboSpicyImageToVideo,
     "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": AtlasWan22SpicyImageToVideoLora,
     "AtlasCloud VEO3 Text-to-Video": AtlasVeo3TextToVideo,
     "AtlasCloud Imagen4 Text-to-Image": AtlasImagen4TextToImage,
@@ -444,6 +448,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedance V1.5 Pro Text-to-Video": "AtlasCloud Seedance V1.5 Pro Text-to-Video",
     "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast": "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast",
     "AtlasCloud Seedance V1.5 Pro Image-to-Video": "AtlasCloud Seedance V1.5 Pro Image-to-Video",
+    "AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy)": "AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy)",
     "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast": "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast",
     "AtlasCloud Seedream V4 Text-to-Image": "AtlasCloud Seedream V4 Text-to-Image",
     "AtlasCloud Seedream V4 Sequential Text-to-Image": "AtlasCloud Seedream V4 Sequential Text-to-Image",
@@ -486,6 +491,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Vidu Q3-Turbo Image-to-Video": "AtlasCloud Vidu Q3-Turbo Image-to-Video",
     "AtlasCloud Vidu Q3-Turbo Start-End-to-Video": "AtlasCloud Vidu Q3-Turbo Start-End-to-Video",
     "AtlasCloud WAN2.2 Spicy Image-to-Video": "AtlasCloud WAN2.2 Spicy Image-to-Video",
+    "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video": "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video",
     "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA",
     "AtlasCloud VEO3 Text-to-Video": "AtlasCloud VEO3 Text-to-Video",
     "AtlasCloud Imagen4 Text-to-Image": "AtlasCloud Imagen4 Text-to-Image",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -185,6 +185,22 @@ def test_wan22_spicy_i2v_lora_node_metadata():
     assert AtlasWan22SpicyImageToVideoLora.RETURN_TYPES == ("STRING", "STRING")
 
 
+def test_wan22_turbo_spicy_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v import AtlasWan22TurboSpicyImageToVideo
+
+    assert "atlas_client" in AtlasWan22TurboSpicyImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22TurboSpicyImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan22TurboSpicyImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_v15_pro_i2v_spicy_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v_spicy import AtlasSeedanceV15ProImageToVideoSpicy
+
+    assert "atlas_client" in AtlasSeedanceV15ProImageToVideoSpicy.INPUT_TYPES()["required"]
+    assert "image" in AtlasSeedanceV15ProImageToVideoSpicy.INPUT_TYPES()["required"]
+    assert AtlasSeedanceV15ProImageToVideoSpicy.RETURN_TYPES == ("STRING", "STRING")
+
+
 # --- Batch 2: Recent HOT models ---
 
 


### PR DESCRIPTION
## Summary\n- Add AtlasCloud WAN2.2 Turbo Spicy Image-to-Video node\n- Add Seedance V1.5 Pro Image-to-Video (Spicy) node\n\n## Models\n- atlascloud/wan-2.2-turbo-spicy/image-to-video\n- bytedance/seedance-v1.5-pro/image-to-video-spicy\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/ -v\n- [x] E2E baseline (tests/test_e2e.py)\n- [x] E2E new models suite (tests/test_e2e_new_models.py)\n\n🤖 Generated with OpenClaw\n