### PR TITLE
feat: add WAN2.2 Turbo Spicy I2V LoRA node

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Vidu Q3-Turbo Start-End-to-Video | vidu/q3-turbo/start-end-to-video |
 | AtlasCloud WAN2.2 Spicy Image-to-Video | alibaba/wan-2.2-spicy/image-to-video |
 | AtlasCloud WAN2.2 Turbo Spicy Image-to-Video | atlascloud/wan-2.2-turbo-spicy/image-to-video |
+| AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA | atlascloud/wan-2.2-turbo-spicy/image-to-video-lora |
 | AtlasCloud WAN2.2 Spicy Image-to-Video LoRA | alibaba/wan-2.2-spicy/image-to-video-lora |
 | AtlasCloud Hunyuan Image-to-Video | atlascloud/hunyuan-video/i2v |
 

--- a/src/atlascloud_comfyui/client/atlas_client.py
+++ b/src/atlascloud_comfyui/client/atlas_client.py
@@ -182,6 +182,7 @@ class AtlasClient:
 
             if status == "failed":
                 err = (data.get("data") or {}).get("error") or "Generation failed"
-                raise AtlasError(err)
+                code = (data.get("data") or {}).get("error_code")
+                raise AtlasError(f"{err} (error_code={code})" if code else err)
 
             time.sleep(float(poll_interval_sec))

--- a/src/atlascloud_comfyui/nodes/video/wan22_turbo_spicy_i2v_lora.py
+++ b/src/atlascloud_comfyui/nodes/video/wan22_turbo_spicy_i2v_lora.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22TurboSpicyImageToVideoLora:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (
+                    ["480p", "720p", "1080p"],
+                    {"default": "480p", "tooltip": "Resolution"},
+                ),
+                "duration": (
+                    [5, 8],
+                    {"default": 5, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "low_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array for `low_noise_loras`. Example: [{"path":"https://.../lora.safetensors","scale":1.0}]',
+                    },
+                ),
+                "high_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array for `high_noise_loras`. Example: [{"path":"https://.../lora.safetensors","scale":1.0}]',
+                    },
+                ),
+            },
+            "optional": {
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        duration: int,
+        seed: int,
+        low_noise_loras_json: str = "[]",
+        high_noise_loras_json: str = "[]",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        import json
+
+        def parse_array(s: str, name: str):
+            try:
+                arr = json.loads(s) if (s or "").strip() else []
+                if not isinstance(arr, list):
+                    raise ValueError(f"{name} must be a JSON array")
+                return arr
+            except Exception as e:
+                raise RuntimeError(f"Invalid {name}. Must be a JSON array. Error: {e}") from e
+
+        low_noise_loras = parse_array(low_noise_loras_json, "low_noise_loras_json")
+        high_noise_loras = parse_array(high_noise_loras_json, "high_noise_loras_json")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2-turbo-spicy/image-to-video-lora",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "seed": int(seed),
+        }
+
+        if low_noise_loras:
+            payload["low_noise_loras"] = low_noise_loras
+        if high_noise_loras:
+            payload["high_noise_loras"] = high_noise_loras
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -71,6 +71,7 @@ from atlascloud_comfyui.nodes.video.vidu_q3_pro_start_end_to_video import AtlasV
 from atlascloud_comfyui.nodes.video.wan22_spicy_i2v import AtlasWan22SpicyImageToVideo
 from atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v import AtlasWan22TurboSpicyImageToVideo
 from atlascloud_comfyui.nodes.video.wan22_spicy_i2v_lora import AtlasWan22SpicyImageToVideoLora
+from atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v_lora import AtlasWan22TurboSpicyImageToVideoLora
 from atlascloud_comfyui.nodes.video.veo3_fast_t2v import AtlasVeo3FastTextToVideo
 from atlascloud_comfyui.nodes.video.veo31_i2v import AtlasVeo31ImageToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_fast_t2v import AtlasVeo31FastTextToVideo
@@ -297,6 +298,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Vidu Q3-Turbo Start-End-to-Video": AtlasViduQ3TurboStartEndToVideo,
     "AtlasCloud WAN2.2 Spicy Image-to-Video": AtlasWan22SpicyImageToVideo,
     "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video": AtlasWan22TurboSpicyImageToVideo,
+    "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA": AtlasWan22TurboSpicyImageToVideoLora,
     "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": AtlasWan22SpicyImageToVideoLora,
     "AtlasCloud VEO3 Text-to-Video": AtlasVeo3TextToVideo,
     "AtlasCloud Imagen4 Text-to-Image": AtlasImagen4TextToImage,
@@ -492,6 +494,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Vidu Q3-Turbo Start-End-to-Video": "AtlasCloud Vidu Q3-Turbo Start-End-to-Video",
     "AtlasCloud WAN2.2 Spicy Image-to-Video": "AtlasCloud WAN2.2 Spicy Image-to-Video",
     "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video": "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video",
+    "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA": "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA",
     "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA",
     "AtlasCloud VEO3 Text-to-Video": "AtlasCloud VEO3 Text-to-Video",
     "AtlasCloud Imagen4 Text-to-Image": "AtlasCloud Imagen4 Text-to-Image",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -193,6 +193,16 @@ def test_wan22_turbo_spicy_i2v_node_metadata():
     assert AtlasWan22TurboSpicyImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
 
+def test_wan22_turbo_spicy_i2v_lora_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v_lora import AtlasWan22TurboSpicyImageToVideoLora
+
+    assert "atlas_client" in AtlasWan22TurboSpicyImageToVideoLora.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22TurboSpicyImageToVideoLora.INPUT_TYPES()["required"]
+    assert "low_noise_loras_json" in AtlasWan22TurboSpicyImageToVideoLora.INPUT_TYPES()["required"]
+    assert "high_noise_loras_json" in AtlasWan22TurboSpicyImageToVideoLora.INPUT_TYPES()["required"]
+    assert AtlasWan22TurboSpicyImageToVideoLora.RETURN_TYPES == ("STRING", "STRING")
+
+
 def test_seedance_v15_pro_i2v_spicy_node_metadata():
     from src.atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v_spicy import AtlasSeedanceV15ProImageToVideoSpicy
 


### PR DESCRIPTION
## Summary\n- Add new ComfyUI node for model `atlascloud/wan-2.2-turbo-spicy/image-to-video-lora` (LoRA-capable I2V)\n- Update registry mappings and README\n- Improve polling to surface failed predictions immediately\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/test_atlascloud_comfyui.py -v\n- [x] E2E: pytest tests/test_e2e.py -v -s (with PYTHONPATH=../ComfyUI)\n- [x] E2E: pytest tests/test_e2e_new_models.py -v -s (with PYTHONPATH=../ComfyUI; video-edit skipped by default)\n\n🤖 Generated with OpenClaw