### PR TITLE
feat: sync new AtlasCloud models (2026-04-15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,15 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
+| AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
 
 ### Video Extend
 
 | Node | Model |
 |------|-------|
 | AtlasCloud WAN2.2 Spicy Video Extend | alibaba/wan-2.2-spicy/video-extend |
+| AtlasCloud WAN2.2 Spicy Video Extend LoRA | alibaba/wan-2.2-spicy/video-extend-lora |
+| AtlasCloud WAN2.5 Video Extend | alibaba/wan-2.5/video-extend |
 
 ### Video Edit
 

--- a/src/atlascloud_comfyui/nodes/image/baidu_ernie_image_turbo_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/baidu_ernie_image_turbo_t2i.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasBaiduERNIEImageTurboTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "size": (
+                    [
+                        "1024x1024",
+                        "1376x768",
+                        "1264x848",
+                        "1200x896",
+                        "896x1200",
+                        "848x1264",
+                    ],
+                    {"default": "1024x1024", "tooltip": "Output size"},
+                ),
+                "n": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "use_pe": ("BOOLEAN", {"default": True, "tooltip": "Enable prompt enhancement"}),
+                "num_inference_steps": ("INT", {"default": 8, "min": 1, "max": 50, "tooltip": "Inference steps"}),
+                "guidance_scale": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 20.0, "tooltip": "Guidance scale"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1024x1024",
+        n: int = 1,
+        seed: int = -1,
+        use_pe: bool = True,
+        num_inference_steps: int = 8,
+        guidance_scale: float = 1.0,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Baidu ERNIE-Image-Turbo Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "baidu/ERNIE-Image-Turbo/text-to-image",
+            "prompt": prompt,
+            "size": size,
+            "n": int(n),
+            "use_pe": bool(use_pe),
+            "num_inference_steps": int(num_inference_steps),
+            "guidance_scale": float(guidance_scale),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_spicy_video_extend_lora.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_spicy_video_extend_lora.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22SpicyVideoExtendLora:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video": ("STRING", {"default": "", "tooltip": "Input video URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Extend instruction"}),
+            },
+            "optional": {
+                "duration": ([5, 8], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Resolution"}),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `loras`",
+                    },
+                ),
+                "low_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `low_noise_loras`",
+                    },
+                ),
+                "high_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "[]",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `high_noise_loras`",
+                    },
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video: str,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "480p",
+        seed: int = -1,
+        loras_json: str = "[]",
+        low_noise_loras_json: str = "[]",
+        high_noise_loras_json: str = "[]",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba WAN2.2 Spicy Video Extend LoRA")
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.2-spicy/video-extend-lora",
+            "prompt": prompt,
+            "video": video,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+        }
+
+        def parse_json_array(s: str, *, field_name: str) -> List[Any]:
+            s = (s or "").strip()
+            if not s or s == "[]":
+                return []
+            import json
+
+            try:
+                v = json.loads(s)
+            except Exception as e:
+                raise RuntimeError(f"Invalid {field_name}. Must be a JSON array. Error: {e}") from e
+            if not isinstance(v, list):
+                raise RuntimeError(f"{field_name} must be a JSON array")
+            return v
+
+        loras = parse_json_array(loras_json, field_name="loras_json")
+        if loras:
+            payload["loras"] = loras
+
+        low = parse_json_array(low_noise_loras_json, field_name="low_noise_loras_json")
+        if low:
+            payload["low_noise_loras"] = low
+
+        high = parse_json_array(high_noise_loras_json, field_name="high_noise_loras_json")
+        if high:
+            payload["high_noise_loras"] = high
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_5_video_extend.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_5_video_extend.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan25VideoExtend:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video": ("STRING", {"default": "", "tooltip": "Input video URL/base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Extend instruction"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Optional audio URL"}),
+                "duration": ([5, 6, 7, 8, 9, 10], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "resolution": (["480p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video: str,
+        prompt: str,
+        negative_prompt: str = "",
+        audio: str = "",
+        duration: int = 5,
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba WAN2.5 Video Extend")
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-2.5/video-extend",
+            "prompt": prompt,
+            "video": video,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        a = (audio or "").strip()
+        if a:
+            payload["audio"] = a
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -40,6 +40,8 @@ from atlascloud_comfyui.nodes.video.kling_video_o3_std_r2v import AtlasKlingVide
 from atlascloud_comfyui.nodes.video.kling_video_o3_std_video_edit import AtlasKlingVideoO3StdVideoEdit
 from atlascloud_comfyui.nodes.video.wan25_t2v import AtlasWAN25TextToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_2_spicy_video_extend import AtlasWan22SpicyVideoExtend
+from atlascloud_comfyui.nodes.video.alibaba_wan_2_2_spicy_video_extend_lora import AtlasWan22SpicyVideoExtendLora
+from atlascloud_comfyui.nodes.video.alibaba_wan_2_5_video_extend import AtlasWan25VideoExtend
 from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_i2v import AtlasAtlascloudWan22ImageToVideo
 from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_i2v_lora import AtlasAtlascloudWan22ImageToVideoLora
 from atlascloud_comfyui.nodes.video.wan22_t2v_720p import AtlasWAN22T2V720p
@@ -146,6 +148,7 @@ from atlascloud_comfyui.nodes.image.imagen4_ultra_t2i import AtlasImagen4UltraTe
 from atlascloud_comfyui.nodes.image.imagen3_t2i import AtlasImagen3TextToImage
 from atlascloud_comfyui.nodes.image.imagen3_fast_t2i import AtlasImagen3FastTextToImage
 from atlascloud_comfyui.nodes.image.wan25_t2i import AtlasWan25TextToImage
+from atlascloud_comfyui.nodes.image.baidu_ernie_image_turbo_t2i import AtlasBaiduERNIEImageTurboTextToImage
 from atlascloud_comfyui.nodes.image.wan25_image_edit import AtlasWan25ImageEdit
 from atlascloud_comfyui.nodes.image.nano_banana_t2i import AtlasNanoBananaTextToImage
 from atlascloud_comfyui.nodes.image.nano_banana_t2i_dev import AtlasNanoBananaTextToImageDeveloper
@@ -258,12 +261,15 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.7 Pro Text-to-Image": AtlasWan27ProTextToImage,
     "AtlasCloud WAN2.7 Pro Image-Edit": AtlasWan27ProImageEdit,
     "AtlasCloud WAN2.5 Text-to-Image": AtlasWan25TextToImage,
+    "AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image": AtlasBaiduERNIEImageTurboTextToImage,
     "AtlasCloud WAN2.5 Image-Edit": AtlasWan25ImageEdit,
     "AtlasCloud WAN2.6 Image-Edit": AtlasWAN26ImageEdit,
     "AtlasCloud WAN2.6 Image-to-Video": AtlasWAN26ImageToVideo,
     "AtlasCloud WAN2.6 Image-to-Video Flash": AtlasWAN26ImageToVideoFlash,
     "AtlasCloud WAN2.6 Video-to-Video": AtlasWAN26VideoToVideo,
     "AtlasCloud WAN2.2 Spicy Video Extend": AtlasWan22SpicyVideoExtend,
+    "AtlasCloud WAN2.2 Spicy Video Extend LoRA": AtlasWan22SpicyVideoExtendLora,
+    "AtlasCloud WAN2.5 Video Extend": AtlasWan25VideoExtend,
     "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video": AtlasAtlascloudWan22ImageToVideo,
     "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video LoRA": AtlasAtlascloudWan22ImageToVideoLora,
     "AtlasCloud Kling Video O3 Pro Text-to-Video": AtlasKlingVideoO3ProTextToVideo,
@@ -480,12 +486,15 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.7 Pro Text-to-Image": "AtlasCloud WAN2.7 Pro Text-to-Image",
     "AtlasCloud WAN2.7 Pro Image-Edit": "AtlasCloud WAN2.7 Pro Image-Edit",
     "AtlasCloud WAN2.5 Text-to-Image": "AtlasCloud WAN2.5 Text-to-Image",
+    "AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image": "AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image",
     "AtlasCloud WAN2.5 Image-Edit": "AtlasCloud WAN2.5 Image-Edit",
     "AtlasCloud WAN2.6 Image-Edit": "AtlasCloud WAN2.6 Image-Edit",
     "AtlasCloud WAN2.6 Image-to-Video": "AtlasCloud WAN2.6 Image-to-Video",
     "AtlasCloud WAN2.6 Image-to-Video Flash": "AtlasCloud WAN2.6 Image-to-Video Flash",
     "AtlasCloud WAN2.6 Video-to-Video": "AtlasCloud WAN2.6 Video-to-Video",
     "AtlasCloud WAN2.2 Spicy Video Extend": "AtlasCloud WAN2.2 Spicy Video Extend",
+    "AtlasCloud WAN2.2 Spicy Video Extend LoRA": "AtlasCloud WAN2.2 Spicy Video Extend LoRA",
+    "AtlasCloud WAN2.5 Video Extend": "AtlasCloud WAN2.5 Video Extend",
     "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video": "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video",
     "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video LoRA": "AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video LoRA",
     "AtlasCloud Kling Video O3 Pro Text-to-Video": "AtlasCloud Kling Video O3 Pro Text-to-Video",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -179,6 +179,33 @@ def test_wan22_turbo_spicy_i2v_lora_node_metadata():
     assert "high_noise_loras_json" in AtlasWan22TurboSpicyImageToVideoLora.INPUT_TYPES()["required"]
     assert AtlasWan22TurboSpicyImageToVideoLora.RETURN_TYPES == ("STRING", "STRING")
 
+
+def test_wan22_spicy_video_extend_lora_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_wan_2_2_spicy_video_extend_lora import AtlasWan22SpicyVideoExtendLora
+
+    assert "atlas_client" in AtlasWan22SpicyVideoExtendLora.INPUT_TYPES()["required"]
+    assert "video" in AtlasWan22SpicyVideoExtendLora.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan22SpicyVideoExtendLora.INPUT_TYPES()["required"]
+    assert AtlasWan22SpicyVideoExtendLora.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan25_video_extend_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_wan_2_5_video_extend import AtlasWan25VideoExtend
+
+    assert "atlas_client" in AtlasWan25VideoExtend.INPUT_TYPES()["required"]
+    assert "video" in AtlasWan25VideoExtend.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan25VideoExtend.INPUT_TYPES()["required"]
+    assert AtlasWan25VideoExtend.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_baidu_ernie_image_turbo_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.baidu_ernie_image_turbo_t2i import AtlasBaiduERNIEImageTurboTextToImage
+
+    assert "atlas_client" in AtlasBaiduERNIEImageTurboTextToImage.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasBaiduERNIEImageTurboTextToImage.INPUT_TYPES()["required"]
+    assert AtlasBaiduERNIEImageTurboTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasBaiduERNIEImageTurboTextToImage.RETURN_NAMES
+
 def test_seedance_v15_pro_i2v_spicy_node_metadata():
     from src.atlascloud_comfyui.nodes.video.seedance_v15_pro_i2v_spicy import AtlasSeedanceV15ProImageToVideoSpicy
 


### PR DESCRIPTION
## Summary
- Add 3 new visual model nodes discovered from AtlasCloud /api/v1/models (visual types only).

### Added
- **AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image** — `baidu/ERNIE-Image-Turbo/text-to-image`
- **AtlasCloud WAN2.5 Video Extend** — `alibaba/wan-2.5/video-extend`
- **AtlasCloud WAN2.2 Spicy Video Extend LoRA** — `alibaba/wan-2.2-spicy/video-extend-lora`

## Test plan
- [x] `ruff check .`
- [x] `pytest tests/ -v`
- [x] E2E baseline: `pytest tests/test_e2e.py -v -s` (T2I uses `google/imagen4-fast`)
- [x] E2E new-model suite: `pytest tests/test_e2e_new_models.py -v -s`

🤖 Generated with OpenClaw
