### PR TITLE
docs: add missing WAN2.7 Reference-to-Video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling Effects | kwaivgi/kling-effects |
 | AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
 | AtlasCloud WAN2.7 Image-to-Video | alibaba/wan-2.7/image-to-video |
+| AtlasCloud WAN2.7 Reference-to-Video | alibaba/wan-2.7/reference-to-video |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
 | AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |
 | AtlasCloud Kling Video O3 Std Image-to-Video | kwaivgi/kling-video-o3-std/image-to-video |


### PR DESCRIPTION
Add missing AtlasCloud WAN2.7 Reference-to-Video entry to README Available Nodes table.