### PR TITLE
feat: add nodes for Seedance 2.0, WAN2.7, VEO3.1 Lite, Vidu Q3 R2V

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3 Text-to-Video | google/veo3 |
 | AtlasCloud VEO3 Fast Text-to-Video | google/veo3-fast |
 | AtlasCloud VEO3.1 Text-to-Video | google/veo3.1/text-to-video |
+| AtlasCloud VEO3.1 Lite Text-to-Video | google/veo3.1-lite/text-to-video |
 | AtlasCloud VEO3.1 Fast Text-to-Video | google/veo3.1-fast/text-to-video |
 | AtlasCloud VEO2 Text-to-Video | google/veo2 |
 | AtlasCloud WAN2.6 Text-to-Video | alibaba/wan-2.6/text-to-video |
+| AtlasCloud WAN2.7 Text-to-Video | alibaba/wan-2.7/text-to-video |
 | AtlasCloud WAN2.6 Video-to-Video | alibaba/wan-2.6/video-to-video |
 | AtlasCloud Kling Video O3 Pro Text-to-Video | kwaivgi/kling-video-o3-pro/text-to-video |
 | AtlasCloud Kling Video O3 Std Text-to-Video | kwaivgi/kling-video-o3-std/text-to-video |
@@ -119,6 +121,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedance V1 Lite T2V 1080p | bytedance/seedance-v1-lite-t2v-1080p |
 | AtlasCloud Seedance V1 Lite T2V 720p | bytedance/seedance-v1-lite-t2v-720p |
 | AtlasCloud Seedance V1.5 Pro Text-to-Video | bytedance/seedance-v1.5-pro/text-to-video |
+| AtlasCloud Seedance 2.0 Text-to-Video | bytedance/seedance-2.0/text-to-video |
+| AtlasCloud Seedance 2.0 Fast Text-to-Video | bytedance/seedance-2.0-fast/text-to-video |
 | AtlasCloud Seedance V1.5 Pro Text-to-Video Fast | bytedance/seedance-v1.5-pro/text-to-video-fast |
 | AtlasCloud Hunyuan Text-to-Video | atlascloud/hunyuan-video/t2v |
 
@@ -130,7 +134,13 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3 Fast Image-to-Video | google/veo3-fast/image-to-video |
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
 | AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |
+| AtlasCloud Seedance 2.0 Reference-to-Video | bytedance/seedance-2.0/reference-to-video |
+| AtlasCloud Seedance 2.0 Fast Reference-to-Video | bytedance/seedance-2.0-fast/reference-to-video |
+| AtlasCloud Vidu Q3 Reference-to-Video | vidu/q3/reference-to-video |
+| AtlasCloud Vidu Q3-Mix Reference-to-Video | vidu/q3-mix/reference-to-video |
 | AtlasCloud VEO3.1 Image-to-Video | google/veo3.1/image-to-video |
+| AtlasCloud VEO3.1 Lite Image-to-Video | google/veo3.1-lite/image-to-video |
+| AtlasCloud VEO3.1 Lite Start-End Frame-to-Video | google/veo3.1-lite/start-end-frame-to-video |
 | AtlasCloud VEO2 Image-to-Video | google/veo2/image-to-video |
 | AtlasCloud WAN2.5 Image-to-Video | alibaba/wan-2.5/image-to-video |
 | AtlasCloud WAN2.5 Image-to-Video Fast | alibaba/wan-2.5/image-to-video-fast |
@@ -161,6 +171,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V1.6 I2V Standard | kwaivgi/kling-v1.6-i2v-standard |
 | AtlasCloud Kling Effects | kwaivgi/kling-effects |
 | AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
+| AtlasCloud WAN2.7 Image-to-Video | alibaba/wan-2.7/image-to-video |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
 | AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |
 | AtlasCloud Kling Video O3 Std Image-to-Video | kwaivgi/kling-video-o3-std/image-to-video |
@@ -182,6 +193,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V2.6 Pro Image-to-Video | kwaivgi/kling-v2.6-pro/image-to-video |
 | AtlasCloud Kling Video O1 Image-to-Video | kwaivgi/kling-video-o1/image-to-video |
 | AtlasCloud Seedance V1.5 Pro Image-to-Video | bytedance/seedance-v1.5-pro/image-to-video |
+| AtlasCloud Seedance 2.0 Image-to-Video | bytedance/seedance-2.0/image-to-video |
+| AtlasCloud Seedance 2.0 Fast Image-to-Video | bytedance/seedance-2.0-fast/image-to-video |
 | AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy) | bytedance/seedance-v1.5-pro/image-to-video-spicy |
 | AtlasCloud Seedance V1 Lite I2V 1080p | bytedance/seedance-v1-lite-i2v-1080p |
 | AtlasCloud Seedance V1 Lite I2V 720p | bytedance/seedance-v1-lite-i2v-720p |
@@ -247,6 +260,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 |------|-------|
 | AtlasCloud Kling Video O3 Pro Video-Edit | kwaivgi/kling-video-o3-pro/video-edit |
 | AtlasCloud Kling Video O3 Std Video-Edit | kwaivgi/kling-video-o3-std/video-edit |
+| AtlasCloud WAN2.7 Video-Edit | alibaba/wan-2.7/video-edit |
 
 ### Image Edit
 

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_7_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_7_i2v.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image (URL/base64)"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Prompt (optional)"}),
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720P", "1080P"], {"default": "1080P", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "prompt_extend": ("BOOLEAN", {"default": True, "tooltip": "Auto prompt expansion"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Optional audio URL"}),
+                "last_image": ("STRING", {"default": "", "tooltip": "Optional last frame image (URL/base64)"}),
+                "video": ("STRING", {"default": "", "tooltip": "(Optional) video URL"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "",
+        negative_prompt: str = "",
+        duration: int = 5,
+        resolution: str = "1080P",
+        seed: int = -1,
+        prompt_extend: bool = True,
+        audio: str = "",
+        last_image: str = "",
+        video: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud WAN2.7 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.7/image-to-video",
+            "image": image,
+            "duration": int(duration),
+            "resolution": resolution,
+            "prompt_extend": bool(prompt_extend),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        a = (audio or "").strip()
+        if a:
+            payload["audio"] = a
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        v = (video or "").strip()
+        if v:
+            payload["video"] = v
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_7_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_7_r2v.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ image URLs/base64, one per line"},
+                ),
+                "videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ video URLs, one per line"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720P", "1080P"], {"default": "1080P", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "9:16", "1:1", "4:3", "3:4"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "prompt_extend": ("BOOLEAN", {"default": False, "tooltip": "Auto prompt expansion"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Optional audio URL"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        videos: str,
+        negative_prompt: str = "",
+        duration: int = 5,
+        resolution: str = "1080P",
+        ratio: str = "16:9",
+        seed: int = -1,
+        prompt_extend: bool = False,
+        audio: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN2.7 Reference-to-Video")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        video_list: List[str] = [v.strip() for v in (videos or "").splitlines() if v.strip()]
+        if not image_list and not video_list:
+            raise RuntimeError("Provide at least one image or video reference")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.7/reference-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "prompt_extend": bool(prompt_extend),
+        }
+
+        if image_list:
+            payload["images"] = image_list
+        if video_list:
+            payload["videos"] = video_list
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        a = (audio or "").strip()
+        if a:
+            payload["audio"] = a
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_7_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_7_t2v.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720P", "1080P"], {"default": "1080P", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "9:16", "1:1", "4:3", "3:4"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "prompt_extend": ("BOOLEAN", {"default": True, "tooltip": "Auto prompt expansion"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Optional audio URL"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        negative_prompt: str = "",
+        duration: int = 5,
+        resolution: str = "1080P",
+        ratio: str = "16:9",
+        seed: int = -1,
+        prompt_extend: bool = True,
+        audio: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN2.7 Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.7/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "prompt_extend": bool(prompt_extend),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        a = (audio or "").strip()
+        if a:
+            payload["audio"] = a
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_7_video_edit.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_7_video_edit.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27VideoEdit:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video": ("STRING", {"default": "", "tooltip": "Input video URL"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Prompt (optional)"}),
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "duration": ("INT", {"default": 0, "min": 0, "max": 60, "tooltip": "Optional duration"}),
+                "resolution": (["720P", "1080P"], {"default": "1080P", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "9:16", "1:1", "4:3", "3:4"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "prompt_extend": ("BOOLEAN", {"default": True, "tooltip": "Auto prompt expansion"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Optional audio URL"}),
+                "images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "Optional images, one per line"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video: str,
+        prompt: str = "",
+        negative_prompt: str = "",
+        duration: int = 0,
+        resolution: str = "1080P",
+        ratio: str = "16:9",
+        seed: int = -1,
+        prompt_extend: bool = True,
+        audio: str = "",
+        images: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required for AtlasCloud WAN2.7 Video-Edit")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.7/video-edit",
+            "video": video,
+            "resolution": resolution,
+            "ratio": ratio,
+            "prompt_extend": bool(prompt_extend),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        if int(duration) > 0:
+            payload["duration"] = int(duration)
+
+        a = (audio or "").strip()
+        if a:
+            payload["audio"] = a
+
+        if image_list:
+            payload["images"] = image_list
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_i2v.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20FastImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {"default": "", "tooltip": "First frame image (URL or base64)"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "last_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional last frame image (URL/base64)"},
+                ),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "The scene comes alive with gentle motion and cinematic lighting",
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        last_image: str = "",
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Seedance 2.0 Fast Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-fast/image-to-video",
+            "image": image,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_r2v.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20FastReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "reference_images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ image URLs/base64, one per line"},
+                ),
+                "reference_videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ video URLs, one per line"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The character in image 1 dances gracefully to the music",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "reference_audio": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional reference audio URL"},
+                ),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        reference_images: str,
+        reference_videos: str,
+        prompt: str = "The character in image 1 dances gracefully to the music",
+        reference_audio: str = "",
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        ref_vids: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
+        if not ref_imgs and not ref_vids:
+            raise RuntimeError("Provide at least one reference image or reference video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-fast/reference-to-video",
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        ra = (reference_audio or "").strip()
+        if ra:
+            payload["reference_audio"] = ra
+
+        if ref_imgs:
+            payload["reference_images"] = ref_imgs
+        if ref_vids:
+            payload["reference_videos"] = ref_vids
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_t2v.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20FastTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "A golden retriever running on a sunny beach, waves crashing in the background, cinematic lighting",
+                        "tooltip": "Text prompt",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Seedance 2.0 Fast Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-fast/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_i2v.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "First frame image (URL or data:image/...;base64,...) ",
+                    },
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "last_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional last frame image (URL/base64)"},
+                ),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "The scene comes alive with gentle motion and cinematic lighting",
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        last_image: str = "",
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Seedance 2.0 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0/image-to-video",
+            "image": image,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_r2v.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "reference_images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ image URLs/base64, one per line"},
+                ),
+                "reference_videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ video URLs, one per line"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The character in image 1 dances gracefully to the music",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "reference_audio": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional reference audio URL"},
+                ),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        reference_images: str,
+        reference_videos: str,
+        prompt: str = "The character in image 1 dances gracefully to the music",
+        reference_audio: str = "",
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        ref_vids: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
+        if not ref_imgs and not ref_vids:
+            raise RuntimeError("Provide at least one reference image or reference video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0/reference-to-video",
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        ra = (reference_audio or "").strip()
+        if ra:
+            payload["reference_audio"] = ra
+
+        if ref_imgs:
+            payload["reference_images"] = ref_imgs
+        if ref_vids:
+            payload["reference_videos"] = ref_vids
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_t2v.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "A golden retriever running on a sunny beach, waves crashing in the background, cinematic lighting",
+                        "tooltip": "Text prompt",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "web_search": ("BOOLEAN", {"default": False, "tooltip": "Enable web search (seedance-2.0 only)"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        web_search: bool = False,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Seedance 2.0 Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "web_search": bool(web_search),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_veo31_lite_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_veo31_lite_i2v.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeo31LiteImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image (URL/base64)"}),
+            },
+            "optional": {
+                "duration": ([4, 6, 8], {"default": 8, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        duration: int = 8,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud VEO3.1 Lite Image-to-Video")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud VEO3.1 Lite Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/veo3.1-lite/image-to-video",
+            "prompt": prompt,
+            "image": image,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_veo31_lite_start_end_frame_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_veo31_lite_start_end_frame_t2v.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeo31LiteStartEndFrameToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Start frame image (URL/base64)"}),
+                "last_image": ("STRING", {"default": "", "tooltip": "End frame image (URL/base64)"}),
+            },
+            "optional": {
+                "duration": ([4, 6, 8], {"default": 8, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        last_image: str,
+        duration: int = 8,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud VEO3.1 Lite Start-End Frame-to-Video")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud VEO3.1 Lite Start-End Frame-to-Video")
+
+        last_image = (last_image or "").strip()
+        if not last_image:
+            raise RuntimeError("last_image is required for AtlasCloud VEO3.1 Lite Start-End Frame-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/veo3.1-lite/start-end-frame-to-video",
+            "prompt": prompt,
+            "image": image,
+            "last_image": last_image,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_veo31_lite_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_veo31_lite_t2v.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeo31LiteTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "duration": ([4, 6, 8], {"default": 8, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 8,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud VEO3.1 Lite Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/veo3.1-lite/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_mix_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_mix_r2v.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3MixReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "tooltip": "1+ images, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement amplitude"},
+                ),
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (
+                    ["16:9", "9:16", "3:4", "4:3", "1:1"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "Seed"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        movement_amplitude: str = "auto",
+        duration: float = 5.0,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        seed: int = 0,
+        generate_audio: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Vidu Q3-Mix Reference-to-Video")
+
+        imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
+        if not imgs:
+            raise RuntimeError("images is required (provide 1+ lines)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3-mix/reference-to-video",
+            "images": imgs,
+            "prompt": prompt,
+            "movement_amplitude": movement_amplitude,
+            "duration": float(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "seed": int(seed),
+            "generate_audio": bool(generate_audio),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_r2v.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ3ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "tooltip": "1+ images, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "movement_amplitude": (
+                    ["auto", "small", "medium", "large"],
+                    {"default": "auto", "tooltip": "Movement amplitude"},
+                ),
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (
+                    ["16:9", "9:16", "3:4", "4:3", "1:1"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "Seed"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        movement_amplitude: str = "auto",
+        duration: float = 5.0,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        seed: int = 0,
+        generate_audio: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Vidu Q3 Reference-to-Video")
+
+        imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
+        if not imgs:
+            raise RuntimeError("images is required (provide 1+ lines)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q3/reference-to-video",
+            "images": imgs,
+            "prompt": prompt,
+            "movement_amplitude": movement_amplitude,
+            "duration": float(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "seed": int(seed),
+            "generate_audio": bool(generate_audio),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -209,6 +209,22 @@ from atlascloud_comfyui.nodes.video.hailuo_02_t2v_standard import AtlasHailuo02T
 from atlascloud_comfyui.nodes.video.seedance_v1_lite_t2v_1080p import AtlasSeedanceV1LiteT2V1080p
 from atlascloud_comfyui.nodes.video.seedance_v1_lite_t2v_720p import AtlasSeedanceV1LiteT2V720p
 from atlascloud_comfyui.nodes.video.seedance_v1_lite_i2v_1080p import AtlasSeedanceV1LiteI2V1080p
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_t2v import AtlasSeedance20TextToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_i2v import AtlasSeedance20ImageToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_r2v import AtlasSeedance20ReferenceToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_t2v import AtlasSeedance20FastTextToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_i2v import AtlasSeedance20FastImageToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_r2v import AtlasSeedance20FastReferenceToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_t2v import AtlasWan27TextToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_i2v import AtlasWan27ImageToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_r2v import AtlasWan27ReferenceToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_video_edit import AtlasWan27VideoEdit
+from atlascloud_comfyui.nodes.video.google_veo31_lite_t2v import AtlasVeo31LiteTextToVideo
+from atlascloud_comfyui.nodes.video.google_veo31_lite_i2v import AtlasVeo31LiteImageToVideo
+from atlascloud_comfyui.nodes.video.google_veo31_lite_start_end_frame_t2v import AtlasVeo31LiteStartEndFrameToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_r2v import AtlasViduQ3ReferenceToVideo
+from atlascloud_comfyui.nodes.video.vidu_q3_mix_r2v import AtlasViduQ3MixReferenceToVideo
+
 from atlascloud_comfyui.nodes.video.bytedance_seedance_v1_lite_t2v_480p import AtlasBytedanceSeedanceV1LiteT2V480p
 from atlascloud_comfyui.nodes.video.bytedance_seedance_v1_lite_i2v_720p import AtlasBytedanceSeedanceV1LiteI2V720p
 from atlascloud_comfyui.nodes.video.bytedance_seedance_v1_lite_i2v_480p import AtlasBytedanceSeedanceV1LiteI2V480p
@@ -264,6 +280,22 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Sora 2 Text-to-Video Pro": AtlasSora2TextToVideoPro,
     "AtlasCloud Seedance V1.5 Pro Text-to-Video": AtlasSeedanceV15ProTextToVideo,
     "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast": AtlasSeedanceV15ProTextToVideoFast,
+    "AtlasCloud Seedance 2.0 Text-to-Video": AtlasSeedance20TextToVideo,
+    "AtlasCloud Seedance 2.0 Image-to-Video": AtlasSeedance20ImageToVideo,
+    "AtlasCloud Seedance 2.0 Reference-to-Video": AtlasSeedance20ReferenceToVideo,
+    "AtlasCloud Seedance 2.0 Fast Text-to-Video": AtlasSeedance20FastTextToVideo,
+    "AtlasCloud Seedance 2.0 Fast Image-to-Video": AtlasSeedance20FastImageToVideo,
+    "AtlasCloud Seedance 2.0 Fast Reference-to-Video": AtlasSeedance20FastReferenceToVideo,
+    "AtlasCloud WAN2.7 Text-to-Video": AtlasWan27TextToVideo,
+    "AtlasCloud WAN2.7 Image-to-Video": AtlasWan27ImageToVideo,
+    "AtlasCloud WAN2.7 Reference-to-Video": AtlasWan27ReferenceToVideo,
+    "AtlasCloud WAN2.7 Video-Edit": AtlasWan27VideoEdit,
+    "AtlasCloud VEO3.1 Lite Text-to-Video": AtlasVeo31LiteTextToVideo,
+    "AtlasCloud VEO3.1 Lite Image-to-Video": AtlasVeo31LiteImageToVideo,
+    "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video": AtlasVeo31LiteStartEndFrameToVideo,
+    "AtlasCloud Vidu Q3 Reference-to-Video": AtlasViduQ3ReferenceToVideo,
+    "AtlasCloud Vidu Q3-Mix Reference-to-Video": AtlasViduQ3MixReferenceToVideo,
+
     "AtlasCloud Seedance V1.5 Pro Image-to-Video": AtlasSeedanceV15ProImageToVideo,
     "AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy)": AtlasSeedanceV15ProImageToVideoSpicy,
     "AtlasCloud Seedance V1.5 Pro Image-to-Video Fast": AtlasSeedanceV15ProImageToVideoFast,
@@ -470,6 +502,22 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Hailuo 2.3 Pro Text-to-Video": "AtlasCloud Hailuo 2.3 Pro Text-to-Video",
     "AtlasCloud Sora 2 Text-to-Video Pro": "AtlasCloud Sora 2 Text-to-Video Pro",
     "AtlasCloud Seedance V1.5 Pro Text-to-Video": "AtlasCloud Seedance V1.5 Pro Text-to-Video",
+    "AtlasCloud Seedance 2.0 Text-to-Video": "AtlasCloud Seedance 2.0 Text-to-Video",
+    "AtlasCloud Seedance 2.0 Image-to-Video": "AtlasCloud Seedance 2.0 Image-to-Video",
+    "AtlasCloud Seedance 2.0 Reference-to-Video": "AtlasCloud Seedance 2.0 Reference-to-Video",
+    "AtlasCloud Seedance 2.0 Fast Text-to-Video": "AtlasCloud Seedance 2.0 Fast Text-to-Video",
+    "AtlasCloud Seedance 2.0 Fast Image-to-Video": "AtlasCloud Seedance 2.0 Fast Image-to-Video",
+    "AtlasCloud Seedance 2.0 Fast Reference-to-Video": "AtlasCloud Seedance 2.0 Fast Reference-to-Video",
+    "AtlasCloud WAN2.7 Text-to-Video": "AtlasCloud WAN2.7 Text-to-Video",
+    "AtlasCloud WAN2.7 Image-to-Video": "AtlasCloud WAN2.7 Image-to-Video",
+    "AtlasCloud WAN2.7 Reference-to-Video": "AtlasCloud WAN2.7 Reference-to-Video",
+    "AtlasCloud WAN2.7 Video-Edit": "AtlasCloud WAN2.7 Video-Edit",
+    "AtlasCloud VEO3.1 Lite Text-to-Video": "AtlasCloud VEO3.1 Lite Text-to-Video",
+    "AtlasCloud VEO3.1 Lite Image-to-Video": "AtlasCloud VEO3.1 Lite Image-to-Video",
+    "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video": "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video",
+    "AtlasCloud Vidu Q3 Reference-to-Video": "AtlasCloud Vidu Q3 Reference-to-Video",
+    "AtlasCloud Vidu Q3-Mix Reference-to-Video": "AtlasCloud Vidu Q3-Mix Reference-to-Video",
+
     "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast": "AtlasCloud Seedance V1.5 Pro Text-to-Video Fast",
     "AtlasCloud Seedance V1.5 Pro Image-to-Video": "AtlasCloud Seedance V1.5 Pro Image-to-Video",
     "AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy)": "AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy)",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -186,6 +186,137 @@ def test_seedance_v15_pro_i2v_spicy_node_metadata():
     assert "image" in AtlasSeedanceV15ProImageToVideoSpicy.INPUT_TYPES()["required"]
     assert AtlasSeedanceV15ProImageToVideoSpicy.RETURN_TYPES == ("STRING", "STRING")
 
+
+# --- Batch 1.5: API high-priority models (2026-04-08) ---
+
+def test_seedance_20_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_t2v import AtlasSeedance20TextToVideo
+
+    assert "atlas_client" in AtlasSeedance20TextToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasSeedance20TextToVideo.INPUT_TYPES()["required"]
+    assert AtlasSeedance20TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_i2v import AtlasSeedance20ImageToVideo
+
+    assert "atlas_client" in AtlasSeedance20ImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasSeedance20ImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasSeedance20ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_r2v import AtlasSeedance20ReferenceToVideo
+
+    assert "atlas_client" in AtlasSeedance20ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "reference_images" in AtlasSeedance20ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "reference_videos" in AtlasSeedance20ReferenceToVideo.INPUT_TYPES()["required"]
+    assert AtlasSeedance20ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_fast_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_t2v import AtlasSeedance20FastTextToVideo
+
+    assert "atlas_client" in AtlasSeedance20FastTextToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasSeedance20FastTextToVideo.INPUT_TYPES()["required"]
+    assert AtlasSeedance20FastTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_fast_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_i2v import AtlasSeedance20FastImageToVideo
+
+    assert "atlas_client" in AtlasSeedance20FastImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasSeedance20FastImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasSeedance20FastImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_fast_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_r2v import AtlasSeedance20FastReferenceToVideo
+
+    assert "atlas_client" in AtlasSeedance20FastReferenceToVideo.INPUT_TYPES()["required"]
+    assert "reference_images" in AtlasSeedance20FastReferenceToVideo.INPUT_TYPES()["required"]
+    assert "reference_videos" in AtlasSeedance20FastReferenceToVideo.INPUT_TYPES()["required"]
+    assert AtlasSeedance20FastReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan27_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_wan_2_7_t2v import AtlasWan27TextToVideo
+
+    assert "atlas_client" in AtlasWan27TextToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan27TextToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan27TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan27_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_wan_2_7_i2v import AtlasWan27ImageToVideo
+
+    assert "atlas_client" in AtlasWan27ImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan27ImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan27ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan27_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_wan_2_7_r2v import AtlasWan27ReferenceToVideo
+
+    assert "atlas_client" in AtlasWan27ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan27ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "images" in AtlasWan27ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "videos" in AtlasWan27ReferenceToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan27ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan27_video_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_wan_2_7_video_edit import AtlasWan27VideoEdit
+
+    assert "atlas_client" in AtlasWan27VideoEdit.INPUT_TYPES()["required"]
+    assert "video" in AtlasWan27VideoEdit.INPUT_TYPES()["required"]
+    assert AtlasWan27VideoEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_veo31_lite_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_veo31_lite_t2v import AtlasVeo31LiteTextToVideo
+
+    assert "atlas_client" in AtlasVeo31LiteTextToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasVeo31LiteTextToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeo31LiteTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_veo31_lite_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_veo31_lite_i2v import AtlasVeo31LiteImageToVideo
+
+    assert "atlas_client" in AtlasVeo31LiteImageToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasVeo31LiteImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasVeo31LiteImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeo31LiteImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_veo31_lite_start_end_frame_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_veo31_lite_start_end_frame_t2v import AtlasVeo31LiteStartEndFrameToVideo
+
+    assert "atlas_client" in AtlasVeo31LiteStartEndFrameToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasVeo31LiteStartEndFrameToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasVeo31LiteStartEndFrameToVideo.INPUT_TYPES()["required"]
+    assert "last_image" in AtlasVeo31LiteStartEndFrameToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeo31LiteStartEndFrameToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q3_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_r2v import AtlasViduQ3ReferenceToVideo
+
+    assert "atlas_client" in AtlasViduQ3ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasViduQ3ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "images" in AtlasViduQ3ReferenceToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q3_mix_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q3_mix_r2v import AtlasViduQ3MixReferenceToVideo
+
+    assert "atlas_client" in AtlasViduQ3MixReferenceToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasViduQ3MixReferenceToVideo.INPUT_TYPES()["required"]
+    assert "images" in AtlasViduQ3MixReferenceToVideo.INPUT_TYPES()["required"]
+    assert AtlasViduQ3MixReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
 # --- Batch 2: Recent HOT models ---
 
 def test_veo3_t2v_node_metadata():


### PR DESCRIPTION
## Summary\n- Add 15 new AtlasCloud ComfyUI nodes (Video)\n  - Seedance 2.0: T2V / I2V / R2V\n  - Seedance 2.0 Fast: T2V / I2V / R2V\n  - WAN2.7: T2V / I2V / R2V / Video-Edit\n  - VEO3.1 Lite: T2V / I2V / Start-End Frame-to-Video\n  - Vidu Q3: Reference-to-Video (+ Q3-Mix)\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/ -v\n- [x] E2E manual (keyed): Seedance2.0 T2V/I2V, WAN2.7 T2V, VEO3.1 Lite T2V/I2V, Vidu Q3 R2V\n- [ ] Video-edit E2E (needs ATLASCLOUD_E2E_VIDEO_URL; optional)\n\n🤖 Generated with OpenClaw