### PR TITLE
Sync AtlasCloud models: add GPT Image-2 nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
 | AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
+| AtlasCloud GPT Image-2 Text-to-Image | openai/gpt-image-2/text-to-image |
 
 ### Video Extend
 
@@ -328,6 +329,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Flux Kontext Dev Edit | black-forest-labs/flux-kontext-dev |
 | AtlasCloud Flux Kontext Dev LoRA Edit | black-forest-labs/flux-kontext-dev-lora |
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
+| AtlasCloud GPT Image-2 Edit | openai/gpt-image-2/edit |
 
 > Nodes are continuously expanded as new models are added to AtlasCloud.
 

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_edit.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage2Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text instruction for editing"}),
+                # Schema requires 'images' as an array; follow existing GPT Image-1.5 Edit UX: multiline string, one per line.
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "input_fidelity": (
+                    ["low", "high"],
+                    {"default": "high", "tooltip": "Preserve details from input images (useful for faces/logos)."},
+                ),
+                "size": (
+                    ["1024x1024", "1024x1536", "1536x1024"],
+                    {"default": "1024x1024", "tooltip": "The size of the generated image in pixels (width x height)."},
+                ),
+                "quality": (
+                    ["low", "medium", "high"],
+                    {"default": "medium", "tooltip": "The quality of the generated image."},
+                ),
+                "output_format": (
+                    ["jpeg", "png"],
+                    {"default": "jpeg", "tooltip": "The format of the output image."},
+                ),
+                "enable_sync_mode": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "If true, server may try to return result synchronously"},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        input_fidelity: str = "high",
+        size: str = "1024x1024",
+        quality: str = "medium",
+        output_format: str = "jpeg",
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-2/edit",
+            "prompt": p,
+            "images": image_list,
+            "input_fidelity": input_fidelity,
+            "size": size,
+            "quality": quality,
+            "output_format": output_format,
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_t2i.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage2TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "size": (
+                    ["1024x1024", "1024x1536", "1536x1024"],
+                    {"default": "1024x1024", "tooltip": "The size of the generated image in pixels (width x height)."},
+                ),
+                "quality": (
+                    ["low", "medium", "high"],
+                    {"default": "medium", "tooltip": "The quality of the generated image."},
+                ),
+                "output_format": (
+                    ["jpeg", "png"],
+                    {"default": "jpeg", "tooltip": "The format of the output image."},
+                ),
+                "enable_base64_output": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Return base64 instead of URL if supported"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1024x1024",
+        quality: str = "medium",
+        output_format: str = "jpeg",
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-2/text-to-image",
+            "prompt": p,
+            "size": size,
+            "quality": quality,
+            "output_format": output_format,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -174,6 +174,8 @@ from atlascloud_comfyui.nodes.image.openai_gpt_image_1_mini_t2i import AtlasOpen
 from atlascloud_comfyui.nodes.image.openai_gpt_image_1_mini_edit import AtlasOpenAIGPTImage1MiniEdit
 from atlascloud_comfyui.nodes.image.openai_gpt_image_15_t2i import AtlasOpenAIGPTImage15TextToImage
 from atlascloud_comfyui.nodes.image.openai_gpt_image_15_edit import AtlasOpenAIGPTImage15Edit
+from atlascloud_comfyui.nodes.image.openai_gpt_image_2_t2i import AtlasOpenAIGPTImage2TextToImage
+from atlascloud_comfyui.nodes.image.openai_gpt_image_2_edit import AtlasOpenAIGPTImage2Edit
 from atlascloud_comfyui.nodes.image.qwen_image_20_t2i import AtlasQwenImage20TextToImage
 from atlascloud_comfyui.nodes.image.qwen_image_20_edit import AtlasQwenImage20Edit
 from atlascloud_comfyui.nodes.image.qwen_image_20_pro_t2i import AtlasQwenImage20ProTextToImage
@@ -453,6 +455,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud GPT Image-1 Mini Edit": AtlasOpenAIGPTImage1MiniEdit,
     "AtlasCloud GPT Image-1.5 Text-to-Image": AtlasOpenAIGPTImage15TextToImage,
     "AtlasCloud GPT Image-1.5 Edit": AtlasOpenAIGPTImage15Edit,
+    "AtlasCloud GPT Image-2 Text-to-Image": AtlasOpenAIGPTImage2TextToImage,
+    "AtlasCloud GPT Image-2 Edit": AtlasOpenAIGPTImage2Edit,
     "AtlasCloud Qwen Image 2.0 Text-to-Image": AtlasQwenImage20TextToImage,
     "AtlasCloud Qwen Image 2.0 Edit": AtlasQwenImage20Edit,
     "AtlasCloud Qwen Image 2.0 Pro Text-to-Image": AtlasQwenImage20ProTextToImage,

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -220,8 +220,28 @@ def test_seedance_20_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_t2v import AtlasSeedance20TextToVideo
 
     assert "atlas_client" in AtlasSeedance20TextToVideo.INPUT_TYPES()["required"]
-    assert "prompt" in AtlasSeedance20TextToVideo.INPUT_TYPES()["required"]
     assert AtlasSeedance20TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+# --- Batch X: API high-priority visual models (2026-04-23) ---
+
+def test_openai_gpt_image_2_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_2_t2i import AtlasOpenAIGPTImage2TextToImage
+
+    assert "atlas_client" in AtlasOpenAIGPTImage2TextToImage.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasOpenAIGPTImage2TextToImage.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage2TextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasOpenAIGPTImage2TextToImage.RETURN_NAMES
+
+
+def test_openai_gpt_image_2_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_2_edit import AtlasOpenAIGPTImage2Edit
+
+    assert "atlas_client" in AtlasOpenAIGPTImage2Edit.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasOpenAIGPTImage2Edit.INPUT_TYPES()["required"]
+    assert "images" in AtlasOpenAIGPTImage2Edit.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage2Edit.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasOpenAIGPTImage2Edit.RETURN_NAMES
 
 
 def test_seedance_20_i2v_node_metadata():


### PR DESCRIPTION
Adds ComfyUI nodes for newly listed AtlasCloud visual models:

- openai/gpt-image-2/text-to-image
- openai/gpt-image-2/edit

Includes registry + README updates and metadata-only tests.

Tested:
- ruff check .
- pytest tests/test_atlascloud_comfyui.py -q
- pytest tests/test_e2e.py::test_t2i (Imagen4 Fast baseline)
- pytest tests/test_e2e.py::test_t2v

Notes:
- Full suite `pytest tests/ -v` was started but terminated mid-run (likely long-running video E2E); reran targeted E2E tests above.