### PR TITLE
Sync AtlasCloud models: Vidu Q1/Q2 + InfiniteTalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedance 2.0 Text-to-Video | bytedance/seedance-2.0/text-to-video |
 | AtlasCloud Seedance 2.0 Fast Text-to-Video | bytedance/seedance-2.0-fast/text-to-video |
 | AtlasCloud Seedance V1.5 Pro Text-to-Video Fast | bytedance/seedance-v1.5-pro/text-to-video-fast |
+| AtlasCloud Vidu Q1 Text-to-Video | vidu/q1/text-to-video |
+| AtlasCloud Vidu Q2 Text-to-Video | vidu/q2/text-to-video |
 | AtlasCloud Hunyuan Text-to-Video | atlascloud/hunyuan-video/t2v |
 
 ### Image-to-Video (I2V)
@@ -160,6 +162,17 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Vidu Reference-to-Video 2.0 | vidu/reference-to-video-2.0 |
 | AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video | vidu/q2-pro-fast/reference-to-video |
 | AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video (with Audio) | vidu/q2-pro-fast/reference-to-video-with-audio |
+| AtlasCloud Vidu Q1 Image-to-Video | vidu/q1/image-to-video |
+| AtlasCloud Vidu Q1 Start-End-to-Video | vidu/q1/start-end-to-video |
+| AtlasCloud Vidu Q1 Reference-to-Video | vidu/q1/reference-to-video |
+| AtlasCloud Vidu Q2 Reference-to-Video | vidu/q2/reference-to-video |
+| AtlasCloud Vidu Q2-Pro Image-to-Video | vidu/q2-pro/image-to-video |
+| AtlasCloud Vidu Q2-Pro Start-End-to-Video | vidu/q2-pro/start-end-to-video |
+| AtlasCloud Vidu Q2-Pro Reference-to-Video | vidu/q2-pro/reference-to-video |
+| AtlasCloud Vidu Q2-Pro-Fast Image-to-Video | vidu/q2-pro-fast/image-to-video |
+| AtlasCloud Vidu Q2-Pro-Fast Start-End-to-Video | vidu/q2-pro-fast/start-end-to-video |
+| AtlasCloud Vidu Q2-Turbo Image-to-Video | vidu/q2-turbo/image-to-video |
+| AtlasCloud Vidu Q2-Turbo Start-End-to-Video | vidu/q2-turbo/start-end-to-video |
 | AtlasCloud Vidu Start-End-to-Video 2.0 | vidu/start-end-to-video-2.0 |
 | AtlasCloud Kling V2.0 I2V Master | kwaivgi/kling-v2.0-i2v-master |
 | AtlasCloud Kling V2.1 I2V Master | kwaivgi/kling-v2.1-i2v-master |
@@ -218,6 +231,12 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Hunyuan Image-to-Video | atlascloud/hunyuan-video/i2v |
 | AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video | atlascloud/wan-2.2/image-to-video |
 | AtlasCloud WAN2.2 (AtlasCloud) Image-to-Video LoRA | atlascloud/wan-2.2/image-to-video-lora |
+
+### Audio-to-Video (A2V)
+
+| Node | Model |
+|------|-------|
+| AtlasCloud InfiniteTalk Audio-to-Video | atlascloud/infinitetalk |
 
 ### Text-to-Image (T2I)
 

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_infinitetalk_a2v.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_infinitetalk_a2v.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasInfiniteTalkAudioToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Portrait photo URL/base64"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Driving audio file URL (WAV/MP3)"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional prompt"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        audio: str,
+        prompt: str = "",
+        resolution: str = "480p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+
+        audio = (audio or "").strip()
+        if not audio:
+            raise RuntimeError("audio is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/infinitetalk",
+            "image": image,
+            "audio": audio,
+            "resolution": resolution,
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q1_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q1_i2v.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ1ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL/base64"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["1080p"], {"default": "1080p", "tooltip": "Resolution"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        duration: float = 5.0,
+        resolution: str = '1080p',
+        movement_amplitude: str = 'auto',
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q1/image-to-video",
+            "prompt": p,
+            "image": image,
+            "duration": float(duration),
+            "resolution": resolution,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q1_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q1_r2v.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ1ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "images": ("STRING", {"multiline": True, "tooltip": "1-7 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["1080p"], {"default": "1080p", "tooltip": "Resolution"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "audio_type": (["all", "speech_only", "sound_effect_only"], {"default": "all", "tooltip": "Audio type"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        duration: float = 5.0,
+        resolution: str = '1080p',
+        aspect_ratio: str = '16:9',
+        movement_amplitude: str = 'auto',
+        audio_type: str = 'all',
+        generate_audio: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
+        if not imgs:
+            raise RuntimeError("images is required (provide 1-7 lines)")
+        if len(imgs) > 7:
+            raise RuntimeError("images maxItems is 7")
+
+        # API schema uses `subjects` (array of objects) rather than `images`.
+        subjects: List[Dict[str, Any]] = [{"id": "subject1", "images": imgs}]
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q1/reference-to-video",
+            "prompt": p,
+            "subjects": subjects,
+            "duration": float(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "audio_type": (audio_type or "").strip(),
+            "seed": int(seed),
+        }
+
+        if not (payload.get("audio_type") or "").strip():
+            payload.pop("audio_type", None)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q1_start_end.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q1_start_end.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ1StartEndToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "End image URL/base64"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["1080p"], {"default": "1080p", "tooltip": "Resolution"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        end_image: str,
+        duration: float = 5.0,
+        resolution: str = '1080p',
+        movement_amplitude: str = 'auto',
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+        end_image = (end_image or "").strip()
+        if not end_image:
+            raise RuntimeError("end_image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q1/start-end-to-video",
+            "prompt": p,
+            "image": image,
+            "end_image": end_image,
+            "duration": float(duration),
+            "resolution": resolution,
+            "movement_amplitude": movement_amplitude,
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q1_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q1_t2v.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ1TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["1080p"], {"default": "1080p", "tooltip": "Resolution"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "style": (["general", "anime"], {"default": "general", "tooltip": "Style"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: float = 5.0,
+        resolution: str = '1080p',
+        aspect_ratio: str = '16:9',
+        style: str = 'general',
+        movement_amplitude: str = 'auto',
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q1/text-to-video",
+            "prompt": p,
+            "duration": float(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "style": style,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_fast_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_fast_i2v.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2ProFastImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL/base64"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        movement_amplitude: str = 'auto',
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2-pro-fast/image-to-video",
+            "prompt": p,
+            "image": image,
+            "duration": float(duration),
+            "resolution": resolution,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_fast_start_end.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_fast_start_end.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2ProFastStartEndToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "End image URL/base64"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        end_image: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        movement_amplitude: str = 'auto',
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+        end_image = (end_image or "").strip()
+        if not end_image:
+            raise RuntimeError("end_image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2-pro-fast/start-end-to-video",
+            "prompt": p,
+            "image": image,
+            "end_image": end_image,
+            "duration": float(duration),
+            "resolution": resolution,
+            "movement_amplitude": movement_amplitude,
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_i2v.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2ProImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL/base64"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "bgm": ("BOOLEAN", {"default": False, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        movement_amplitude: str = 'auto',
+        generate_audio: bool = True,
+        bgm: bool = False,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2-pro/image-to-video",
+            "prompt": p,
+            "image": image,
+            "duration": float(duration),
+            "resolution": resolution,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_r2v.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2ProReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "images": ("STRING", {"multiline": True, "tooltip": "1-7 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "audio_type": (["all", "speech_only", "sound_effect_only"], {"default": "all", "tooltip": "Audio type"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        aspect_ratio: str = '16:9',
+        audio_type: str = 'all',
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
+        if not imgs:
+            raise RuntimeError("images is required (provide 1-7 lines)")
+        if len(imgs) > 7:
+            raise RuntimeError("images maxItems is 7")
+
+        # API schema uses `subjects` (array of objects) rather than `images`.
+        subjects: List[Dict[str, Any]] = [{"id": "subject1", "images": imgs}]
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2-pro/reference-to-video",
+            "prompt": p,
+            "subjects": subjects,
+            "duration": float(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+            "audio_type": (audio_type or "").strip(),
+            "seed": int(seed),
+        }
+
+        if not (payload.get("audio_type") or "").strip():
+            payload.pop("audio_type", None)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_start_end.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_start_end.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2ProStartEndToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "End image URL/base64"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        end_image: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        movement_amplitude: str = 'auto',
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+        end_image = (end_image or "").strip()
+        if not end_image:
+            raise RuntimeError("end_image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2-pro/start-end-to-video",
+            "prompt": p,
+            "image": image,
+            "end_image": end_image,
+            "duration": float(duration),
+            "resolution": resolution,
+            "movement_amplitude": movement_amplitude,
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_r2v.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "images": ("STRING", {"multiline": True, "tooltip": "1-7 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1", "4:3", "3:4"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "audio_type": (["all", "speech_only", "sound_effect_only"], {"default": "all", "tooltip": "Audio type"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        aspect_ratio: str = '16:9',
+        movement_amplitude: str = 'auto',
+        audio_type: str = 'all',
+        generate_audio: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
+        if not imgs:
+            raise RuntimeError("images is required (provide 1-7 lines)")
+        if len(imgs) > 7:
+            raise RuntimeError("images maxItems is 7")
+
+        # API schema uses `subjects` (array of objects) rather than `images`.
+        subjects: List[Dict[str, Any]] = [{"id": "subject1", "images": imgs}]
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2/reference-to-video",
+            "prompt": p,
+            "subjects": subjects,
+            "duration": float(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "audio_type": (audio_type or "").strip(),
+            "seed": int(seed),
+        }
+
+        if not (payload.get("audio_type") or "").strip():
+            payload.pop("audio_type", None)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_t2v.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1", "4:3", "3:4"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "style": (["general", "anime"], {"default": "general", "tooltip": "Style"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        aspect_ratio: str = '16:9',
+        style: str = 'general',
+        movement_amplitude: str = 'auto',
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2/text-to-video",
+            "prompt": p,
+            "duration": float(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "style": style,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_turbo_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_turbo_i2v.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2TurboImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL/base64"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        movement_amplitude: str = 'auto',
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2-turbo/image-to-video",
+            "prompt": p,
+            "image": image,
+            "duration": float(duration),
+            "resolution": resolution,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_turbo_start_end.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_turbo_start_end.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasViduQ2TurboStartEndToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image": ("STRING", {"default": "", "tooltip": "Start image URL/base64"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "End image URL/base64"}),
+            },
+            "optional": {
+                "duration": ("FLOAT", {"default": 5.0, "min": 1.0, "max": 60.0, "tooltip": "Duration (seconds)"}),
+                "resolution": (["540p", "720p", "1080p"], {"default": "720p", "tooltip": "Resolution"}),
+                "movement_amplitude": (["auto", "small", "medium", "large"], {"default": "auto", "tooltip": "Movement amplitude"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio"}),
+                "bgm": ("BOOLEAN", {"default": True, "tooltip": "Background music"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647, "tooltip": "Seed"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        end_image: str,
+        duration: float = 5.0,
+        resolution: str = '720p',
+        movement_amplitude: str = 'auto',
+        generate_audio: bool = True,
+        bgm: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+        end_image = (end_image or "").strip()
+        if not end_image:
+            raise RuntimeError("end_image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "vidu/q2-turbo/start-end-to-video",
+            "prompt": p,
+            "image": image,
+            "end_image": end_image,
+            "duration": float(duration),
+            "resolution": resolution,
+            "movement_amplitude": movement_amplitude,
+            "generate_audio": bool(generate_audio),
+            "bgm": bool(bgm),
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -189,6 +189,7 @@ from atlascloud_comfyui.nodes.video.van25_t2v import AtlasAtlascloudVan25TextToV
 from atlascloud_comfyui.nodes.video.van25_i2v import AtlasAtlascloudVan25ImageToVideo
 from atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
 from atlascloud_comfyui.nodes.video.van26_i2v import AtlasVan26ImageToVideo
+from atlascloud_comfyui.nodes.video.atlascloud_infinitetalk_a2v import AtlasInfiniteTalkAudioToVideo
 from atlascloud_comfyui.nodes.video.vidu_reference_to_video_q1 import AtlasViduReferenceToVideoQ1
 from atlascloud_comfyui.nodes.video.vidu_reference_to_video_v2 import AtlasViduReferenceToVideoV2
 from atlascloud_comfyui.nodes.video.vidu_start_end_to_video_v2 import AtlasViduStartEndToVideoV2
@@ -234,6 +235,19 @@ from atlascloud_comfyui.nodes.video.google_veo31_lite_i2v import AtlasVeo31LiteI
 from atlascloud_comfyui.nodes.video.google_veo31_lite_start_end_frame_t2v import AtlasVeo31LiteStartEndFrameToVideo
 from atlascloud_comfyui.nodes.video.vidu_q3_r2v import AtlasViduQ3ReferenceToVideo
 from atlascloud_comfyui.nodes.video.vidu_q3_mix_r2v import AtlasViduQ3MixReferenceToVideo
+from atlascloud_comfyui.nodes.video.vidu_q1_t2v import AtlasViduQ1TextToVideo
+from atlascloud_comfyui.nodes.video.vidu_q1_i2v import AtlasViduQ1ImageToVideo
+from atlascloud_comfyui.nodes.video.vidu_q1_start_end import AtlasViduQ1StartEndToVideo
+from atlascloud_comfyui.nodes.video.vidu_q1_r2v import AtlasViduQ1ReferenceToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_t2v import AtlasViduQ2TextToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_r2v import AtlasViduQ2ReferenceToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_pro_i2v import AtlasViduQ2ProImageToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_pro_start_end import AtlasViduQ2ProStartEndToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_pro_r2v import AtlasViduQ2ProReferenceToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_pro_fast_i2v import AtlasViduQ2ProFastImageToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_pro_fast_start_end import AtlasViduQ2ProFastStartEndToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_turbo_i2v import AtlasViduQ2TurboImageToVideo
+from atlascloud_comfyui.nodes.video.vidu_q2_turbo_start_end import AtlasViduQ2TurboStartEndToVideo
 
 from atlascloud_comfyui.nodes.video.bytedance_seedance_v1_lite_t2v_480p import AtlasBytedanceSeedanceV1LiteT2V480p
 from atlascloud_comfyui.nodes.video.bytedance_seedance_v1_lite_i2v_720p import AtlasBytedanceSeedanceV1LiteI2V720p
@@ -444,6 +458,20 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Van-2.5 Image-to-Video": AtlasAtlascloudVan25ImageToVideo,
     "AtlasCloud Van-2.6 Text-to-Video": AtlasVan26TextToVideo,
     "AtlasCloud Van-2.6 Image-to-Video": AtlasVan26ImageToVideo,
+    "AtlasCloud InfiniteTalk Audio-to-Video": AtlasInfiniteTalkAudioToVideo,
+    "AtlasCloud Vidu Q1 Text-to-Video": AtlasViduQ1TextToVideo,
+    "AtlasCloud Vidu Q1 Image-to-Video": AtlasViduQ1ImageToVideo,
+    "AtlasCloud Vidu Q1 Start-End-to-Video": AtlasViduQ1StartEndToVideo,
+    "AtlasCloud Vidu Q1 Reference-to-Video": AtlasViduQ1ReferenceToVideo,
+    "AtlasCloud Vidu Q2 Text-to-Video": AtlasViduQ2TextToVideo,
+    "AtlasCloud Vidu Q2 Reference-to-Video": AtlasViduQ2ReferenceToVideo,
+    "AtlasCloud Vidu Q2-Pro Image-to-Video": AtlasViduQ2ProImageToVideo,
+    "AtlasCloud Vidu Q2-Pro Start-End-to-Video": AtlasViduQ2ProStartEndToVideo,
+    "AtlasCloud Vidu Q2-Pro Reference-to-Video": AtlasViduQ2ProReferenceToVideo,
+    "AtlasCloud Vidu Q2-Pro-Fast Image-to-Video": AtlasViduQ2ProFastImageToVideo,
+    "AtlasCloud Vidu Q2-Pro-Fast Start-End-to-Video": AtlasViduQ2ProFastStartEndToVideo,
+    "AtlasCloud Vidu Q2-Turbo Image-to-Video": AtlasViduQ2TurboImageToVideo,
+    "AtlasCloud Vidu Q2-Turbo Start-End-to-Video": AtlasViduQ2TurboStartEndToVideo,
     "AtlasCloud Vidu Reference-to-Video Q1": AtlasViduReferenceToVideoQ1,
     "AtlasCloud Vidu Reference-to-Video 2.0": AtlasViduReferenceToVideoV2,
     "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video": AtlasViduQ2ProFastReferenceToVideo,
@@ -669,6 +697,20 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Van-2.5 Image-to-Video": "AtlasCloud Van-2.5 Image-to-Video",
     "AtlasCloud Van-2.6 Text-to-Video": "AtlasCloud Van-2.6 Text-to-Video",
     "AtlasCloud Van-2.6 Image-to-Video": "AtlasCloud Van-2.6 Image-to-Video",
+    "AtlasCloud InfiniteTalk Audio-to-Video": "AtlasCloud InfiniteTalk Audio-to-Video",
+    "AtlasCloud Vidu Q1 Text-to-Video": "AtlasCloud Vidu Q1 Text-to-Video",
+    "AtlasCloud Vidu Q1 Image-to-Video": "AtlasCloud Vidu Q1 Image-to-Video",
+    "AtlasCloud Vidu Q1 Start-End-to-Video": "AtlasCloud Vidu Q1 Start-End-to-Video",
+    "AtlasCloud Vidu Q1 Reference-to-Video": "AtlasCloud Vidu Q1 Reference-to-Video",
+    "AtlasCloud Vidu Q2 Text-to-Video": "AtlasCloud Vidu Q2 Text-to-Video",
+    "AtlasCloud Vidu Q2 Reference-to-Video": "AtlasCloud Vidu Q2 Reference-to-Video",
+    "AtlasCloud Vidu Q2-Pro Image-to-Video": "AtlasCloud Vidu Q2-Pro Image-to-Video",
+    "AtlasCloud Vidu Q2-Pro Start-End-to-Video": "AtlasCloud Vidu Q2-Pro Start-End-to-Video",
+    "AtlasCloud Vidu Q2-Pro Reference-to-Video": "AtlasCloud Vidu Q2-Pro Reference-to-Video",
+    "AtlasCloud Vidu Q2-Pro-Fast Image-to-Video": "AtlasCloud Vidu Q2-Pro-Fast Image-to-Video",
+    "AtlasCloud Vidu Q2-Pro-Fast Start-End-to-Video": "AtlasCloud Vidu Q2-Pro-Fast Start-End-to-Video",
+    "AtlasCloud Vidu Q2-Turbo Image-to-Video": "AtlasCloud Vidu Q2-Turbo Image-to-Video",
+    "AtlasCloud Vidu Q2-Turbo Start-End-to-Video": "AtlasCloud Vidu Q2-Turbo Start-End-to-Video",
     "AtlasCloud Vidu Reference-to-Video Q1": "AtlasCloud Vidu Reference-to-Video Q1",
     "AtlasCloud Vidu Reference-to-Video 2.0": "AtlasCloud Vidu Reference-to-Video 2.0",
     "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video": "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video",

--- a/tests/test_new_nodes_2026_04_17.py
+++ b/tests/test_new_nodes_2026_04_17.py
@@ -1,0 +1,146 @@
+"""Metadata-only tests for newly added nodes (2026-04-17).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_vidu_q1_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q1_t2v import AtlasViduQ1TextToVideo
+
+    required = AtlasViduQ1TextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasViduQ1TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q1_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q1_i2v import AtlasViduQ1ImageToVideo
+
+    required = AtlasViduQ1ImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert AtlasViduQ1ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q1_start_end_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q1_start_end import AtlasViduQ1StartEndToVideo
+
+    required = AtlasViduQ1StartEndToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert "end_image" in required
+    assert AtlasViduQ1StartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q1_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q1_r2v import AtlasViduQ1ReferenceToVideo
+
+    required = AtlasViduQ1ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasViduQ1ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_t2v import AtlasViduQ2TextToVideo
+
+    required = AtlasViduQ2TextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasViduQ2TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_r2v import AtlasViduQ2ReferenceToVideo
+
+    required = AtlasViduQ2ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasViduQ2ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_pro_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_pro_i2v import AtlasViduQ2ProImageToVideo
+
+    required = AtlasViduQ2ProImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert AtlasViduQ2ProImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_pro_start_end_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_pro_start_end import AtlasViduQ2ProStartEndToVideo
+
+    required = AtlasViduQ2ProStartEndToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert "end_image" in required
+    assert AtlasViduQ2ProStartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_pro_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_pro_r2v import AtlasViduQ2ProReferenceToVideo
+
+    required = AtlasViduQ2ProReferenceToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasViduQ2ProReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_pro_fast_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_pro_fast_i2v import AtlasViduQ2ProFastImageToVideo
+
+    required = AtlasViduQ2ProFastImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert AtlasViduQ2ProFastImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_pro_fast_start_end_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_pro_fast_start_end import AtlasViduQ2ProFastStartEndToVideo
+
+    required = AtlasViduQ2ProFastStartEndToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert "end_image" in required
+    assert AtlasViduQ2ProFastStartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_turbo_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_turbo_i2v import AtlasViduQ2TurboImageToVideo
+
+    required = AtlasViduQ2TurboImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert AtlasViduQ2TurboImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_vidu_q2_turbo_start_end_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.vidu_q2_turbo_start_end import AtlasViduQ2TurboStartEndToVideo
+
+    required = AtlasViduQ2TurboStartEndToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert "end_image" in required
+    assert AtlasViduQ2TurboStartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_infinitetalk_a2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_infinitetalk_a2v import AtlasInfiniteTalkAudioToVideo
+
+    required = AtlasInfiniteTalkAudioToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "audio" in required
+    assert AtlasInfiniteTalkAudioToVideo.RETURN_TYPES == ("STRING", "STRING")


### PR DESCRIPTION
This PR adds ComfyUI node support for newly available AtlasCloud visual models from /api/v1/models.

Added:
- Vidu Q1: text-to-video, image-to-video, start-end-to-video, reference-to-video
- Vidu Q2: text-to-video, reference-to-video
- Vidu Q2-Pro: image-to-video, start-end-to-video, reference-to-video
- Vidu Q2-Pro-Fast: image-to-video, start-end-to-video (reference-to-video already existed)
- Vidu Q2-Turbo: image-to-video, start-end-to-video
- InfiniteTalk: audio-to-video (atlascloud/infinitetalk)

Tests:
- ruff check .
- pytest tests/ -v
- E2E: existing tests/test_e2e.py and test_e2e_new_models*.py (skips Kling O3 unless opt-in)

Notes:
- For Vidu reference-to-video, API schema uses `subjects` (array) rather than `images`; nodes build a single subject from provided image URLs.
