### PR TITLE
feat: add GPT Image-2 Developer nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
 | AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
 | AtlasCloud GPT Image-2 Text-to-Image | openai/gpt-image-2/text-to-image |
+| AtlasCloud GPT Image-2 Developer Text-to-Image | openai/gpt-image-2-developer/text-to-image |
 
 ### Video Extend
 
@@ -330,6 +331,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Flux Kontext Dev LoRA Edit | black-forest-labs/flux-kontext-dev-lora |
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
 | AtlasCloud GPT Image-2 Edit | openai/gpt-image-2/edit |
+| AtlasCloud GPT Image-2 Developer Edit | openai/gpt-image-2-developer/edit |
 
 > Nodes are continuously expanded as new models are added to AtlasCloud.
 

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_dev_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_dev_edit.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage2DeveloperEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text instruction for editing"}),
+                # Schema requires 'images' as an array; follow existing edit UX: multiline string, one per line.
+                "images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"},
+                ),
+            },
+            "optional": {
+                "size": (
+                    [
+                        "1:1",
+                        "3:2",
+                        "2:3",
+                        "4:3",
+                        "3:4",
+                        "5:4",
+                        "4:5",
+                        "16:9",
+                        "9:16",
+                        "2:1",
+                        "1:2",
+                        "21:9",
+                        "9:21",
+                    ],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (
+                    ["1k", "2k", "4k"],
+                    {"default": "1k", "tooltip": "Output resolution"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str = "1:1",
+        resolution: str = "1k",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-2-developer/edit",
+            "prompt": p,
+            "images": image_list,
+            "size": size,
+            "resolution": resolution,
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_dev_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_dev_t2i.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasOpenAIGPTImage2DeveloperTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "size": (
+                    [
+                        "1:1",
+                        "3:2",
+                        "2:3",
+                        "4:3",
+                        "3:4",
+                        "5:4",
+                        "4:5",
+                        "16:9",
+                        "9:16",
+                        "2:1",
+                        "1:2",
+                        "21:9",
+                        "9:21",
+                    ],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (
+                    ["1k", "2k", "4k"],
+                    {"default": "1k", "tooltip": "Output resolution"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1:1",
+        resolution: str = "1k",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "openai/gpt-image-2-developer/text-to-image",
+            "prompt": p,
+            "size": size,
+            "resolution": resolution,
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -176,6 +176,8 @@ from atlascloud_comfyui.nodes.image.openai_gpt_image_15_t2i import AtlasOpenAIGP
 from atlascloud_comfyui.nodes.image.openai_gpt_image_15_edit import AtlasOpenAIGPTImage15Edit
 from atlascloud_comfyui.nodes.image.openai_gpt_image_2_t2i import AtlasOpenAIGPTImage2TextToImage
 from atlascloud_comfyui.nodes.image.openai_gpt_image_2_edit import AtlasOpenAIGPTImage2Edit
+from atlascloud_comfyui.nodes.image.openai_gpt_image_2_dev_t2i import AtlasOpenAIGPTImage2DeveloperTextToImage
+from atlascloud_comfyui.nodes.image.openai_gpt_image_2_dev_edit import AtlasOpenAIGPTImage2DeveloperEdit
 from atlascloud_comfyui.nodes.image.qwen_image_20_t2i import AtlasQwenImage20TextToImage
 from atlascloud_comfyui.nodes.image.qwen_image_20_edit import AtlasQwenImage20Edit
 from atlascloud_comfyui.nodes.image.qwen_image_20_pro_t2i import AtlasQwenImage20ProTextToImage
@@ -457,6 +459,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud GPT Image-1.5 Edit": AtlasOpenAIGPTImage15Edit,
     "AtlasCloud GPT Image-2 Text-to-Image": AtlasOpenAIGPTImage2TextToImage,
     "AtlasCloud GPT Image-2 Edit": AtlasOpenAIGPTImage2Edit,
+    "AtlasCloud GPT Image-2 Developer Text-to-Image": AtlasOpenAIGPTImage2DeveloperTextToImage,
+    "AtlasCloud GPT Image-2 Developer Edit": AtlasOpenAIGPTImage2DeveloperEdit,
     "AtlasCloud Qwen Image 2.0 Text-to-Image": AtlasQwenImage20TextToImage,
     "AtlasCloud Qwen Image 2.0 Edit": AtlasQwenImage20Edit,
     "AtlasCloud Qwen Image 2.0 Pro Text-to-Image": AtlasQwenImage20ProTextToImage,
@@ -702,7 +706,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud GPT Image-1 Mini Edit": "AtlasCloud GPT Image-1 Mini Edit",
     "AtlasCloud GPT Image-1.5 Text-to-Image": "AtlasCloud GPT Image-1.5 Text-to-Image",
     "AtlasCloud GPT Image-1.5 Edit": "AtlasCloud GPT Image-1.5 Edit",
-    "AtlasCloud Qwen Image 2.0 Text-to-Image": "AtlasCloud Qwen Image 2.0 Text-to-Image",
+    "AtlasCloud GPT Image-2 Developer Text-to-Image": "AtlasCloud GPT Image-2 Developer Text-to-Image",
+    "AtlasCloud GPT Image-2 Developer Edit": "AtlasCloud GPT Image-2 Developer Edit",
+    "AtlasCloud Qwen Image 2.0 Text-to-Image": "AtlasCloud Qwen Image 2.0 Text-to-Image", 
     "AtlasCloud Qwen Image 2.0 Edit": "AtlasCloud Qwen Image 2.0 Edit",
     "AtlasCloud Qwen Image 2.0 Pro Text-to-Image": "AtlasCloud Qwen Image 2.0 Pro Text-to-Image",
     "AtlasCloud Qwen Image 2.0 Pro Edit": "AtlasCloud Qwen Image 2.0 Pro Edit",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -244,6 +244,27 @@ def test_openai_gpt_image_2_edit_node_metadata():
     assert "image_url" in AtlasOpenAIGPTImage2Edit.RETURN_NAMES
 
 
+def test_openai_gpt_image_2_developer_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_2_dev_t2i import (
+        AtlasOpenAIGPTImage2DeveloperTextToImage,
+    )
+
+    assert "atlas_client" in AtlasOpenAIGPTImage2DeveloperTextToImage.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasOpenAIGPTImage2DeveloperTextToImage.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage2DeveloperTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasOpenAIGPTImage2DeveloperTextToImage.RETURN_NAMES
+
+
+def test_openai_gpt_image_2_developer_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.openai_gpt_image_2_dev_edit import AtlasOpenAIGPTImage2DeveloperEdit
+
+    assert "atlas_client" in AtlasOpenAIGPTImage2DeveloperEdit.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasOpenAIGPTImage2DeveloperEdit.INPUT_TYPES()["required"]
+    assert "images" in AtlasOpenAIGPTImage2DeveloperEdit.INPUT_TYPES()["required"]
+    assert AtlasOpenAIGPTImage2DeveloperEdit.RETURN_TYPES == ("STRING", "STRING")
+    assert "image_url" in AtlasOpenAIGPTImage2DeveloperEdit.RETURN_NAMES
+
+
 def test_seedance_20_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_i2v import AtlasSeedance20ImageToVideo
 


### PR DESCRIPTION
Adds ComfyUI node support for newly listed AtlasCloud models:\n- openai/gpt-image-2-developer/text-to-image\n- openai/gpt-image-2-developer/edit\n\nChanges:\n- New node files for T2I + Edit (schema-driven params)\n- Registry + README updates\n- Metadata-only tests\n\nNotes:\n- E2E validated locally (T2I + Edit) with ATLASCLOUD_API_KEY.\n