### PR TITLE
feat: add WAN2.2 turbo infinite image-to-video nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud WAN2.2 Animate Move | alibaba/wan-2.2/animate-move |
 | AtlasCloud WAN2.2 Image-to-Video 720p | alibaba/wan-2.2/i2v-720p |
 | AtlasCloud WAN2.2 Image-to-Video 480p | alibaba/wan-2.2/i2v-480p |
+| AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video | atlascloud/wan-2.2-turbo/infinite-image-to-video |
+| AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video LoRA | atlascloud/wan-2.2-turbo/infinite-image-to-video-lora |
+| AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video | atlascloud/wan-2.2-turbo-spicy/infinite-image-to-video |
+| AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA | atlascloud/wan-2.2-turbo-spicy/infinite-image-to-video-lora |
 | AtlasCloud Van-2.6 Image-to-Video | atlascloud/van-2.6/image-to-video |
 | AtlasCloud Seedance V1 Pro Fast Image-to-Video | bytedance/seedance-v1-pro-fast/image-to-video |
 | AtlasCloud Seedance V1 Pro I2V 1080p | bytedance/seedance-v1-pro-i2v-1080p |

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_turbo_infinite_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_turbo_infinite_i2v.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22TurboInfiniteImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {"default": "", "tooltip": "First-frame image URL/base64"},
+                ),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "tooltip": "Prompts (one per line). Each segment generates `duration` seconds.",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Seconds per prompt segment"},
+                ),
+                "resolution": (
+                    ["480p", "720p", "1080p"],
+                    {"default": "720p", "tooltip": "Output resolution"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        # Schema expects an ordered list of prompts (array). ComfyUI provides STRING, so split by lines.
+        prompt_lines: List[str] = [ln.strip() for ln in (prompt or "").splitlines() if ln.strip()]
+        if not prompt_lines:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2-turbo/infinite-image-to-video",
+            "image": image,
+            "prompt": prompt_lines,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_turbo_infinite_i2v_lora.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_turbo_infinite_i2v_lora.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22TurboInfiniteImageToVideoLoRA:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {"default": "", "tooltip": "First-frame image URL/base64"},
+                ),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "tooltip": "Prompts (one per line). Each segment generates `duration` seconds.",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Seconds per prompt segment"},
+                ),
+                "resolution": (
+                    ["480p", "720p", "1080p"],
+                    {"default": "720p", "tooltip": "Output resolution"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                # LoRA fields are arrays in the schema; expose as JSON strings to keep inputs simple.
+                "loras_json": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `loras` (leave empty to omit)",
+                    },
+                ),
+                "low_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `low_noise_loras` (leave empty to omit)",
+                    },
+                ),
+                "high_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `high_noise_loras` (leave empty to omit)",
+                    },
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720p",
+        seed: int = -1,
+        loras_json: str = "",
+        low_noise_loras_json: str = "",
+        high_noise_loras_json: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        import json
+
+        client = atlas_client.client
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt_lines: List[str] = [ln.strip() for ln in (prompt or "").splitlines() if ln.strip()]
+        if not prompt_lines:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2-turbo/infinite-image-to-video-lora",
+            "image": image,
+            "prompt": prompt_lines,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+        }
+
+        for key, raw in [
+            ("loras", loras_json),
+            ("low_noise_loras", low_noise_loras_json),
+            ("high_noise_loras", high_noise_loras_json),
+        ]:
+            raw = (raw or "").strip()
+            if not raw:
+                continue
+            try:
+                val = json.loads(raw)
+            except Exception as e:
+                raise RuntimeError(f"{key}_json must be valid JSON: {e}")
+            if not isinstance(val, list):
+                raise RuntimeError(f"{key}_json must be a JSON array")
+            payload[key] = val
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_turbo_spicy_infinite_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_turbo_spicy_infinite_i2v.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22TurboSpicyInfiniteImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {"default": "", "tooltip": "First-frame image URL/base64"},
+                ),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "tooltip": "Prompts (one per line). Each segment generates `duration` seconds.",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Seconds per prompt segment"},
+                ),
+                "resolution": (
+                    ["480p", "720p", "1080p"],
+                    {"default": "720p", "tooltip": "Output resolution"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt_lines: List[str] = [ln.strip() for ln in (prompt or "").splitlines() if ln.strip()]
+        if not prompt_lines:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2-turbo-spicy/infinite-image-to-video",
+            "image": image,
+            "prompt": prompt_lines,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_turbo_spicy_infinite_i2v_lora.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_2_turbo_spicy_infinite_i2v_lora.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22TurboSpicyInfiniteImageToVideoLoRA:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {"default": "", "tooltip": "First-frame image URL/base64"},
+                ),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "tooltip": "Prompts (one per line). Each segment generates `duration` seconds.",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Seconds per prompt segment"},
+                ),
+                "resolution": (
+                    ["480p", "720p", "1080p"],
+                    {"default": "720p", "tooltip": "Output resolution"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "loras_json": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `loras` (leave empty to omit)",
+                    },
+                ),
+                "low_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `low_noise_loras` (leave empty to omit)",
+                    },
+                ),
+                "high_noise_loras_json": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "multiline": True,
+                        "tooltip": "Optional JSON array for `high_noise_loras` (leave empty to omit)",
+                    },
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720p",
+        seed: int = -1,
+        loras_json: str = "",
+        low_noise_loras_json: str = "",
+        high_noise_loras_json: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        import json
+
+        client = atlas_client.client
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt_lines: List[str] = [ln.strip() for ln in (prompt or "").splitlines() if ln.strip()]
+        if not prompt_lines:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2-turbo-spicy/infinite-image-to-video-lora",
+            "image": image,
+            "prompt": prompt_lines,
+            "duration": int(duration),
+            "resolution": resolution,
+            "seed": int(seed),
+        }
+
+        for key, raw in [
+            ("loras", loras_json),
+            ("low_noise_loras", low_noise_loras_json),
+            ("high_noise_loras", high_noise_loras_json),
+        ]:
+            raw = (raw or "").strip()
+            if not raw:
+                continue
+            try:
+                val = json.loads(raw)
+            except Exception as e:
+                raise RuntimeError(f"{key}_json must be valid JSON: {e}")
+            if not isinstance(val, list):
+                raise RuntimeError(f"{key}_json must be a JSON array")
+            payload[key] = val
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -189,6 +189,18 @@ from atlascloud_comfyui.nodes.video.wan25_fast_t2v import AtlasWAN25TextToVideoF
 from atlascloud_comfyui.nodes.video.wan25_fast_i2v import AtlasWAN25ImageToVideoFast
 from atlascloud_comfyui.nodes.video.wan22_animate_mix import AtlasWan22AnimateMix
 from atlascloud_comfyui.nodes.video.wan22_animate_move import AtlasWan22AnimateMove
+from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_infinite_i2v import (
+    AtlasWan22TurboInfiniteImageToVideo,
+)
+from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_infinite_i2v_lora import (
+    AtlasWan22TurboInfiniteImageToVideoLoRA,
+)
+from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_spicy_infinite_i2v import (
+    AtlasWan22TurboSpicyInfiniteImageToVideo,
+)
+from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_spicy_infinite_i2v_lora import (
+    AtlasWan22TurboSpicyInfiniteImageToVideoLoRA,
+)
 from atlascloud_comfyui.nodes.video.van25_t2v import AtlasAtlascloudVan25TextToVideo
 from atlascloud_comfyui.nodes.video.van25_i2v import AtlasAtlascloudVan25ImageToVideo
 from atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
@@ -435,6 +447,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.2 Image-to-Video 480p": AtlasAlibabaWan22I2V480p,
     "AtlasCloud WAN2.2 Animate Mix": AtlasWan22AnimateMix,
     "AtlasCloud WAN2.2 Animate Move": AtlasWan22AnimateMove,
+    "AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video": AtlasWan22TurboInfiniteImageToVideo,
+    "AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video LoRA": AtlasWan22TurboInfiniteImageToVideoLoRA,
+    "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video": AtlasWan22TurboSpicyInfiniteImageToVideo,
+    "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA": AtlasWan22TurboSpicyInfiniteImageToVideoLoRA,
     "AtlasCloud Imagen4 Ultra Text-to-Image": AtlasImagen4UltraTextToImage,
     "AtlasCloud Imagen3 Text-to-Image": AtlasImagen3TextToImage,
     "AtlasCloud Imagen3 Fast Text-to-Image": AtlasImagen3FastTextToImage,
@@ -688,6 +704,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.2 Image-to-Video 480p": "AtlasCloud WAN2.2 Image-to-Video 480p",
     "AtlasCloud WAN2.2 Animate Mix": "AtlasCloud WAN2.2 Animate Mix",
     "AtlasCloud WAN2.2 Animate Move": "AtlasCloud WAN2.2 Animate Move",
+    "AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video": "AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video",
+    "AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video LoRA": "AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video LoRA",
+    "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video": "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video",
+    "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA": "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA",
     "AtlasCloud Imagen4 Ultra Text-to-Image": "AtlasCloud Imagen4 Ultra Text-to-Image",
     "AtlasCloud Imagen3 Text-to-Image": "AtlasCloud Imagen3 Text-to-Image",
     "AtlasCloud Imagen3 Fast Text-to-Image": "AtlasCloud Imagen3 Fast Text-to-Image",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -180,6 +180,52 @@ def test_wan22_turbo_spicy_i2v_lora_node_metadata():
     assert AtlasWan22TurboSpicyImageToVideoLora.RETURN_TYPES == ("STRING", "STRING")
 
 
+# --- Batch: Wan 2.2 Turbo Infinite I2V (2026-05-07) ---
+
+def test_wan22_turbo_infinite_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_infinite_i2v import (
+        AtlasWan22TurboInfiniteImageToVideo,
+    )
+
+    assert "atlas_client" in AtlasWan22TurboInfiniteImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22TurboInfiniteImageToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan22TurboInfiniteImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan22TurboInfiniteImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan22_turbo_infinite_i2v_lora_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_infinite_i2v_lora import (
+        AtlasWan22TurboInfiniteImageToVideoLoRA,
+    )
+
+    assert "atlas_client" in AtlasWan22TurboInfiniteImageToVideoLoRA.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22TurboInfiniteImageToVideoLoRA.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan22TurboInfiniteImageToVideoLoRA.INPUT_TYPES()["required"]
+    assert AtlasWan22TurboInfiniteImageToVideoLoRA.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan22_turbo_spicy_infinite_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_spicy_infinite_i2v import (
+        AtlasWan22TurboSpicyInfiniteImageToVideo,
+    )
+
+    assert "atlas_client" in AtlasWan22TurboSpicyInfiniteImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22TurboSpicyInfiniteImageToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan22TurboSpicyInfiniteImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan22TurboSpicyInfiniteImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_wan22_turbo_spicy_infinite_i2v_lora_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_spicy_infinite_i2v_lora import (
+        AtlasWan22TurboSpicyInfiniteImageToVideoLoRA,
+    )
+
+    assert "atlas_client" in AtlasWan22TurboSpicyInfiniteImageToVideoLoRA.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22TurboSpicyInfiniteImageToVideoLoRA.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan22TurboSpicyInfiniteImageToVideoLoRA.INPUT_TYPES()["required"]
+    assert AtlasWan22TurboSpicyInfiniteImageToVideoLoRA.RETURN_TYPES == ("STRING", "STRING")
+
+
 def test_wan22_spicy_video_extend_lora_node_metadata():
     from src.atlascloud_comfyui.nodes.video.alibaba_wan_2_2_spicy_video_extend_lora import AtlasWan22SpicyVideoExtendLora
 

--- a/tests/test_e2e_new_models_2026_05_07.py
+++ b/tests/test_e2e_new_models_2026_05_07.py
@@ -1,0 +1,144 @@
+"""End-to-end (opt-in) smoke tests for nodes added on 2026-05-07.
+
+Models:
+- atlascloud/wan-2.2-turbo/infinite-image-to-video
+- atlascloud/wan-2.2-turbo/infinite-image-to-video-lora
+- atlascloud/wan-2.2-turbo-spicy/infinite-image-to-video
+- atlascloud/wan-2.2-turbo-spicy/infinite-image-to-video-lora
+
+Notes:
+- These tests are optional in CI (skip if no key).
+- Infinite I2V models may queue; keep this suite opt-in to avoid hangs.
+
+Run locally (opt-in):
+  ATLASCLOUD_API_KEY=... ATLASCLOUD_RUN_WAN22_INFINITE_E2E=1 PYTHONPATH=../ComfyUI \
+    pytest tests/test_e2e_new_models_2026_05_07.py -v -s
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import sys
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+_HAS_KEY = bool(os.getenv("ATLASCLOUD_API_KEY", "").strip())
+_OPT_IN = bool(os.getenv("ATLASCLOUD_RUN_WAN22_INFINITE_E2E", "").strip())
+
+skip_no_key = pytest.mark.skipif(not _HAS_KEY, reason="ATLASCLOUD_API_KEY not set")
+skip_no_opt_in = pytest.mark.skipif(
+    not _OPT_IN,
+    reason="Set ATLASCLOUD_RUN_WAN22_INFINITE_E2E=1 to run (avoid queue/credit hangs by default)",
+)
+
+from atlascloud_comfyui.client.atlas_client import AtlasClient
+from atlascloud_comfyui.nodes.auth.atlas_client_node import AtlasClientHandle
+
+
+def make_client() -> AtlasClientHandle:
+    client = AtlasClient.from_env()
+    return AtlasClientHandle(client=client)
+
+
+_image_url: str | None = None
+
+
+@skip_no_key
+def test_setup_image_fixture_imagen4_fast_t2i():
+    """Generate an image that can be used as input for I2V tests."""
+
+    global _image_url
+
+    from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import AtlasImagen4FastTextToImage
+
+    node = AtlasImagen4FastTextToImage()
+    handle = make_client()
+
+    start = time.time()
+    image_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A clean studio photo of a cute cat plush toy on a white background",
+        aspect_ratio="1:1",
+        num_images=1,
+        enable_base64_output=False,
+        poll_interval_sec=2.0,
+        timeout_sec=180,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  image_url:     {image_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert image_url
+    _image_url = image_url
+
+
+@skip_no_key
+@skip_no_opt_in
+def test_wan22_turbo_infinite_i2v_smoke():
+    from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_infinite_i2v import (
+        AtlasWan22TurboInfiniteImageToVideo,
+    )
+
+    if not _image_url:
+        pytest.skip("No image available (setup test must run first)")
+
+    node = AtlasWan22TurboInfiniteImageToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        image=_image_url,
+        prompt="A cat plush toy slowly rotates\nSoft studio lighting",
+        duration=3,
+        resolution="480p",
+        seed=-1,
+        poll_interval_sec=3.0,
+        timeout_sec=240,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert video_url.startswith("http")
+
+
+@skip_no_key
+@skip_no_opt_in
+def test_wan22_turbo_spicy_infinite_i2v_smoke():
+    from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_spicy_infinite_i2v import (
+        AtlasWan22TurboSpicyInfiniteImageToVideo,
+    )
+
+    if not _image_url:
+        pytest.skip("No image available (setup test must run first)")
+
+    node = AtlasWan22TurboSpicyInfiniteImageToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        image=_image_url,
+        prompt="A cat plush toy blinks\nCute stop-motion style",
+        duration=3,
+        resolution="480p",
+        seed=-1,
+        poll_interval_sec=3.0,
+        timeout_sec=240,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert video_url.startswith("http")


### PR DESCRIPTION
## Summary
- Add 4 new ComfyUI nodes for WAN2.2 Turbo Infinite I2V variants (Turbo / Turbo+LoRA / Spicy / Spicy+LoRA).
- Nodes follow existing patterns: runtime-only imports, payload contains exact model id, poll_prediction + outputs[0].
- Update registry + README tables.
- Add metadata-only tests (no API key required).

## Models added
- atlascloud/wan-2.2-turbo/infinite-image-to-video
- atlascloud/wan-2.2-turbo/infinite-image-to-video-lora
- atlascloud/wan-2.2-turbo-spicy/infinite-image-to-video
- atlascloud/wan-2.2-turbo-spicy/infinite-image-to-video-lora

## Test plan
- [x] ruff check .
- [x] pytest tests/test_atlascloud_comfyui.py -v
- [ ] E2E: blocked (HTTP 402 Payment Required with current key) — marked in report

🤖 Generated with OpenClaw