### PR TITLE
feat: add HappyHorse-1.0 model nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO2 Text-to-Video | google/veo2 |
 | AtlasCloud WAN2.6 Text-to-Video | alibaba/wan-2.6/text-to-video |
 | AtlasCloud WAN2.7 Text-to-Video | alibaba/wan-2.7/text-to-video |
+| AtlasCloud HappyHorse 1.0 Text-to-Video | alibaba/happyhorse-1.0/text-to-video |
 | AtlasCloud WAN2.6 Video-to-Video | alibaba/wan-2.6/video-to-video |
 | AtlasCloud Kling Video O3 Pro Text-to-Video | kwaivgi/kling-video-o3-pro/text-to-video |
 | AtlasCloud Kling Video O3 Std Text-to-Video | kwaivgi/kling-video-o3-std/text-to-video |
@@ -189,6 +190,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling Effects | kwaivgi/kling-effects |
 | AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
 | AtlasCloud WAN2.7 Image-to-Video | alibaba/wan-2.7/image-to-video |
+| AtlasCloud HappyHorse 1.0 Image-to-Video | alibaba/happyhorse-1.0/image-to-video |
+| AtlasCloud HappyHorse 1.0 Reference-to-Video | alibaba/happyhorse-1.0/reference-to-video |
 | AtlasCloud WAN2.7 Reference-to-Video | alibaba/wan-2.7/reference-to-video |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
 | AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |
@@ -302,6 +305,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling Video O3 Pro Video-Edit | kwaivgi/kling-video-o3-pro/video-edit |
 | AtlasCloud Kling Video O3 Std Video-Edit | kwaivgi/kling-video-o3-std/video-edit |
 | AtlasCloud WAN2.7 Video-Edit | alibaba/wan-2.7/video-edit |
+| AtlasCloud HappyHorse 1.0 Video-Edit | alibaba/happyhorse-1.0/video-edit |
 
 ### Image Edit
 

--- a/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_0_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_0_i2v.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHappyHorse10ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image (URL/base64)"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Prompt (optional)"}),
+                "resolution": (
+                    ["720P", "1080P"],
+                    {"default": "1080P", "tooltip": "Resolution"},
+                ),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "",
+        resolution: str = "1080P",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for Alibaba HappyHorse-1.0 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/happyhorse-1.0/image-to-video",
+            "image": image,
+            "resolution": resolution,
+            "duration": int(duration),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_0_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_0_r2v.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHappyHorse10ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "images": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": "1+ reference image URLs/base64, one per line",
+                    },
+                ),
+            },
+            "optional": {
+                "resolution": (
+                    ["720P", "1080P"],
+                    {"default": "1080P", "tooltip": "Resolution"},
+                ),
+                "ratio": (
+                    ["16:9", "9:16", "1:1", "4:3", "3:4"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        resolution: str = "1080P",
+        ratio: str = "16:9",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba HappyHorse-1.0 Reference-to-Video")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required for Alibaba HappyHorse-1.0 Reference-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/happyhorse-1.0/reference-to-video",
+            "prompt": prompt,
+            "images": image_list,
+            "resolution": resolution,
+            "ratio": ratio,
+            "duration": int(duration),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_0_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_0_t2v.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHappyHorse10TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "resolution": (
+                    ["720P", "1080P"],
+                    {"default": "1080P", "tooltip": "Resolution"},
+                ),
+                "ratio": (
+                    ["16:9", "9:16", "1:1", "4:3", "3:4"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str = "1080P",
+        ratio: str = "16:9",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba HappyHorse-1.0 Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/happyhorse-1.0/text-to-video",
+            "prompt": prompt,
+            "resolution": resolution,
+            "ratio": ratio,
+            "duration": int(duration),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_0_video_edit.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_0_video_edit.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHappyHorse10VideoEdit:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video": ("STRING", {"default": "", "tooltip": "Input video URL"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "images": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": "Optional reference image URLs/base64, one per line (up to 5)",
+                    },
+                ),
+                "resolution": (
+                    ["720P", "1080P"],
+                    {"default": "1080P", "tooltip": "Resolution"},
+                ),
+                "audio_setting": (
+                    ["auto", "origin"],
+                    {
+                        "default": "auto",
+                        "tooltip": "Audio behavior (auto or keep origin)",
+                    },
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 1200, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video: str,
+        prompt: str,
+        images: str = "",
+        resolution: str = "1080P",
+        audio_setting: str = "auto",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 1200,
+    ) -> Tuple[str, str]:
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required for Alibaba HappyHorse-1.0 Video-Edit")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba HappyHorse-1.0 Video-Edit")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/happyhorse-1.0/video-edit",
+            "video": video,
+            "prompt": prompt,
+            "resolution": resolution,
+            "audio_setting": audio_setting,
+        }
+
+        if image_list:
+            payload["images"] = image_list
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -240,6 +240,10 @@ from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_t2v import AtlasWan27TextToV
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_i2v import AtlasWan27ImageToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_r2v import AtlasWan27ReferenceToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_video_edit import AtlasWan27VideoEdit
+from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_t2v import AtlasHappyHorse10TextToVideo
+from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_i2v import AtlasHappyHorse10ImageToVideo
+from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_r2v import AtlasHappyHorse10ReferenceToVideo
+from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_video_edit import AtlasHappyHorse10VideoEdit
 from atlascloud_comfyui.nodes.video.google_veo31_lite_t2v import AtlasVeo31LiteTextToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_lite_i2v import AtlasVeo31LiteImageToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_lite_start_end_frame_t2v import AtlasVeo31LiteStartEndFrameToVideo
@@ -339,6 +343,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.7 Image-to-Video": AtlasWan27ImageToVideo,
     "AtlasCloud WAN2.7 Reference-to-Video": AtlasWan27ReferenceToVideo,
     "AtlasCloud WAN2.7 Video-Edit": AtlasWan27VideoEdit,
+    "AtlasCloud HappyHorse 1.0 Text-to-Video": AtlasHappyHorse10TextToVideo,
+    "AtlasCloud HappyHorse 1.0 Image-to-Video": AtlasHappyHorse10ImageToVideo,
+    "AtlasCloud HappyHorse 1.0 Reference-to-Video": AtlasHappyHorse10ReferenceToVideo,
+    "AtlasCloud HappyHorse 1.0 Video-Edit": AtlasHappyHorse10VideoEdit,
     "AtlasCloud VEO3.1 Lite Text-to-Video": AtlasVeo31LiteTextToVideo,
     "AtlasCloud VEO3.1 Lite Image-to-Video": AtlasVeo31LiteImageToVideo,
     "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video": AtlasVeo31LiteStartEndFrameToVideo,
@@ -587,6 +595,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.7 Image-to-Video": "AtlasCloud WAN2.7 Image-to-Video",
     "AtlasCloud WAN2.7 Reference-to-Video": "AtlasCloud WAN2.7 Reference-to-Video",
     "AtlasCloud WAN2.7 Video-Edit": "AtlasCloud WAN2.7 Video-Edit",
+    "AtlasCloud HappyHorse 1.0 Text-to-Video": "AtlasCloud HappyHorse 1.0 Text-to-Video",
+    "AtlasCloud HappyHorse 1.0 Image-to-Video": "AtlasCloud HappyHorse 1.0 Image-to-Video",
+    "AtlasCloud HappyHorse 1.0 Reference-to-Video": "AtlasCloud HappyHorse 1.0 Reference-to-Video",
+    "AtlasCloud HappyHorse 1.0 Video-Edit": "AtlasCloud HappyHorse 1.0 Video-Edit",
     "AtlasCloud VEO3.1 Lite Text-to-Video": "AtlasCloud VEO3.1 Lite Text-to-Video",
     "AtlasCloud VEO3.1 Lite Image-to-Video": "AtlasCloud VEO3.1 Lite Image-to-Video",
     "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video": "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -402,6 +402,42 @@ def test_wan27_video_edit_node_metadata():
     assert AtlasWan27VideoEdit.RETURN_TYPES == ("STRING", "STRING")
 
 
+# --- Batch Y: API high-priority visual models (2026-04-27) ---
+
+def test_happyhorse_10_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_t2v import AtlasHappyHorse10TextToVideo
+
+    assert "atlas_client" in AtlasHappyHorse10TextToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasHappyHorse10TextToVideo.INPUT_TYPES()["required"]
+    assert AtlasHappyHorse10TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_happyhorse_10_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_i2v import AtlasHappyHorse10ImageToVideo
+
+    assert "atlas_client" in AtlasHappyHorse10ImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasHappyHorse10ImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasHappyHorse10ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_happyhorse_10_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_r2v import AtlasHappyHorse10ReferenceToVideo
+
+    assert "atlas_client" in AtlasHappyHorse10ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasHappyHorse10ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "images" in AtlasHappyHorse10ReferenceToVideo.INPUT_TYPES()["required"]
+    assert AtlasHappyHorse10ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_happyhorse_10_video_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_video_edit import AtlasHappyHorse10VideoEdit
+
+    assert "atlas_client" in AtlasHappyHorse10VideoEdit.INPUT_TYPES()["required"]
+    assert "video" in AtlasHappyHorse10VideoEdit.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasHappyHorse10VideoEdit.INPUT_TYPES()["required"]
+    assert AtlasHappyHorse10VideoEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
 def test_veo31_lite_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.google_veo31_lite_t2v import AtlasVeo31LiteTextToVideo
 

--- a/tests/test_e2e_new_models_2026_04_27.py
+++ b/tests/test_e2e_new_models_2026_04_27.py
@@ -1,0 +1,175 @@
+"""End-to-end tests for newly added HappyHorse-1.0 nodes (2026-04-27).
+
+Requires ATLASCLOUD_API_KEY environment variable.
+Run:
+  ATLASCLOUD_API_KEY=... PYTHONPATH=../ComfyUI pytest tests/test_e2e_new_models_2026_04_27.py -v -s
+
+Notes:
+- Designed to be optional in CI (skips if no key).
+- Video-edit is opt-in due to queue/credit variability.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+# Add src to path
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+_HAS_KEY = bool(os.getenv("ATLASCLOUD_API_KEY", "").strip())
+skip_no_key = pytest.mark.skipif(not _HAS_KEY, reason="ATLASCLOUD_API_KEY not set")
+
+from atlascloud_comfyui.client.atlas_client import AtlasClient
+from atlascloud_comfyui.nodes.auth.atlas_client_node import AtlasClientHandle
+
+
+def make_client() -> AtlasClientHandle:
+    client = AtlasClient.from_env()
+    return AtlasClientHandle(client=client)
+
+
+# Module-level cache so I2V tests can reuse the T2I output
+_imagen4_fast_image_url: str | None = None
+
+
+@skip_no_key
+def test_setup_image_fixture_imagen4_fast_t2i():
+    """Use a stable T2I model to generate an image for downstream I2V tests."""
+    global _imagen4_fast_image_url
+
+    from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import AtlasImagen4FastTextToImage
+
+    node = AtlasImagen4FastTextToImage()
+    handle = make_client()
+
+    start = time.time()
+    image_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A clean studio photo of a running horse figurine on a white background",
+        aspect_ratio="1:1",
+        num_images=1,
+        enable_base64_output=False,
+        poll_interval_sec=2.0,
+        timeout_sec=180,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  image_url:     {image_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert image_url
+    assert image_url.startswith("http") or image_url.startswith("data:"), image_url[:80]
+
+    _imagen4_fast_image_url = image_url
+
+
+@skip_no_key
+def test_happyhorse_10_t2v():
+    """HappyHorse-1.0 text-to-video should return a video URL."""
+    from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_t2v import AtlasHappyHorse10TextToVideo
+
+    node = AtlasHappyHorse10TextToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A horse gallops across a grassy field at golden hour, cinematic",
+        resolution="720P",
+        ratio="16:9",
+        duration=5,
+        poll_interval_sec=3.0,
+        timeout_sec=600,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]
+
+
+@skip_no_key
+def test_happyhorse_10_i2v_uses_generated_image():
+    """HappyHorse-1.0 image-to-video should work using an Imagen4 Fast image as input."""
+    from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_i2v import AtlasHappyHorse10ImageToVideo
+
+    image_url = _imagen4_fast_image_url
+    if not image_url:
+        pytest.skip("No image available (test_setup_image_fixture_imagen4_fast_t2i must run first)")
+
+    node = AtlasHappyHorse10ImageToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        image=image_url,
+        prompt="The horse figurine slowly turns on a rotating display stand",
+        resolution="720P",
+        duration=5,
+        poll_interval_sec=3.0,
+        timeout_sec=600,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]
+
+
+@skip_no_key
+def test_happyhorse_10_video_edit_opt_in_requires_input_video():
+    """Video-edit needs a real video URL; skip unless provided.
+
+    Queueing can be long; treat it as opt-in.
+    """
+
+    if os.getenv("ATLASCLOUD_RUN_HAPPYHORSE_VIDEO_EDIT_E2E", "").strip() != "1":
+        pytest.skip("Set ATLASCLOUD_RUN_HAPPYHORSE_VIDEO_EDIT_E2E=1 to run HappyHorse Video-Edit E2E")
+
+    video = os.getenv("ATLASCLOUD_E2E_VIDEO_URL", "").strip()
+    if not video:
+        pytest.skip("Set ATLASCLOUD_E2E_VIDEO_URL to run video-edit E2E")
+
+    if os.getenv("ATLASCLOUD_SKIP_VIDEO_EDIT_E2E", "").strip() == "1":
+        pytest.skip("ATLASCLOUD_SKIP_VIDEO_EDIT_E2E=1")
+
+    from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_video_edit import AtlasHappyHorse10VideoEdit
+
+    node = AtlasHappyHorse10VideoEdit()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        video=video,
+        prompt="Stabilize the clip and enhance the color grading",
+        resolution="720P",
+        audio_setting="origin",
+        poll_interval_sec=3.0,
+        timeout_sec=1200,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]


### PR DESCRIPTION
## Summary
- Add ComfyUI node support for Alibaba HappyHorse-1.0 video models:
  - Text-to-Video: `alibaba/happyhorse-1.0/text-to-video`
  - Image-to-Video: `alibaba/happyhorse-1.0/image-to-video`
  - Reference-to-Video: `alibaba/happyhorse-1.0/reference-to-video`
  - Video-Edit: `alibaba/happyhorse-1.0/video-edit`
- Update node registry + README tables
- Add metadata-only tests + E2E tests (video-edit E2E is opt-in)

## Why
- Models appear in AtlasCloud /api/v1/models as NEW (visual/video) and were missing from the ComfyUI nodes.

## Test plan
- [x] `ruff check .`
- [x] `pytest tests/ -v`
- [x] Baseline E2E: `PYTHONPATH=../ComfyUI ATLASCLOUD_API_KEY=... pytest tests/test_e2e.py -v -s`
- [x] New models E2E: `PYTHONPATH=../ComfyUI ATLASCLOUD_API_KEY=... pytest tests/test_e2e_new_models_2026_04_27.py -v -s` (video-edit skipped by default)

🤖 Generated with OpenClaw