### PR TITLE
Sync new AtlasCloud models → ComfyUI nodes (2026-04-08)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,12 +215,16 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA | atlascloud/wan-2.2-turbo-spicy/image-to-video-lora |
 | AtlasCloud WAN2.2 Spicy Image-to-Video LoRA | alibaba/wan-2.2-spicy/image-to-video-lora |
 | AtlasCloud Hunyuan Image-to-Video | atlascloud/hunyuan-video/i2v |
+| AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video | atlascloud/wan-2.2/image-to-video |
+| AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video LoRA | atlascloud/wan-2.2/image-to-video-lora |
 
 ### Text-to-Image (T2I)
 
 | Node | Model |
 |------|-------|
 | AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
+| AtlasCloud WAN2.7 Text-to-Image | alibaba/wan-2.7/text-to-image |
+| AtlasCloud WAN2.7 Pro Text-to-Image | alibaba/wan-2.7-pro/text-to-image |
 | AtlasCloud WAN2.5 Text-to-Image | alibaba/wan-2.5/text-to-image |
 | AtlasCloud Imagen4 Text-to-Image | google/imagen4 |
 | AtlasCloud Imagen4 Fast Text-to-Image | google/imagen4-fast |
@@ -254,6 +258,12 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
 
+### Video Extend
+
+| Node | Model |
+|------|-------|
+| AtlasCloud WAN2.2 Spicy Video Extend | alibaba/wan-2.2-spicy/video-extend |
+
 ### Video Edit
 
 | Node | Model |
@@ -271,6 +281,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |
 | AtlasCloud Seedream V5.0 Lite Edit Sequential | bytedance/seedream-v5.0-lite/edit-sequential |
 | AtlasCloud WAN2.6 Image-Edit | alibaba/wan-2.6/image-edit |
+| AtlasCloud WAN2.7 Image-Edit | alibaba/wan-2.7/image-edit |
+| AtlasCloud WAN2.7 Pro Image-Edit | alibaba/wan-2.7-pro/image-edit |
 | AtlasCloud WAN2.5 Image-Edit | alibaba/wan-2.5/image-edit |
 | AtlasCloud Seedream V4 Edit | bytedance/seedream-v4/edit |
 | AtlasCloud Seedream V4 Edit Sequential | bytedance/seedream-v4/edit-sequential |

--- a/src/atlascloud_comfyui/nodes/image/alibaba_wan_2_7_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/alibaba_wan_2_7_edit.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27ImageEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "1+ image URLs/base64, one per line"},
+                ),
+            },
+            "optional": {
+                "size": (
+                    ["1K", "2K"],
+                    {"default": "2K", "tooltip": "Output resolution"},
+                ),
+                "thinking_mode": ("BOOLEAN", {"default": True, "tooltip": "Enable thinking mode"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str = "2K",
+        thinking_mode: bool = True,
+        seed: int = -1,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba WAN2.7 Image Edit")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (provide 1+ lines)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.7/image-edit",
+            "prompt": prompt,
+            "images": image_list,
+            "size": size,
+            "n": 1,
+            "thinking_mode": bool(thinking_mode),
+            "seed": int(seed),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            # Some schemas declare outputs as objects; best-effort common fields.
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/alibaba_wan_2_7_pro_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/alibaba_wan_2_7_pro_edit.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27ProImageEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "1+ image URLs/base64, one per line"},
+                ),
+            },
+            "optional": {
+                "size": (
+                    ["1K", "2K"],
+                    {"default": "2K", "tooltip": "Output resolution"},
+                ),
+                "thinking_mode": ("BOOLEAN", {"default": True, "tooltip": "Enable thinking mode"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str = "2K",
+        thinking_mode: bool = True,
+        seed: int = -1,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba WAN2.7 Pro Image Edit")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (provide 1+ lines)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.7-pro/image-edit",
+            "prompt": prompt,
+            "images": image_list,
+            "size": size,
+            "n": 1,
+            "thinking_mode": bool(thinking_mode),
+            "seed": int(seed),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            # Some schemas declare outputs as objects; best-effort common fields.
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/alibaba_wan_2_7_pro_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/alibaba_wan_2_7_pro_t2i.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27ProTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "size": (
+                    ["1K", "2K", "4K"],
+                    {"default": "2K", "tooltip": "Output resolution"},
+                ),
+                "color_palette_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `color_palette`",
+                    },
+                ),
+                "thinking_mode": ("BOOLEAN", {"default": True, "tooltip": "Enable thinking mode"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "2K",
+        color_palette_json: str = "[]",
+        thinking_mode: bool = True,
+        seed: int = -1,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba WAN2.7 Pro Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.7-pro/text-to-image",
+            "prompt": prompt,
+            "size": size,
+            "n": 1,
+            "thinking_mode": bool(thinking_mode),
+            "seed": int(seed),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        cp = (color_palette_json or "").strip()
+        if cp and cp != "[]":
+            import json
+
+            try:
+                arr = json.loads(cp)
+            except Exception as e:
+                raise RuntimeError(f"Invalid color_palette_json. Must be a JSON array. Error: {e}") from e
+            if not isinstance(arr, list):
+                raise RuntimeError("color_palette_json must be a JSON array")
+            if arr:
+                payload["color_palette"] = arr
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/alibaba_wan_2_7_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/alibaba_wan_2_7_t2i.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "size": (
+                    ["1K", "2K"],
+                    {"default": "2K", "tooltip": "Output resolution"},
+                ),
+                "color_palette_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `color_palette`",
+                    },
+                ),
+                "thinking_mode": ("BOOLEAN", {"default": True, "tooltip": "Enable thinking mode"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "2K",
+        color_palette_json: str = "[]",
+        thinking_mode: bool = True,
+        seed: int = -1,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba WAN2.7 Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.7/text-to-image",
+            "prompt": prompt,
+            "size": size,
+            "n": 1,
+            "thinking_mode": bool(thinking_mode),
+            "seed": int(seed),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        cp = (color_palette_json or "").strip()
+        if cp and cp != "[]":
+            import json
+
+            try:
+                arr = json.loads(cp)
+            except Exception as e:
+                raise RuntimeError(f"Invalid color_palette_json. Must be a JSON array. Error: {e}") from e
+            if not isinstance(arr, list):
+                raise RuntimeError("color_palette_json must be a JSON array")
+            if arr:
+                payload["color_palette"] = arr
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_spicy_video_extend.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_spicy_video_extend.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22SpicyVideoExtend:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video_url": ("STRING", {"default": "", "tooltip": "Input video URL"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Extend instruction"}),
+            },
+            "optional": {
+                "duration": ([5, 10], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video_url: str,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "480p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        video_url = (video_url or "").strip()
+        if not video_url:
+            raise RuntimeError("video_url is required")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba WAN2.2 Spicy Video Extend")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.2-spicy/video-extend",
+            "video_url": video_url,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_i2v.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasAtlascloudWan22ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Resolution"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        negative_prompt: str = "",
+        resolution: str = "480p",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN2.2 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "negative_prompt": (negative_prompt or "").strip(),
+            "resolution": resolution,
+            "duration": int(duration),
+            "seed": int(seed),
+        }
+
+        if not payload["negative_prompt"]:
+            payload.pop("negative_prompt", None)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_i2v_lora.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_i2v_lora.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasAtlascloudWan22ImageToVideoLora:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array for `loras`. Example: [{"path":"https://.../lora.safetensors","scale":1.0}]',
+                    },
+                ),
+                "high_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array for `high_noise_loras`. Example: [{"path":"https://.../lora.safetensors","scale":1.0}]',
+                    },
+                ),
+                "low_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": 'JSON array for `low_noise_loras`. Example: [{"path":"https://.../lora.safetensors","scale":1.0}]',
+                    },
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "resolution": (
+                    ["480p", "720p"],
+                    {"default": "480p", "tooltip": "Resolution"},
+                ),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        loras_json: str = "[]",
+        high_noise_loras_json: str = "[]",
+        low_noise_loras_json: str = "[]",
+        negative_prompt: str = "",
+        resolution: str = "480p",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN2.2 Image-to-Video LoRA")
+
+        import json
+
+        def parse_array(s: str, name: str):
+            try:
+                arr = json.loads(s) if (s or "").strip() else []
+                if not isinstance(arr, list):
+                    raise ValueError(f"{name} must be a JSON array")
+                return arr
+            except Exception as e:
+                raise RuntimeError(f"Invalid {name}. Must be a JSON array. Error: {e}") from e
+
+        loras = parse_array(loras_json, "loras_json")
+        low_noise_loras = parse_array(low_noise_loras_json, "low_noise_loras_json")
+        high_noise_loras = parse_array(high_noise_loras_json, "high_noise_loras_json")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2/image-to-video-lora",
+            "image": image,
+            "prompt": prompt,
+            "negative_prompt": (negative_prompt or "").strip(),
+            "resolution": resolution,
+            "duration": int(duration),
+            "seed": int(seed),
+        }
+
+        if not payload["negative_prompt"]:
+            payload.pop("negative_prompt", None)
+
+        if loras:
+            payload["loras"] = loras
+        if high_noise_loras:
+            payload["high_noise_loras"] = high_noise_loras
+        if low_noise_loras:
+            payload["low_noise_loras"] = low_noise_loras
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -24,6 +24,10 @@ from atlascloud_comfyui.nodes.video.wan26_i2v import AtlasWAN26ImageToVideo
 from atlascloud_comfyui.nodes.video.wan26_v2v import AtlasWAN26VideoToVideo
 from atlascloud_comfyui.nodes.image.wan26_t2i import AtlasWAN26TextToImage
 from atlascloud_comfyui.nodes.image.wan26_image_edit import AtlasWAN26ImageEdit
+from atlascloud_comfyui.nodes.image.alibaba_wan_2_7_t2i import AtlasWan27TextToImage
+from atlascloud_comfyui.nodes.image.alibaba_wan_2_7_edit import AtlasWan27ImageEdit
+from atlascloud_comfyui.nodes.image.alibaba_wan_2_7_pro_t2i import AtlasWan27ProTextToImage
+from atlascloud_comfyui.nodes.image.alibaba_wan_2_7_pro_edit import AtlasWan27ProImageEdit
 
 from atlascloud_comfyui.nodes.video.kling_video_o3_pro_t2v import AtlasKlingVideoO3ProTextToVideo
 from atlascloud_comfyui.nodes.video.kling_video_o3_pro_i2v import AtlasKlingVideoO3ProImageToVideo
@@ -35,6 +39,9 @@ from atlascloud_comfyui.nodes.video.kling_video_o3_std_i2v import AtlasKlingVide
 from atlascloud_comfyui.nodes.video.kling_video_o3_std_r2v import AtlasKlingVideoO3StdReferenceToVideo
 from atlascloud_comfyui.nodes.video.kling_video_o3_std_video_edit import AtlasKlingVideoO3StdVideoEdit
 from atlascloud_comfyui.nodes.video.wan25_t2v import AtlasWAN25TextToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_2_2_spicy_video_extend import AtlasWan22SpicyVideoExtend
+from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_i2v import AtlasAtlascloudWan22ImageToVideo
+from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_i2v_lora import AtlasAtlascloudWan22ImageToVideoLora
 from atlascloud_comfyui.nodes.video.wan22_t2v_720p import AtlasWAN22T2V720p
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_2_t2v_480p import AtlasAlibabaWan22T2V480p
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_2_i2v_720p import AtlasAlibabaWan22I2V720p
@@ -245,12 +252,19 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.5 Text-to-Video": AtlasWAN25TextToVideo,
     "AtlasCloud WAN2.6 Text-to-Video": AtlasWAN26TextToVideo,
     "AtlasCloud WAN2.6 Text-to-Image": AtlasWAN26TextToImage,
+    "AtlasCloud WAN2.7 Text-to-Image": AtlasWan27TextToImage,
+    "AtlasCloud WAN2.7 Image-Edit": AtlasWan27ImageEdit,
+    "AtlasCloud WAN2.7 Pro Text-to-Image": AtlasWan27ProTextToImage,
+    "AtlasCloud WAN2.7 Pro Image-Edit": AtlasWan27ProImageEdit,
     "AtlasCloud WAN2.5 Text-to-Image": AtlasWan25TextToImage,
     "AtlasCloud WAN2.5 Image-Edit": AtlasWan25ImageEdit,
     "AtlasCloud WAN2.6 Image-Edit": AtlasWAN26ImageEdit,
     "AtlasCloud WAN2.6 Image-to-Video": AtlasWAN26ImageToVideo,
     "AtlasCloud WAN2.6 Image-to-Video Flash": AtlasWAN26ImageToVideoFlash,
     "AtlasCloud WAN2.6 Video-to-Video": AtlasWAN26VideoToVideo,
+    "AtlasCloud WAN2.2 Spicy Video Extend": AtlasWan22SpicyVideoExtend,
+    "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video": AtlasAtlascloudWan22ImageToVideo,
+    "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video LoRA": AtlasAtlascloudWan22ImageToVideoLora,
 
     "AtlasCloud Kling Video O3 Pro Text-to-Video": AtlasKlingVideoO3ProTextToVideo,
     "AtlasCloud Kling Video O3 Pro Image-to-Video": AtlasKlingVideoO3ProImageToVideo,
@@ -468,12 +482,19 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.5 Text-to-Video": "AtlasCloud WAN2.5 Text-to-Video",
     "AtlasCloud WAN2.6 Text-to-Video": "AtlasCloud WAN2.6 Text-to-Video",
     "AtlasCloud WAN2.6 Text-to-Image": "AtlasCloud WAN2.6 Text-to-Image",
+    "AtlasCloud WAN2.7 Text-to-Image": "AtlasCloud WAN2.7 Text-to-Image",
+    "AtlasCloud WAN2.7 Image-Edit": "AtlasCloud WAN2.7 Image-Edit",
+    "AtlasCloud WAN2.7 Pro Text-to-Image": "AtlasCloud WAN2.7 Pro Text-to-Image",
+    "AtlasCloud WAN2.7 Pro Image-Edit": "AtlasCloud WAN2.7 Pro Image-Edit", 
     "AtlasCloud WAN2.5 Text-to-Image": "AtlasCloud WAN2.5 Text-to-Image",
     "AtlasCloud WAN2.5 Image-Edit": "AtlasCloud WAN2.5 Image-Edit",
     "AtlasCloud WAN2.6 Image-Edit": "AtlasCloud WAN2.6 Image-Edit",
     "AtlasCloud WAN2.6 Image-to-Video": "AtlasCloud WAN2.6 Image-to-Video",
     "AtlasCloud WAN2.6 Image-to-Video Flash": "AtlasCloud WAN2.6 Image-to-Video Flash",
     "AtlasCloud WAN2.6 Video-to-Video": "AtlasCloud WAN2.6 Video-to-Video",
+    "AtlasCloud WAN2.2 Spicy Video Extend": "AtlasCloud WAN2.2 Spicy Video Extend",
+    "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video": "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video",
+    "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video LoRA": "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video LoRA",
 
     "AtlasCloud Kling Video O3 Pro Text-to-Video": "AtlasCloud Kling Video O3 Pro Text-to-Video",
     "AtlasCloud Kling Video O3 Pro Image-to-Video": "AtlasCloud Kling Video O3 Pro Image-to-Video",

--- a/tests/test_new_nodes_2026_04_08.py
+++ b/tests/test_new_nodes_2026_04_08.py
@@ -1,0 +1,75 @@
+"""Metadata-only tests for newly added nodes (2026-04-08).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_wan27_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.alibaba_wan_2_7_t2i import AtlasWan27TextToImage
+
+    required = AtlasWan27TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasWan27TextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan27_image_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.alibaba_wan_2_7_edit import AtlasWan27ImageEdit
+
+    required = AtlasWan27ImageEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasWan27ImageEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan27_pro_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.alibaba_wan_2_7_pro_t2i import AtlasWan27ProTextToImage
+
+    required = AtlasWan27ProTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasWan27ProTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan27_pro_image_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.alibaba_wan_2_7_pro_edit import AtlasWan27ProImageEdit
+
+    required = AtlasWan27ProImageEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasWan27ProImageEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan22_spicy_video_extend_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_wan_2_2_spicy_video_extend import AtlasWan22SpicyVideoExtend
+
+    required = AtlasWan22SpicyVideoExtend.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "video_url" in required
+    assert "prompt" in required
+    assert AtlasWan22SpicyVideoExtend.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_atlascloud_wan22_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_i2v import AtlasAtlascloudWan22ImageToVideo
+
+    required = AtlasAtlascloudWan22ImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasAtlascloudWan22ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_atlascloud_wan22_i2v_lora_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_i2v_lora import AtlasAtlascloudWan22ImageToVideoLora
+
+    required = AtlasAtlascloudWan22ImageToVideoLora.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert "loras_json" in required
+    assert "high_noise_loras_json" in required
+    assert "low_noise_loras_json" in required
+    assert AtlasAtlascloudWan22ImageToVideoLora.RETURN_TYPES == ("STRING", "STRING")


### PR DESCRIPTION
This PR adds ComfyUI node support for new/previously-missing visual models returned by AtlasCloud /api/v1/models.

Added nodes:
- alibaba/wan-2.7/text-to-image
- alibaba/wan-2.7/image-edit
- alibaba/wan-2.7-pro/text-to-image
- alibaba/wan-2.7-pro/image-edit
- atlascloud/wan-2.2/image-to-video
- atlascloud/wan-2.2/image-to-video-lora
- alibaba/wan-2.2-spicy/video-extend

Also:
- registry.py: register nodes
- README: update Available Nodes tables
- tests: metadata-only tests for new nodes

Tests:
- ruff check . (pass)
- pytest tests/ -v (pass)
- E2E local: WAN2.7 T2I/Edit, WAN2.7 Pro T2I/Edit, atlascloud WAN2.2 I2V (pass). Video-extend requires ATLASCLOUD_E2E_VIDEO_URL so was skipped.