### PR TITLE
feat: add Seedance 2.0 upscaled video nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedance V1.5 Pro Text-to-Video | bytedance/seedance-v1.5-pro/text-to-video |
 | AtlasCloud Seedance 2.0 Text-to-Video | bytedance/seedance-2.0/text-to-video |
 | AtlasCloud Seedance 2.0 Fast Text-to-Video | bytedance/seedance-2.0-fast/text-to-video |
+| AtlasCloud Seedance 2.0 Text-to-Video Upscaled | bytedance/seedance-2.0/text-to-video-upscaled |
+| AtlasCloud Seedance 2.0 Fast Text-to-Video Upscaled | bytedance/seedance-2.0-fast/text-to-video-upscaled |
 | AtlasCloud Seedance V1.5 Pro Text-to-Video Fast | bytedance/seedance-v1.5-pro/text-to-video-fast |
 | AtlasCloud Vidu Q1 Text-to-Video | vidu/q1/text-to-video |
 | AtlasCloud Vidu Q2 Text-to-Video | vidu/q2/text-to-video |
@@ -138,6 +140,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |
 | AtlasCloud Seedance 2.0 Reference-to-Video | bytedance/seedance-2.0/reference-to-video |
 | AtlasCloud Seedance 2.0 Fast Reference-to-Video | bytedance/seedance-2.0-fast/reference-to-video |
+| AtlasCloud Seedance 2.0 Reference-to-Video Upscaled | bytedance/seedance-2.0/reference-to-video-upscaled |
+| AtlasCloud Seedance 2.0 Fast Reference-to-Video Upscaled | bytedance/seedance-2.0-fast/reference-to-video-upscaled |
 | AtlasCloud Vidu Q3 Reference-to-Video | vidu/q3/reference-to-video |
 | AtlasCloud Vidu Q3-Mix Reference-to-Video | vidu/q3-mix/reference-to-video |
 | AtlasCloud VEO3.1 Image-to-Video | google/veo3.1/image-to-video |
@@ -209,6 +213,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Seedance V1.5 Pro Image-to-Video | bytedance/seedance-v1.5-pro/image-to-video |
 | AtlasCloud Seedance 2.0 Image-to-Video | bytedance/seedance-2.0/image-to-video |
 | AtlasCloud Seedance 2.0 Fast Image-to-Video | bytedance/seedance-2.0-fast/image-to-video |
+| AtlasCloud Seedance 2.0 Image-to-Video Upscaled | bytedance/seedance-2.0/image-to-video-upscaled |
+| AtlasCloud Seedance 2.0 Fast Image-to-Video Upscaled | bytedance/seedance-2.0-fast/image-to-video-upscaled |
 | AtlasCloud Seedance V1.5 Pro Image-to-Video (Spicy) | bytedance/seedance-v1.5-pro/image-to-video-spicy |
 | AtlasCloud Seedance V1 Lite I2V 1080p | bytedance/seedance-v1-lite-i2v-1080p |
 | AtlasCloud Seedance V1 Lite I2V 720p | bytedance/seedance-v1-lite-i2v-720p |

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_i2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_i2v_upscaled.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20FastImageToVideoUpscaled:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image (URL or base64)"}),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9', 'adaptive'],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "last_image": ("STRING", {"default": "", "tooltip": "Optional last frame image (URL/base64)"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return last frame (if supported)"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "The scene comes alive with gentle motion and cinematic lighting",
+        duration: int = 5,
+        resolution: str = "1080p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        last_image: str = "",
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Seedance 2.0 Fast Image-to-Video Upscaled")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-fast/image-to-video-upscaled",
+            "image": image,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_r2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_r2v_upscaled.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20FastReferenceToVideoUpscaled:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "reference_images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ image URLs/base64, one per line"},
+                ),
+                "reference_videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ video URLs, one per line"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "reference_audio": ("STRING", {"default": "", "tooltip": "Optional reference audio URL"}),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9', 'adaptive'],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        reference_images: str,
+        reference_videos: str,
+        prompt: str = "The scene comes alive with gentle motion and cinematic lighting",
+        reference_audio: str = "",
+        duration: int = 5,
+        resolution: str = "1080p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        ref_vids: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
+        if not ref_imgs and not ref_vids:
+            raise RuntimeError("Provide at least one reference image or reference video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-fast/reference-to-video-upscaled",
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        ra = (reference_audio or "").strip()
+        if ra:
+            payload["reference_audio"] = ra
+
+        if ref_imgs:
+            payload["reference_images"] = ref_imgs
+        if ref_vids:
+            payload["reference_videos"] = ref_vids
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_t2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_t2v_upscaled.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20FastTextToVideoUpscaled:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Text prompt",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return last frame (if supported)"},
+                ),
+
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "1080p",
+        ratio: str = "16:9",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Seedance 2.0 Fast Text-to-Video Upscaled")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-fast/text-to-video-upscaled",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_i2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_i2v_upscaled.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20ImageToVideoUpscaled:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image (URL or base64)"}),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9', 'adaptive'],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "last_image": ("STRING", {"default": "", "tooltip": "Optional last frame image (URL/base64)"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return last frame (if supported)"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "The scene comes alive with gentle motion and cinematic lighting",
+        duration: int = 5,
+        resolution: str = "1080p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        last_image: str = "",
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Seedance 2.0 Image-to-Video Upscaled")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0/image-to-video-upscaled",
+            "image": image,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_r2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_r2v_upscaled.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20ReferenceToVideoUpscaled:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "reference_images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ image URLs/base64, one per line"},
+                ),
+                "reference_videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ video URLs, one per line"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "reference_audio": ("STRING", {"default": "", "tooltip": "Optional reference audio URL"}),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9', 'adaptive'],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        reference_images: str,
+        reference_videos: str,
+        prompt: str = "The scene comes alive with gentle motion and cinematic lighting",
+        reference_audio: str = "",
+        duration: int = 5,
+        resolution: str = "1080p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        ref_vids: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
+        if not ref_imgs and not ref_vids:
+            raise RuntimeError("Provide at least one reference image or reference video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0/reference-to-video-upscaled",
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        ra = (reference_audio or "").strip()
+        if ra:
+            payload["reference_audio"] = ra
+
+        if ref_imgs:
+            payload["reference_images"] = ref_imgs
+        if ref_vids:
+            payload["reference_videos"] = ref_vids
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_t2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_t2v_upscaled.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20TextToVideoUpscaled:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Text prompt",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return last frame (if supported)"},
+                ),
+                "web_search": ("BOOLEAN", {"default": False, "tooltip": "Enable web search (seedance-2.0 only)"}),
+
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "1080p",
+        ratio: str = "16:9",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        web_search: bool = False,
+
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Seedance 2.0 Text-to-Video Upscaled")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0/text-to-video-upscaled",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+            "web_search": bool(web_search),
+
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -226,6 +226,12 @@ from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_r2v import AtlasSeeda
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_t2v import AtlasSeedance20FastTextToVideo
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_i2v import AtlasSeedance20FastImageToVideo
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_r2v import AtlasSeedance20FastReferenceToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_t2v_upscaled import AtlasSeedance20TextToVideoUpscaled
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_i2v_upscaled import AtlasSeedance20ImageToVideoUpscaled
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_r2v_upscaled import AtlasSeedance20ReferenceToVideoUpscaled
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_t2v_upscaled import AtlasSeedance20FastTextToVideoUpscaled
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_i2v_upscaled import AtlasSeedance20FastImageToVideoUpscaled
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_r2v_upscaled import AtlasSeedance20FastReferenceToVideoUpscaled
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_t2v import AtlasWan27TextToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_i2v import AtlasWan27ImageToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_r2v import AtlasWan27ReferenceToVideo
@@ -319,6 +325,12 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Seedance 2.0 Fast Text-to-Video": AtlasSeedance20FastTextToVideo,
     "AtlasCloud Seedance 2.0 Fast Image-to-Video": AtlasSeedance20FastImageToVideo,
     "AtlasCloud Seedance 2.0 Fast Reference-to-Video": AtlasSeedance20FastReferenceToVideo,
+    "AtlasCloud Seedance 2.0 Text-to-Video Upscaled": AtlasSeedance20TextToVideoUpscaled,
+    "AtlasCloud Seedance 2.0 Image-to-Video Upscaled": AtlasSeedance20ImageToVideoUpscaled,
+    "AtlasCloud Seedance 2.0 Reference-to-Video Upscaled": AtlasSeedance20ReferenceToVideoUpscaled,
+    "AtlasCloud Seedance 2.0 Fast Text-to-Video Upscaled": AtlasSeedance20FastTextToVideoUpscaled,
+    "AtlasCloud Seedance 2.0 Fast Image-to-Video Upscaled": AtlasSeedance20FastImageToVideoUpscaled,
+    "AtlasCloud Seedance 2.0 Fast Reference-to-Video Upscaled": AtlasSeedance20FastReferenceToVideoUpscaled,
     "AtlasCloud WAN2.7 Text-to-Video": AtlasWan27TextToVideo,
     "AtlasCloud WAN2.7 Image-to-Video": AtlasWan27ImageToVideo,
     "AtlasCloud WAN2.7 Reference-to-Video": AtlasWan27ReferenceToVideo,
@@ -557,6 +569,12 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedance 2.0 Fast Text-to-Video": "AtlasCloud Seedance 2.0 Fast Text-to-Video",
     "AtlasCloud Seedance 2.0 Fast Image-to-Video": "AtlasCloud Seedance 2.0 Fast Image-to-Video",
     "AtlasCloud Seedance 2.0 Fast Reference-to-Video": "AtlasCloud Seedance 2.0 Fast Reference-to-Video",
+    "AtlasCloud Seedance 2.0 Text-to-Video Upscaled": "AtlasCloud Seedance 2.0 Text-to-Video Upscaled",
+    "AtlasCloud Seedance 2.0 Image-to-Video Upscaled": "AtlasCloud Seedance 2.0 Image-to-Video Upscaled",
+    "AtlasCloud Seedance 2.0 Reference-to-Video Upscaled": "AtlasCloud Seedance 2.0 Reference-to-Video Upscaled",
+    "AtlasCloud Seedance 2.0 Fast Text-to-Video Upscaled": "AtlasCloud Seedance 2.0 Fast Text-to-Video Upscaled",
+    "AtlasCloud Seedance 2.0 Fast Image-to-Video Upscaled": "AtlasCloud Seedance 2.0 Fast Image-to-Video Upscaled",
+    "AtlasCloud Seedance 2.0 Fast Reference-to-Video Upscaled": "AtlasCloud Seedance 2.0 Fast Reference-to-Video Upscaled",
     "AtlasCloud WAN2.7 Text-to-Video": "AtlasCloud WAN2.7 Text-to-Video",
     "AtlasCloud WAN2.7 Image-to-Video": "AtlasCloud WAN2.7 Image-to-Video",
     "AtlasCloud WAN2.7 Reference-to-Video": "AtlasCloud WAN2.7 Reference-to-Video",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -238,7 +238,68 @@ def test_seedance_20_r2v_node_metadata():
     assert "atlas_client" in AtlasSeedance20ReferenceToVideo.INPUT_TYPES()["required"]
     assert "reference_images" in AtlasSeedance20ReferenceToVideo.INPUT_TYPES()["required"]
     assert "reference_videos" in AtlasSeedance20ReferenceToVideo.INPUT_TYPES()["required"]
-    assert AtlasSeedance20ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_t2v_upscaled_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_t2v_upscaled import (
+        AtlasSeedance20TextToVideoUpscaled,
+    )
+
+    assert "atlas_client" in AtlasSeedance20TextToVideoUpscaled.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasSeedance20TextToVideoUpscaled.INPUT_TYPES()["required"]
+    assert AtlasSeedance20TextToVideoUpscaled.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_i2v_upscaled_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_i2v_upscaled import (
+        AtlasSeedance20ImageToVideoUpscaled,
+    )
+
+    assert "atlas_client" in AtlasSeedance20ImageToVideoUpscaled.INPUT_TYPES()["required"]
+    assert "image" in AtlasSeedance20ImageToVideoUpscaled.INPUT_TYPES()["required"]
+    assert AtlasSeedance20ImageToVideoUpscaled.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_r2v_upscaled_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_r2v_upscaled import (
+        AtlasSeedance20ReferenceToVideoUpscaled,
+    )
+
+    assert "atlas_client" in AtlasSeedance20ReferenceToVideoUpscaled.INPUT_TYPES()["required"]
+    assert "reference_images" in AtlasSeedance20ReferenceToVideoUpscaled.INPUT_TYPES()["required"]
+    assert "reference_videos" in AtlasSeedance20ReferenceToVideoUpscaled.INPUT_TYPES()["required"]
+    assert AtlasSeedance20ReferenceToVideoUpscaled.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_fast_t2v_upscaled_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_t2v_upscaled import (
+        AtlasSeedance20FastTextToVideoUpscaled,
+    )
+
+    assert "atlas_client" in AtlasSeedance20FastTextToVideoUpscaled.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasSeedance20FastTextToVideoUpscaled.INPUT_TYPES()["required"]
+    assert AtlasSeedance20FastTextToVideoUpscaled.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_fast_i2v_upscaled_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_i2v_upscaled import (
+        AtlasSeedance20FastImageToVideoUpscaled,
+    )
+
+    assert "atlas_client" in AtlasSeedance20FastImageToVideoUpscaled.INPUT_TYPES()["required"]
+    assert "image" in AtlasSeedance20FastImageToVideoUpscaled.INPUT_TYPES()["required"]
+    assert AtlasSeedance20FastImageToVideoUpscaled.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_seedance_20_fast_r2v_upscaled_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_r2v_upscaled import (
+        AtlasSeedance20FastReferenceToVideoUpscaled,
+    )
+
+    assert "atlas_client" in AtlasSeedance20FastReferenceToVideoUpscaled.INPUT_TYPES()["required"]
+    assert "reference_images" in AtlasSeedance20FastReferenceToVideoUpscaled.INPUT_TYPES()["required"]
+    assert "reference_videos" in AtlasSeedance20FastReferenceToVideoUpscaled.INPUT_TYPES()["required"]
+    assert AtlasSeedance20FastReferenceToVideoUpscaled.RETURN_TYPES == ("STRING", "STRING")
 
 
 def test_seedance_20_fast_t2v_node_metadata():


### PR DESCRIPTION
## Summary
- Add nodes for Seedance 2.0 upscaled models (T2V/I2V/R2V)
- Add nodes for Seedance 2.0 Fast upscaled models (T2V/I2V/R2V)
- Update registry + README Available Nodes + metadata-only tests

## Why
- AtlasCloud models API lists 6 visual models not yet covered by ComfyUI nodes (Seedance 2.0 / Fast upscaled variants).

## Test plan
- [x] ruff check .
- [x] pytest tests/ -v
- [x] E2E baseline: tests/test_e2e.py (T2I=google/imagen4-fast)
- [x] E2E new models: verified locally (smoke tests for new nodes)

🤖 Generated with OpenClaw