### PR TITLE
feat: add GPT Image + Qwen Image 2.0 nodes

### DIFF
--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_15_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_15_edit.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage15Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text instruction for editing"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "input_fidelity": (
+                    ["low", "high"],
+                    {
+                        "default": "high",
+                        "tooltip": "Preserve details from input images (useful for faces/logos).",
+                    },
+                ),
+                "quality": (
+                    ["low", "medium", "high"],
+                    {"default": "medium", "tooltip": "The quality of the generated image."},
+                ),
+                "size": (
+                    ["1024x1024", "1024x1536", "1536x1024"],
+                    {"default": "1024x1024", "tooltip": "The size of the generated media in pixels (width*height)."},
+                ),
+                "output_format": (
+                    ["jpeg", "png"],
+                    {"default": "jpeg", "tooltip": "The format of the output image."},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        input_fidelity: str = "high",
+        quality: str = "medium",
+        size: str = "1024x1024",
+        output_format: str = "jpeg",
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-1.5/edit",
+            "prompt": p,
+            "images": image_list,
+            "input_fidelity": input_fidelity,
+            "quality": quality,
+            "size": size,
+            "output_format": output_format,
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_15_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_15_t2i.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage15TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "quality": (
+                    ["low", "medium", "high"],
+                    {"default": "medium", "tooltip": "The quality of the generated image."},
+                ),
+                "size": (
+                    ["1024x1024", "1024x1536", "1536x1024"],
+                    {"default": "1024x1024", "tooltip": "The size of the generated media in pixels (width*height)."},
+                ),
+                "output_format": (
+                    ["jpeg", "png"],
+                    {"default": "jpeg", "tooltip": "The format of the output image."},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        quality: str = "medium",
+        size: str = "1024x1024",
+        output_format: str = "jpeg",
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-1.5/text-to-image",
+            "prompt": p,
+            "quality": quality,
+            "size": size,
+            "output_format": output_format,
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_1_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_1_edit.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage1Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text instruction for editing"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "mask_image": ("STRING", {"default": "", "tooltip": "Optional mask image URL/base64 (PNG preferred)"}),
+                "quality": (
+                    ["low", "medium", "high"],
+                    {"default": "medium", "tooltip": "The quality of the generated image."},
+                ),
+                "size": (
+                    ["1024x1024", "1024x1536", "1536x1024"],
+                    {"default": "1024x1024", "tooltip": "The size of the generated media in pixels (width*height)."},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        mask_image: str = "",
+        quality: str = "medium",
+        size: str = "1024x1024",
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-1/edit",
+            "prompt": p,
+            "images": image_list,
+            "quality": quality,
+            "size": size,
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        mi = (mask_image or "").strip()
+        if mi:
+            payload["mask_image"] = mi
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_1_mini_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_1_mini_edit.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage1MiniEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text instruction for editing"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "quality": (
+                    ["low", "medium", "high"],
+                    {"default": "medium", "tooltip": "The quality of the generated image."},
+                ),
+                "size": (
+                    ["1024x1024", "1024x1536", "1536x1024"],
+                    {"default": "1024x1024", "tooltip": "The size of the generated media in pixels (width*height)."},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        quality: str = "medium",
+        size: str = "1024x1024",
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-1-mini/edit",
+            "prompt": p,
+            "images": image_list,
+            "quality": quality,
+            "size": size,
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_1_mini_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_1_mini_t2i.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage1MiniTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "quality": (
+                    ["low", "medium", "high"],
+                    {"default": "medium", "tooltip": "The quality of the generated image."},
+                ),
+                "size": (
+                    ["1024x1024", "1024x1536", "1536x1024"],
+                    {"default": "1024x1024", "tooltip": "The size of the generated media in pixels (widthxheight)."},
+                ),
+                "output_format": (
+                    ["png", "jpeg"],
+                    {"default": "png", "tooltip": "Output image format."},
+                ),
+                "output_compression": (
+                    "INT",
+                    {
+                        "default": 100,
+                        "min": 0,
+                        "max": 100,
+                        "tooltip": "Compression level for output image.",
+                    },
+                ),
+                "n": (
+                    "INT",
+                    {"default": 1, "min": 1, "max": 10, "tooltip": "Number of images to generate."},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        quality: str = "medium",
+        size: str = "1024x1024",
+        output_format: str = "png",
+        output_compression: int = 100,
+        n: int = 1,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-1-mini/text-to-image",
+            "prompt": p,
+            "quality": quality,
+            "size": size,
+            "output_format": output_format,
+            "output_compression": int(output_compression),
+            "n": int(n),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_1_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_1_t2i.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage1TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "quality": (
+                    ["low", "medium", "high"],
+                    {"default": "medium", "tooltip": "The quality of the generated image."},
+                ),
+                "size": (
+                    ["1024x1024", "1024x1536", "1536x1024"],
+                    {"default": "1024x1024", "tooltip": "The size of the generated media in pixels (widthxheight)."},
+                ),
+                "output_format": (
+                    ["png", "jpeg"],
+                    {"default": "png", "tooltip": "Output image format."},
+                ),
+                "output_compression": (
+                    "INT",
+                    {
+                        "default": 100,
+                        "min": 0,
+                        "max": 100,
+                        "tooltip": "Compression level for output image.",
+                    },
+                ),
+                "n": (
+                    "INT",
+                    {"default": 1, "min": 1, "max": 10, "tooltip": "Number of images to generate."},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        quality: str = "medium",
+        size: str = "1024x1024",
+        output_format: str = "png",
+        output_compression: int = 100,
+        n: int = 1,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-1/text-to-image",
+            "prompt": p,
+            "quality": quality,
+            "size": size,
+            "output_format": output_format,
+            "output_compression": int(output_compression),
+            "n": int(n),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_20_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_20_edit.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasQwenImage20Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text instruction for editing"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-6 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "1024*1024",
+                        "tooltip": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720)",
+                    },
+                ),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2**31 - 1,
+                        "tooltip": "Random seed (-1 for random)",
+                    },
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str = "1024*1024",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-6 lines)")
+        if len(image_list) > 6:
+            raise RuntimeError("images maxItems is 6")
+
+        payload: Dict[str, Any] = {
+            "model": "qwen/qwen-image-2.0/edit",
+            "prompt": p,
+            "images": image_list,
+            "size": size,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_20_pro_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_20_pro_edit.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasQwenImage20ProEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text instruction for editing"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-6 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "1024*1024",
+                        "tooltip": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720)",
+                    },
+                ),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2**31 - 1,
+                        "tooltip": "Random seed (-1 for random)",
+                    },
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str = "1024*1024",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-6 lines)")
+        if len(image_list) > 6:
+            raise RuntimeError("images maxItems is 6")
+
+        payload: Dict[str, Any] = {
+            "model": "qwen/qwen-image-2.0-pro/edit",
+            "prompt": p,
+            "images": image_list,
+            "size": size,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_20_pro_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_20_pro_t2i.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasQwenImage20ProTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "1024*1024",
+                        "tooltip": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720)",
+                    },
+                ),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2**31 - 1,
+                        "tooltip": "Random seed (-1 for random)",
+                    },
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1024*1024",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "qwen/qwen-image-2.0-pro/text-to-image",
+            "prompt": p,
+            "size": size,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_20_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_20_t2i.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasQwenImage20TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "1024*1024",
+                        "tooltip": "Image dimensions in width*height format (e.g., 1024*1024, 1280*720)",
+                    },
+                ),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2**31 - 1,
+                        "tooltip": "Random seed (-1 for random)",
+                    },
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1024*1024",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "qwen/qwen-image-2.0/text-to-image",
+            "prompt": p,
+            "size": size,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -158,6 +158,17 @@ from atlascloud_comfyui.nodes.image.qwen_image_edit_plus_20251215 import AtlasQw
 from atlascloud_comfyui.nodes.image.qwen_image_t2i_plus import AtlasQwenImageTextToImagePlus
 from atlascloud_comfyui.nodes.image.qwen_image_t2i_max import AtlasQwenImageTextToImageMax
 
+from atlascloud_comfyui.nodes.image.openai_gpt_image_1_t2i import AtlasOpenAIGPTImage1TextToImage
+from atlascloud_comfyui.nodes.image.openai_gpt_image_1_edit import AtlasOpenAIGPTImage1Edit
+from atlascloud_comfyui.nodes.image.openai_gpt_image_1_mini_t2i import AtlasOpenAIGPTImage1MiniTextToImage
+from atlascloud_comfyui.nodes.image.openai_gpt_image_1_mini_edit import AtlasOpenAIGPTImage1MiniEdit
+from atlascloud_comfyui.nodes.image.openai_gpt_image_15_t2i import AtlasOpenAIGPTImage15TextToImage
+from atlascloud_comfyui.nodes.image.openai_gpt_image_15_edit import AtlasOpenAIGPTImage15Edit
+from atlascloud_comfyui.nodes.image.qwen_image_20_t2i import AtlasQwenImage20TextToImage
+from atlascloud_comfyui.nodes.image.qwen_image_20_edit import AtlasQwenImage20Edit
+from atlascloud_comfyui.nodes.image.qwen_image_20_pro_t2i import AtlasQwenImage20ProTextToImage
+from atlascloud_comfyui.nodes.image.qwen_image_20_pro_edit import AtlasQwenImage20ProEdit
+
 from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_t2v import AtlasSeedanceV1ProFastTextToVideo
 from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_i2v import AtlasSeedanceV1ProFastImageToVideo
 from atlascloud_comfyui.nodes.video.wan25_fast_t2v import AtlasWAN25TextToVideoFast
@@ -360,6 +371,17 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Qwen Image Text-to-Image Plus": AtlasQwenImageTextToImagePlus,
     "AtlasCloud Qwen Image Text-to-Image Max": AtlasQwenImageTextToImageMax,
 
+    "AtlasCloud GPT Image-1 Text-to-Image": AtlasOpenAIGPTImage1TextToImage,
+    "AtlasCloud GPT Image-1 Edit": AtlasOpenAIGPTImage1Edit,
+    "AtlasCloud GPT Image-1 Mini Text-to-Image": AtlasOpenAIGPTImage1MiniTextToImage,
+    "AtlasCloud GPT Image-1 Mini Edit": AtlasOpenAIGPTImage1MiniEdit,
+    "AtlasCloud GPT Image-1.5 Text-to-Image": AtlasOpenAIGPTImage15TextToImage,
+    "AtlasCloud GPT Image-1.5 Edit": AtlasOpenAIGPTImage15Edit,
+    "AtlasCloud Qwen Image 2.0 Text-to-Image": AtlasQwenImage20TextToImage,
+    "AtlasCloud Qwen Image 2.0 Edit": AtlasQwenImage20Edit,
+    "AtlasCloud Qwen Image 2.0 Pro Text-to-Image": AtlasQwenImage20ProTextToImage,
+    "AtlasCloud Qwen Image 2.0 Pro Edit": AtlasQwenImage20ProEdit,
+
     "AtlasCloud Seedance V1 Pro Fast Text-to-Video": AtlasSeedanceV1ProFastTextToVideo,
     "AtlasCloud Seedance V1 Pro Fast Image-to-Video": AtlasSeedanceV1ProFastImageToVideo,
     "AtlasCloud Seedance V1 Pro Image-to-Video 1080p": AtlasBytedanceSeedanceV1ProI2V1080p,
@@ -555,6 +577,17 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Qwen Image Edit Plus 20251215": "AtlasCloud Qwen Image Edit Plus 20251215",
     "AtlasCloud Qwen Image Text-to-Image Plus": "AtlasCloud Qwen Image Text-to-Image Plus",
     "AtlasCloud Qwen Image Text-to-Image Max": "AtlasCloud Qwen Image Text-to-Image Max",
+
+    "AtlasCloud GPT Image-1 Text-to-Image": "AtlasCloud GPT Image-1 Text-to-Image",
+    "AtlasCloud GPT Image-1 Edit": "AtlasCloud GPT Image-1 Edit",
+    "AtlasCloud GPT Image-1 Mini Text-to-Image": "AtlasCloud GPT Image-1 Mini Text-to-Image",
+    "AtlasCloud GPT Image-1 Mini Edit": "AtlasCloud GPT Image-1 Mini Edit",
+    "AtlasCloud GPT Image-1.5 Text-to-Image": "AtlasCloud GPT Image-1.5 Text-to-Image",
+    "AtlasCloud GPT Image-1.5 Edit": "AtlasCloud GPT Image-1.5 Edit",
+    "AtlasCloud Qwen Image 2.0 Text-to-Image": "AtlasCloud Qwen Image 2.0 Text-to-Image",
+    "AtlasCloud Qwen Image 2.0 Edit": "AtlasCloud Qwen Image 2.0 Edit",
+    "AtlasCloud Qwen Image 2.0 Pro Text-to-Image": "AtlasCloud Qwen Image 2.0 Pro Text-to-Image",
+    "AtlasCloud Qwen Image 2.0 Pro Edit": "AtlasCloud Qwen Image 2.0 Pro Edit",
 
     "AtlasCloud Seedance V1 Pro Fast Text-to-Video": "AtlasCloud Seedance V1 Pro Fast Text-to-Video",
     "AtlasCloud Seedance V1 Pro Fast Image-to-Video": "AtlasCloud Seedance V1 Pro Fast Image-to-Video",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -11,17 +11,14 @@ Covers:
 import pytest
 from src.atlascloud_comfyui.nodes.auth.atlas_client_node import AtlasClientNode
 
-
 @pytest.fixture
 def atlas_client_node():
     """Fixture to create an AtlasClientNode instance."""
     return AtlasClientNode()
 
-
 def test_atlas_client_node_initialization(atlas_client_node):
     """Test that AtlasClientNode can be instantiated."""
     assert isinstance(atlas_client_node, AtlasClientNode)
-
 
 def test_atlas_client_node_metadata():
     """Test AtlasClientNode INPUT_TYPES and RETURN_NAMES."""
@@ -35,7 +32,6 @@ def test_atlas_client_node_metadata():
         },
     }
 
-
 # Model nodes: ensure INPUT_TYPES and RETURN_TYPES are correct so nodes are usable
 def test_wan26_t2v_node_metadata():
     """Test WAN2.6 Text-to-Video node metadata."""
@@ -45,7 +41,6 @@ def test_wan26_t2v_node_metadata():
     assert AtlasWAN26TextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasWAN26TextToVideo.RETURN_NAMES
 
-
 def test_flux2_flex_t2i_node_metadata():
     """Test Flux2 Flex Text-to-Image node metadata."""
     from src.atlascloud_comfyui.nodes.image.flux2_flex_t2i import AtlasFlux2FlexTextToImage
@@ -53,9 +48,7 @@ def test_flux2_flex_t2i_node_metadata():
     assert "atlas_client" in [k for k, _ in AtlasFlux2FlexTextToImage.INPUT_TYPES()["required"].items()]
     assert AtlasFlux2FlexTextToImage.RETURN_TYPES == ("STRING", "STRING")
 
-
 # --- Batch 1: Newest models (NEW badge) ---
-
 
 def test_nano_banana2_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana2_t2i import AtlasNanoBanana2TextToImage
@@ -64,14 +57,12 @@ def test_nano_banana2_t2i_node_metadata():
     assert AtlasNanoBanana2TextToImage.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasNanoBanana2TextToImage.RETURN_NAMES
 
-
 def test_nano_banana2_t2i_dev_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana2_t2i_dev import AtlasNanoBanana2TextToImageDev
 
     assert "atlas_client" in AtlasNanoBanana2TextToImageDev.INPUT_TYPES()["required"]
     assert AtlasNanoBanana2TextToImageDev.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasNanoBanana2TextToImageDev.RETURN_NAMES
-
 
 def test_nano_banana2_edit_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana2_edit import AtlasNanoBanana2Edit
@@ -80,14 +71,12 @@ def test_nano_banana2_edit_node_metadata():
     assert "image" in AtlasNanoBanana2Edit.INPUT_TYPES()["required"]
     assert AtlasNanoBanana2Edit.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_nano_banana2_edit_dev_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana2_edit_dev import AtlasNanoBanana2EditDev
 
     assert "atlas_client" in AtlasNanoBanana2EditDev.INPUT_TYPES()["required"]
     assert "image" in AtlasNanoBanana2EditDev.INPUT_TYPES()["required"]
     assert AtlasNanoBanana2EditDev.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_seedream_v50_lite_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.seedream_v50_lite_t2i import AtlasSeedreamV50LiteTextToImage
@@ -96,14 +85,12 @@ def test_seedream_v50_lite_t2i_node_metadata():
     assert AtlasSeedreamV50LiteTextToImage.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasSeedreamV50LiteTextToImage.RETURN_NAMES
 
-
 def test_seedream_v50_lite_edit_node_metadata():
     from src.atlascloud_comfyui.nodes.image.seedream_v50_lite_edit import AtlasSeedreamV50LiteEdit
 
     assert "atlas_client" in AtlasSeedreamV50LiteEdit.INPUT_TYPES()["required"]
     assert "image" in AtlasSeedreamV50LiteEdit.INPUT_TYPES()["required"]
     assert AtlasSeedreamV50LiteEdit.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_vidu_q3_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q3_i2v import AtlasViduQ3ImageToVideo
@@ -113,14 +100,12 @@ def test_vidu_q3_i2v_node_metadata():
     assert AtlasViduQ3ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasViduQ3ImageToVideo.RETURN_NAMES
 
-
 def test_vidu_q3_pro_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q3_pro_t2v import AtlasViduQ3ProTextToVideo
 
     assert "atlas_client" in AtlasViduQ3ProTextToVideo.INPUT_TYPES()["required"]
     assert AtlasViduQ3ProTextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasViduQ3ProTextToVideo.RETURN_NAMES
-
 
 def test_vidu_q3_pro_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q3_pro_i2v import AtlasViduQ3ProImageToVideo
@@ -129,7 +114,6 @@ def test_vidu_q3_pro_i2v_node_metadata():
     assert "image" in AtlasViduQ3ProImageToVideo.INPUT_TYPES()["required"]
     assert AtlasViduQ3ProImageToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasViduQ3ProImageToVideo.RETURN_NAMES
-
 
 def test_vidu_q3_pro_start_end_to_video_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q3_pro_start_end_to_video import AtlasViduQ3ProStartEndToVideo
@@ -140,14 +124,12 @@ def test_vidu_q3_pro_start_end_to_video_node_metadata():
     assert AtlasViduQ3ProStartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasViduQ3ProStartEndToVideo.RETURN_NAMES
 
-
 def test_vidu_q3_turbo_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q3_turbo_t2v import AtlasViduQ3TurboTextToVideo
 
     assert "atlas_client" in AtlasViduQ3TurboTextToVideo.INPUT_TYPES()["required"]
     assert AtlasViduQ3TurboTextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasViduQ3TurboTextToVideo.RETURN_NAMES
-
 
 def test_vidu_q3_turbo_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q3_turbo_i2v import AtlasViduQ3TurboImageToVideo
@@ -156,7 +138,6 @@ def test_vidu_q3_turbo_i2v_node_metadata():
     assert "image" in AtlasViduQ3TurboImageToVideo.INPUT_TYPES()["required"]
     assert AtlasViduQ3TurboImageToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasViduQ3TurboImageToVideo.RETURN_NAMES
-
 
 def test_vidu_q3_turbo_start_end_to_video_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q3_turbo_start_end_to_video import AtlasViduQ3TurboStartEndToVideo
@@ -167,14 +148,12 @@ def test_vidu_q3_turbo_start_end_to_video_node_metadata():
     assert AtlasViduQ3TurboStartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasViduQ3TurboStartEndToVideo.RETURN_NAMES
 
-
 def test_wan22_spicy_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.wan22_spicy_i2v import AtlasWan22SpicyImageToVideo
 
     assert "atlas_client" in AtlasWan22SpicyImageToVideo.INPUT_TYPES()["required"]
     assert "image" in AtlasWan22SpicyImageToVideo.INPUT_TYPES()["required"]
     assert AtlasWan22SpicyImageToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_wan22_spicy_i2v_lora_node_metadata():
     from src.atlascloud_comfyui.nodes.video.wan22_spicy_i2v_lora import AtlasWan22SpicyImageToVideoLora
@@ -184,14 +163,12 @@ def test_wan22_spicy_i2v_lora_node_metadata():
     assert "loras_json" in AtlasWan22SpicyImageToVideoLora.INPUT_TYPES()["required"]
     assert AtlasWan22SpicyImageToVideoLora.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_wan22_turbo_spicy_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v import AtlasWan22TurboSpicyImageToVideo
 
     assert "atlas_client" in AtlasWan22TurboSpicyImageToVideo.INPUT_TYPES()["required"]
     assert "image" in AtlasWan22TurboSpicyImageToVideo.INPUT_TYPES()["required"]
     assert AtlasWan22TurboSpicyImageToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_wan22_turbo_spicy_i2v_lora_node_metadata():
     from src.atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v_lora import AtlasWan22TurboSpicyImageToVideoLora
@@ -202,7 +179,6 @@ def test_wan22_turbo_spicy_i2v_lora_node_metadata():
     assert "high_noise_loras_json" in AtlasWan22TurboSpicyImageToVideoLora.INPUT_TYPES()["required"]
     assert AtlasWan22TurboSpicyImageToVideoLora.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_seedance_v15_pro_i2v_spicy_node_metadata():
     from src.atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v_spicy import AtlasSeedanceV15ProImageToVideoSpicy
 
@@ -210,9 +186,7 @@ def test_seedance_v15_pro_i2v_spicy_node_metadata():
     assert "image" in AtlasSeedanceV15ProImageToVideoSpicy.INPUT_TYPES()["required"]
     assert AtlasSeedanceV15ProImageToVideoSpicy.RETURN_TYPES == ("STRING", "STRING")
 
-
 # --- Batch 2: Recent HOT models ---
-
 
 def test_veo3_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.veo3_t2v import AtlasVeo3TextToVideo
@@ -221,14 +195,12 @@ def test_veo3_t2v_node_metadata():
     assert AtlasVeo3TextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasVeo3TextToVideo.RETURN_NAMES
 
-
 def test_imagen4_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.imagen4_t2i import AtlasImagen4TextToImage
 
     assert "atlas_client" in AtlasImagen4TextToImage.INPUT_TYPES()["required"]
     assert AtlasImagen4TextToImage.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasImagen4TextToImage.RETURN_NAMES
-
 
 def test_imagen4_fast_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.imagen4_fast_t2i import AtlasImagen4FastTextToImage
@@ -237,14 +209,12 @@ def test_imagen4_fast_t2i_node_metadata():
     assert AtlasImagen4FastTextToImage.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasImagen4FastTextToImage.RETURN_NAMES
 
-
 def test_luma_ray2_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.luma_ray2_t2v import AtlasLumaRay2TextToVideo
 
     assert "atlas_client" in AtlasLumaRay2TextToVideo.INPUT_TYPES()["required"]
     assert AtlasLumaRay2TextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasLumaRay2TextToVideo.RETURN_NAMES
-
 
 def test_luma_ray2_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.luma_ray2_i2v import AtlasLumaRay2ImageToVideo
@@ -253,14 +223,12 @@ def test_luma_ray2_i2v_node_metadata():
     assert "image" in AtlasLumaRay2ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasLumaRay2ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_pika_v22_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.pika_v22_t2v import AtlasPikaV22TextToVideo
 
     assert "atlas_client" in AtlasPikaV22TextToVideo.INPUT_TYPES()["required"]
     assert AtlasPikaV22TextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasPikaV22TextToVideo.RETURN_NAMES
-
 
 def test_pixverse_v45_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.pixverse_v45_t2v import AtlasPixVerseV45TextToVideo
@@ -269,14 +237,12 @@ def test_pixverse_v45_t2v_node_metadata():
     assert AtlasPixVerseV45TextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasPixVerseV45TextToVideo.RETURN_NAMES
 
-
 def test_hailuo_02_t2v_pro_node_metadata():
     from src.atlascloud_comfyui.nodes.video.hailuo_02_t2v_pro import AtlasHailuo02T2VPro
 
     assert "atlas_client" in AtlasHailuo02T2VPro.INPUT_TYPES()["required"]
     assert AtlasHailuo02T2VPro.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasHailuo02T2VPro.RETURN_NAMES
-
 
 def test_sora2_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.sora2_i2v import AtlasSora2ImageToVideo
@@ -285,14 +251,12 @@ def test_sora2_i2v_node_metadata():
     assert "image" in AtlasSora2ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasSora2ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_kling_v25_turbo_pro_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.kling_v25_turbo_pro_t2v import AtlasKlingV25TurboProTextToVideo
 
     assert "atlas_client" in AtlasKlingV25TurboProTextToVideo.INPUT_TYPES()["required"]
     assert AtlasKlingV25TurboProTextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasKlingV25TurboProTextToVideo.RETURN_NAMES
-
 
 def test_hunyuan_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.hunyuan_t2v import AtlasHunyuanTextToVideo
@@ -301,9 +265,7 @@ def test_hunyuan_t2v_node_metadata():
     assert AtlasHunyuanTextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasHunyuanTextToVideo.RETURN_NAMES
 
-
 # --- Batch 3: Additional models ---
-
 
 def test_veo3_fast_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.veo3_fast_t2v import AtlasVeo3FastTextToVideo
@@ -312,14 +274,12 @@ def test_veo3_fast_t2v_node_metadata():
     assert AtlasVeo3FastTextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasVeo3FastTextToVideo.RETURN_NAMES
 
-
 def test_veo31_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.veo31_i2v import AtlasVeo31ImageToVideo
 
     assert "atlas_client" in AtlasVeo31ImageToVideo.INPUT_TYPES()["required"]
     assert "image" in AtlasVeo31ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasVeo31ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_veo3_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.veo3_i2v import AtlasVeo3ImageToVideo
@@ -328,13 +288,11 @@ def test_veo3_i2v_node_metadata():
     assert "image" in AtlasVeo3ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasVeo3ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_veo2_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.veo2_t2v import AtlasVeo2TextToVideo
 
     assert "atlas_client" in AtlasVeo2TextToVideo.INPUT_TYPES()["required"]
     assert AtlasVeo2TextToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_veo2_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.veo2_i2v import AtlasVeo2ImageToVideo
@@ -343,20 +301,17 @@ def test_veo2_i2v_node_metadata():
     assert "image" in AtlasVeo2ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasVeo2ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_luma_ray2_flash_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.luma_ray2_flash_t2v import AtlasLumaRay2FlashTextToVideo
 
     assert "atlas_client" in AtlasLumaRay2FlashTextToVideo.INPUT_TYPES()["required"]
     assert AtlasLumaRay2FlashTextToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_pika_v20_turbo_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.pika_v20_turbo_t2v import AtlasPikaV20TurboTextToVideo
 
     assert "atlas_client" in AtlasPikaV20TurboTextToVideo.INPUT_TYPES()["required"]
     assert AtlasPikaV20TurboTextToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_pika_v21_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.pika_v21_i2v import AtlasPikaV21ImageToVideo
@@ -365,14 +320,12 @@ def test_pika_v21_i2v_node_metadata():
     assert "image" in AtlasPikaV21ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasPikaV21ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_pixverse_v45_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.pixverse_v45_i2v import AtlasPixVerseV45ImageToVideo
 
     assert "atlas_client" in AtlasPixVerseV45ImageToVideo.INPUT_TYPES()["required"]
     assert "image" in AtlasPixVerseV45ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasPixVerseV45ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_hailuo_02_i2v_pro_node_metadata():
     from src.atlascloud_comfyui.nodes.video.hailuo_02_i2v_pro import AtlasHailuo02I2VPro
@@ -381,7 +334,6 @@ def test_hailuo_02_i2v_pro_node_metadata():
     assert "image" in AtlasHailuo02I2VPro.INPUT_TYPES()["required"]
     assert AtlasHailuo02I2VPro.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_sora2_i2v_pro_node_metadata():
     from src.atlascloud_comfyui.nodes.video.sora2_i2v_pro import AtlasSora2ImageToVideoPro
 
@@ -389,13 +341,11 @@ def test_sora2_i2v_pro_node_metadata():
     assert "image" in AtlasSora2ImageToVideoPro.INPUT_TYPES()["required"]
     assert AtlasSora2ImageToVideoPro.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_sora2_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.sora2_t2v import AtlasSora2TextToVideo
 
     assert "atlas_client" in AtlasSora2TextToVideo.INPUT_TYPES()["required"]
     assert AtlasSora2TextToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_kling_v25_turbo_pro_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.kling_v25_turbo_pro_i2v import AtlasKlingV25TurboProImageToVideo
@@ -404,14 +354,12 @@ def test_kling_v25_turbo_pro_i2v_node_metadata():
     assert "image" in AtlasKlingV25TurboProImageToVideo.INPUT_TYPES()["required"]
     assert AtlasKlingV25TurboProImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_hunyuan_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.hunyuan_i2v import AtlasHunyuanImageToVideo
 
     assert "atlas_client" in AtlasHunyuanImageToVideo.INPUT_TYPES()["required"]
     assert "image" in AtlasHunyuanImageToVideo.INPUT_TYPES()["required"]
     assert AtlasHunyuanImageToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_wan25_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.wan25_i2v import AtlasWAN25ImageToVideo
@@ -420,13 +368,11 @@ def test_wan25_i2v_node_metadata():
     assert "image" in AtlasWAN25ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasWAN25ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_imagen4_ultra_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.imagen4_ultra_t2i import AtlasImagen4UltraTextToImage
 
     assert "atlas_client" in AtlasImagen4UltraTextToImage.INPUT_TYPES()["required"]
     assert AtlasImagen4UltraTextToImage.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_imagen3_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.imagen3_t2i import AtlasImagen3TextToImage
@@ -434,13 +380,11 @@ def test_imagen3_t2i_node_metadata():
     assert "atlas_client" in AtlasImagen3TextToImage.INPUT_TYPES()["required"]
     assert AtlasImagen3TextToImage.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_ideogram_v3_quality_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.ideogram_v3_quality_t2i import AtlasIdeogramV3QualityTextToImage
 
     assert "atlas_client" in AtlasIdeogramV3QualityTextToImage.INPUT_TYPES()["required"]
     assert AtlasIdeogramV3QualityTextToImage.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_ideogram_v3_turbo_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.ideogram_v3_turbo_t2i import AtlasIdeogramV3TurboTextToImage
@@ -448,13 +392,11 @@ def test_ideogram_v3_turbo_t2i_node_metadata():
     assert "atlas_client" in AtlasIdeogramV3TurboTextToImage.INPUT_TYPES()["required"]
     assert AtlasIdeogramV3TurboTextToImage.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_luma_photon_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.luma_photon_t2i import AtlasLumaPhotonTextToImage
 
     assert "atlas_client" in AtlasLumaPhotonTextToImage.INPUT_TYPES()["required"]
     assert AtlasLumaPhotonTextToImage.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_luma_photon_flash_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.luma_photon_flash_t2i import AtlasLumaPhotonFlashTextToImage
@@ -462,16 +404,13 @@ def test_luma_photon_flash_t2i_node_metadata():
     assert "atlas_client" in AtlasLumaPhotonFlashTextToImage.INPUT_TYPES()["required"]
     assert AtlasLumaPhotonFlashTextToImage.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_recraft_v3_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.recraft_v3_t2i import AtlasRecraftV3TextToImage
 
     assert "atlas_client" in AtlasRecraftV3TextToImage.INPUT_TYPES()["required"]
     assert AtlasRecraftV3TextToImage.RETURN_TYPES == ("STRING", "STRING")
 
-
 # --- Batch 4: 2026-03-05 sync ---
-
 
 def test_imagen3_fast_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.imagen3_fast_t2i import AtlasImagen3FastTextToImage
@@ -480,7 +419,6 @@ def test_imagen3_fast_t2i_node_metadata():
     assert AtlasImagen3FastTextToImage.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasImagen3FastTextToImage.RETURN_NAMES
 
-
 def test_nano_banana_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana_t2i import AtlasNanoBananaTextToImage
 
@@ -488,13 +426,11 @@ def test_nano_banana_t2i_node_metadata():
     assert AtlasNanoBananaTextToImage.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasNanoBananaTextToImage.RETURN_NAMES
 
-
 def test_nano_banana_t2i_dev_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana_t2i_dev import AtlasNanoBananaTextToImageDeveloper
 
     assert "atlas_client" in AtlasNanoBananaTextToImageDeveloper.INPUT_TYPES()["required"]
     assert AtlasNanoBananaTextToImageDeveloper.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_nano_banana_edit_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana_edit import AtlasNanoBananaEdit
@@ -503,7 +439,6 @@ def test_nano_banana_edit_node_metadata():
     assert "images" in AtlasNanoBananaEdit.INPUT_TYPES()["required"]
     assert AtlasNanoBananaEdit.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_nano_banana_edit_dev_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana_edit_dev import AtlasNanoBananaEditDeveloper
 
@@ -511,13 +446,11 @@ def test_nano_banana_edit_dev_node_metadata():
     assert "images" in AtlasNanoBananaEditDeveloper.INPUT_TYPES()["required"]
     assert AtlasNanoBananaEditDeveloper.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_nano_banana_pro_t2i_dev_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana_pro_t2i_dev import AtlasNanoBananaProTextToImageDeveloper
 
     assert "atlas_client" in AtlasNanoBananaProTextToImageDeveloper.INPUT_TYPES()["required"]
     assert AtlasNanoBananaProTextToImageDeveloper.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_nano_banana_pro_edit_dev_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana_pro_edit_dev import AtlasNanoBananaProEditDeveloper
@@ -526,13 +459,11 @@ def test_nano_banana_pro_edit_dev_node_metadata():
     assert "images" in AtlasNanoBananaProEditDeveloper.INPUT_TYPES()["required"]
     assert AtlasNanoBananaProEditDeveloper.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_flux_schnell_t2i_node_metadata():
     from src.atlascloud_comfyui.nodes.image.flux_schnell_t2i import AtlasFluxSchnellTextToImage
 
     assert "atlas_client" in AtlasFluxSchnellTextToImage.INPUT_TYPES()["required"]
     assert AtlasFluxSchnellTextToImage.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_flux_kontext_dev_edit_node_metadata():
     from src.atlascloud_comfyui.nodes.image.flux_kontext_dev_edit import AtlasFluxKontextDevEdit
@@ -541,14 +472,12 @@ def test_flux_kontext_dev_edit_node_metadata():
     assert "image" in AtlasFluxKontextDevEdit.INPUT_TYPES()["required"]
     assert AtlasFluxKontextDevEdit.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_flux_kontext_dev_lora_edit_node_metadata():
     from src.atlascloud_comfyui.nodes.image.flux_kontext_dev_lora_edit import AtlasFluxKontextDevLoraEdit
 
     assert "atlas_client" in AtlasFluxKontextDevLoraEdit.INPUT_TYPES()["required"]
     assert "image" in AtlasFluxKontextDevLoraEdit.INPUT_TYPES()["required"]
     assert AtlasFluxKontextDevLoraEdit.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_wan25_image_edit_node_metadata():
     from src.atlascloud_comfyui.nodes.image.wan25_image_edit import AtlasWan25ImageEdit
@@ -557,14 +486,12 @@ def test_wan25_image_edit_node_metadata():
     assert "images" in AtlasWan25ImageEdit.INPUT_TYPES()["required"]
     assert AtlasWan25ImageEdit.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_kling_v16_i2v_standard_node_metadata():
     from src.atlascloud_comfyui.nodes.video.kling_v16_i2v_standard import AtlasKlingV16I2VStandard
 
     assert "atlas_client" in AtlasKlingV16I2VStandard.INPUT_TYPES()["required"]
     assert "image" in AtlasKlingV16I2VStandard.INPUT_TYPES()["required"]
     assert AtlasKlingV16I2VStandard.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_hailuo_02_standard_node_metadata():
     from src.atlascloud_comfyui.nodes.video.hailuo_02_i2v_standard import AtlasHailuo02I2VStandard
@@ -573,14 +500,12 @@ def test_hailuo_02_standard_node_metadata():
     assert "image" in AtlasHailuo02I2VStandard.INPUT_TYPES()["required"]
     assert AtlasHailuo02I2VStandard.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_qwen_image_t2i_plus_node_metadata():
     from src.atlascloud_comfyui.nodes.image.qwen_image_t2i_plus import AtlasQwenImageTextToImagePlus
 
     assert "atlas_client" in AtlasQwenImageTextToImagePlus.INPUT_TYPES()["required"]
     assert AtlasQwenImageTextToImagePlus.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasQwenImageTextToImagePlus.RETURN_NAMES
-
 
 def test_qwen_image_t2i_max_node_metadata():
     from src.atlascloud_comfyui.nodes.image.qwen_image_t2i_max import AtlasQwenImageTextToImageMax
@@ -589,14 +514,12 @@ def test_qwen_image_t2i_max_node_metadata():
     assert AtlasQwenImageTextToImageMax.RETURN_TYPES == ("STRING", "STRING")
     assert "image_url" in AtlasQwenImageTextToImageMax.RETURN_NAMES
 
-
 def test_seedance_v1_pro_fast_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_t2v import AtlasSeedanceV1ProFastTextToVideo
 
     assert "atlas_client" in AtlasSeedanceV1ProFastTextToVideo.INPUT_TYPES()["required"]
     assert AtlasSeedanceV1ProFastTextToVideo.RETURN_TYPES == ("STRING", "STRING")
     assert "video_url" in AtlasSeedanceV1ProFastTextToVideo.RETURN_NAMES
-
 
 def test_seedance_v1_pro_fast_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_i2v import AtlasSeedanceV1ProFastImageToVideo
@@ -605,13 +528,11 @@ def test_seedance_v1_pro_fast_i2v_node_metadata():
     assert "image" in AtlasSeedanceV1ProFastImageToVideo.INPUT_TYPES()["required"]
     assert AtlasSeedanceV1ProFastImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_wan25_fast_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.wan25_fast_t2v import AtlasWAN25TextToVideoFast
 
     assert "atlas_client" in AtlasWAN25TextToVideoFast.INPUT_TYPES()["required"]
     assert AtlasWAN25TextToVideoFast.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_wan25_fast_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.wan25_fast_i2v import AtlasWAN25ImageToVideoFast
@@ -620,13 +541,11 @@ def test_wan25_fast_i2v_node_metadata():
     assert "image" in AtlasWAN25ImageToVideoFast.INPUT_TYPES()["required"]
     assert AtlasWAN25ImageToVideoFast.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_van26_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
 
     assert "atlas_client" in AtlasVan26TextToVideo.INPUT_TYPES()["required"]
     assert AtlasVan26TextToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_van26_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.van26_i2v import AtlasVan26ImageToVideo
@@ -635,20 +554,17 @@ def test_van26_i2v_node_metadata():
     assert "image" in AtlasVan26ImageToVideo.INPUT_TYPES()["required"]
     assert AtlasVan26ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_vidu_reference_to_video_q1_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_reference_to_video_q1 import AtlasViduReferenceToVideoQ1
 
     assert "atlas_client" in AtlasViduReferenceToVideoQ1.INPUT_TYPES()["required"]
     assert AtlasViduReferenceToVideoQ1.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_vidu_reference_to_video_v2_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_reference_to_video_v2 import AtlasViduReferenceToVideoV2
 
     assert "atlas_client" in AtlasViduReferenceToVideoV2.INPUT_TYPES()["required"]
     assert AtlasViduReferenceToVideoV2.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_vidu_start_end_to_video_v2_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_start_end_to_video_v2 import AtlasViduStartEndToVideoV2
@@ -658,14 +574,12 @@ def test_vidu_start_end_to_video_v2_node_metadata():
     assert "end_image" in AtlasViduStartEndToVideoV2.INPUT_TYPES()["required"]
     assert AtlasViduStartEndToVideoV2.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_kling_v20_i2v_master_node_metadata():
     from src.atlascloud_comfyui.nodes.video.kling_v20_i2v_master import AtlasKlingV20I2VMaster
 
     assert "atlas_client" in AtlasKlingV20I2VMaster.INPUT_TYPES()["required"]
     assert "image" in AtlasKlingV20I2VMaster.INPUT_TYPES()["required"]
     assert AtlasKlingV20I2VMaster.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_veo3_fast_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.veo3_fast_i2v import AtlasVeo3FastImageToVideo
@@ -674,13 +588,11 @@ def test_veo3_fast_i2v_node_metadata():
     assert "image" in AtlasVeo3FastImageToVideo.INPUT_TYPES()["required"]
     assert AtlasVeo3FastImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_kling_v21_t2v_master_node_metadata():
     from src.atlascloud_comfyui.nodes.video.kling_v21_t2v_master import AtlasKlingV21T2VMaster
 
     assert "atlas_client" in AtlasKlingV21T2VMaster.INPUT_TYPES()["required"]
     assert AtlasKlingV21T2VMaster.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_kling_v20_t2v_master_node_metadata():
     from src.atlascloud_comfyui.nodes.video.kling_v20_t2v_master import AtlasKlingV20T2VMaster
@@ -690,7 +602,6 @@ def test_kling_v20_t2v_master_node_metadata():
 
 # --- 2026-03-19: Sync NEW models from /api/v1/models ---
 
-
 def test_nano_banana_pro_edit_ultra_node_metadata():
     from src.atlascloud_comfyui.nodes.image.nano_banana_pro_edit_ultra import AtlasNanoBananaProEditUltra
 
@@ -699,7 +610,6 @@ def test_nano_banana_pro_edit_ultra_node_metadata():
     assert "prompt" in AtlasNanoBananaProEditUltra.INPUT_TYPES()["required"]
     assert AtlasNanoBananaProEditUltra.RETURN_TYPES == ("STRING", "STRING")
 
-
 def test_vidu_q2_pro_fast_reference_to_video_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q2_pro_fast_reference_to_video import AtlasViduQ2ProFastReferenceToVideo
 
@@ -707,7 +617,6 @@ def test_vidu_q2_pro_fast_reference_to_video_node_metadata():
     assert "images" in AtlasViduQ2ProFastReferenceToVideo.INPUT_TYPES()["required"]
     assert "prompt" in AtlasViduQ2ProFastReferenceToVideo.INPUT_TYPES()["required"]
     assert AtlasViduQ2ProFastReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
-
 
 def test_vidu_q2_pro_fast_reference_to_video_with_audio_node_metadata():
     from src.atlascloud_comfyui.nodes.video.vidu_q2_pro_fast_reference_to_video_with_audio import (
@@ -718,3 +627,71 @@ def test_vidu_q2_pro_fast_reference_to_video_with_audio_node_metadata():
     assert "images" in AtlasViduQ2ProFastReferenceToVideoWithAudio.INPUT_TYPES()["required"]
     assert "prompt" in AtlasViduQ2ProFastReferenceToVideoWithAudio.INPUT_TYPES()["required"]
     assert AtlasViduQ2ProFastReferenceToVideoWithAudio.RETURN_TYPES == ("STRING", "STRING")
+
+# --- Batch 2026-03-30: GPT Image + Qwen Image 2.0 ---
+
+def test_openai_gpt_image_1_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_1_t2i import AtlasOpenAIGPTImage1TextToImage
+
+    assert "atlas_client" in AtlasOpenAIGPTImage1TextToImage.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage1TextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasOpenAIGPTImage1TextToImage.RETURN_NAMES
+
+def test_openai_gpt_image_1_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_1_edit import AtlasOpenAIGPTImage1Edit
+
+    assert "atlas_client" in AtlasOpenAIGPTImage1Edit.INPUT_TYPES()["required"]
+    assert "images" in AtlasOpenAIGPTImage1Edit.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage1Edit.RETURN_TYPES == ("STRING", "STRING")
+
+def test_openai_gpt_image_1_mini_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_1_mini_t2i import AtlasOpenAIGPTImage1MiniTextToImage
+
+    assert "atlas_client" in AtlasOpenAIGPTImage1MiniTextToImage.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage1MiniTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+def test_openai_gpt_image_1_mini_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_1_mini_edit import AtlasOpenAIGPTImage1MiniEdit
+
+    assert "atlas_client" in AtlasOpenAIGPTImage1MiniEdit.INPUT_TYPES()["required"]
+    assert "images" in AtlasOpenAIGPTImage1MiniEdit.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage1MiniEdit.RETURN_TYPES == ("STRING", "STRING")
+
+def test_openai_gpt_image_15_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_15_t2i import AtlasOpenAIGPTImage15TextToImage
+
+    assert "atlas_client" in AtlasOpenAIGPTImage15TextToImage.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage15TextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+def test_openai_gpt_image_15_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_15_edit import AtlasOpenAIGPTImage15Edit
+
+    assert "atlas_client" in AtlasOpenAIGPTImage15Edit.INPUT_TYPES()["required"]
+    assert "images" in AtlasOpenAIGPTImage15Edit.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage15Edit.RETURN_TYPES == ("STRING", "STRING")
+
+def test_qwen_image_20_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_20_t2i import AtlasQwenImage20TextToImage
+
+    assert "atlas_client" in AtlasQwenImage20TextToImage.INPUT_TYPES()["required"]
+    assert AtlasQwenImage20TextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+def test_qwen_image_20_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_20_edit import AtlasQwenImage20Edit
+
+    assert "atlas_client" in AtlasQwenImage20Edit.INPUT_TYPES()["required"]
+    assert "images" in AtlasQwenImage20Edit.INPUT_TYPES()["required"]
+    assert AtlasQwenImage20Edit.RETURN_TYPES == ("STRING", "STRING")
+
+def test_qwen_image_20_pro_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_20_pro_t2i import AtlasQwenImage20ProTextToImage
+
+    assert "atlas_client" in AtlasQwenImage20ProTextToImage.INPUT_TYPES()["required"]
+    assert AtlasQwenImage20ProTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+def test_qwen_image_20_pro_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_20_pro_edit import AtlasQwenImage20ProEdit
+
+    assert "atlas_client" in AtlasQwenImage20ProEdit.INPUT_TYPES()["required"]
+    assert "images" in AtlasQwenImage20ProEdit.INPUT_TYPES()["required"]
+    assert AtlasQwenImage20ProEdit.RETURN_TYPES == ("STRING", "STRING")


### PR DESCRIPTION
## Summary\n- Add ComfyUI nodes for OpenAI GPT Image (gpt-image-1, gpt-image-1-mini, gpt-image-1.5)\n- Add ComfyUI nodes for Qwen Image 2.0 + Qwen Image 2.0 Pro (T2I + Edit)\n\n## Reason\n- Models are returned by AtlasCloud /api/v1/models and are visual generation models.\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/ -v (includes optional E2E; some are skipped by design)\n\n🤖 Generated with OpenClaw