### PR TITLE
feat: add WAN2.2 Turbo Image-to-Video node

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Vidu Q3-Turbo Image-to-Video | vidu/q3-turbo/image-to-video |
 | AtlasCloud Vidu Q3-Turbo Start-End-to-Video | vidu/q3-turbo/start-end-to-video |
 | AtlasCloud WAN2.2 Spicy Image-to-Video | alibaba/wan-2.2-spicy/image-to-video |
+| AtlasCloud WAN2.2 Turbo Image-to-Video | atlascloud/wan-2.2-turbo/image-to-video |
 | AtlasCloud WAN2.2 Turbo Spicy Image-to-Video | atlascloud/wan-2.2-turbo-spicy/image-to-video |
 | AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA | atlascloud/wan-2.2-turbo-spicy/image-to-video-lora |
 | AtlasCloud WAN2.2 Spicy Image-to-Video LoRA | alibaba/wan-2.2-spicy/image-to-video-lora |

--- a/src/atlascloud_comfyui/nodes/video/wan22_turbo_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/wan22_turbo_i2v.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan22TurboImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64"}),
+                "prompt": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "Text prompt"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "Negative prompt (optional)"},
+                ),
+                "resolution": (
+                    ["480p", "720p", "1080p"],
+                    {"default": "720p", "tooltip": "Resolution"},
+                ),
+                "duration": (
+                    [5],
+                    {"default": 5, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        negative_prompt: str = "",
+        resolution: str = "720p",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.2-turbo/image-to-video",
+            "image": image,
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+        }
+
+        np = (negative_prompt or "").strip()
+        if np:
+            payload["negative_prompt"] = np
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -81,6 +81,7 @@ from atlascloud_comfyui.nodes.video.wan22_spicy_i2v import AtlasWan22SpicyImageT
 from atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v import AtlasWan22TurboSpicyImageToVideo
 from atlascloud_comfyui.nodes.video.wan22_spicy_i2v_lora import AtlasWan22SpicyImageToVideoLora
 from atlascloud_comfyui.nodes.video.wan22_turbo_spicy_i2v_lora import AtlasWan22TurboSpicyImageToVideoLora
+from atlascloud_comfyui.nodes.video.wan22_turbo_i2v import AtlasWan22TurboImageToVideo
 from atlascloud_comfyui.nodes.video.veo3_fast_t2v import AtlasVeo3FastTextToVideo
 from atlascloud_comfyui.nodes.video.veo31_i2v import AtlasVeo31ImageToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_fast_t2v import AtlasVeo31FastTextToVideo
@@ -409,6 +410,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Vidu Q3-Turbo Image-to-Video": AtlasViduQ3TurboImageToVideo,
     "AtlasCloud Vidu Q3-Turbo Start-End-to-Video": AtlasViduQ3TurboStartEndToVideo,
     "AtlasCloud WAN2.2 Spicy Image-to-Video": AtlasWan22SpicyImageToVideo,
+    "AtlasCloud WAN2.2 Turbo Image-to-Video": AtlasWan22TurboImageToVideo,
     "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video": AtlasWan22TurboSpicyImageToVideo,
     "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA": AtlasWan22TurboSpicyImageToVideoLora,
     "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": AtlasWan22SpicyImageToVideoLora,
@@ -666,6 +668,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Vidu Q3-Turbo Image-to-Video": "AtlasCloud Vidu Q3-Turbo Image-to-Video",
     "AtlasCloud Vidu Q3-Turbo Start-End-to-Video": "AtlasCloud Vidu Q3-Turbo Start-End-to-Video",
     "AtlasCloud WAN2.2 Spicy Image-to-Video": "AtlasCloud WAN2.2 Spicy Image-to-Video",
+    "AtlasCloud WAN2.2 Turbo Image-to-Video": "AtlasCloud WAN2.2 Turbo Image-to-Video",
     "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video": "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video",
     "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA": "AtlasCloud WAN2.2 Turbo Spicy Image-to-Video LoRA",
     "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA": "AtlasCloud WAN2.2 Spicy Image-to-Video LoRA",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -1037,3 +1037,12 @@ def test_qwen_image_20_pro_edit_node_metadata():
     assert "atlas_client" in AtlasQwenImage20ProEdit.INPUT_TYPES()["required"]
     assert "images" in AtlasQwenImage20ProEdit.INPUT_TYPES()["required"]
     assert AtlasQwenImage20ProEdit.RETURN_TYPES == ("STRING", "STRING")
+
+def test_wan22_turbo_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.wan22_turbo_i2v import AtlasWan22TurboImageToVideo
+
+    assert "atlas_client" in AtlasWan22TurboImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan22TurboImageToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan22TurboImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan22TurboImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert "video_url" in AtlasWan22TurboImageToVideo.RETURN_NAMES

--- a/tests/test_e2e_new_models_2026_05_08.py
+++ b/tests/test_e2e_new_models_2026_05_08.py
@@ -1,0 +1,102 @@
+"""E2E tests for nodes added in 2026-05-08 sync.
+
+Requires ATLASCLOUD_API_KEY environment variable.
+Run:
+  ATLASCLOUD_API_KEY=... PYTHONPATH=../ComfyUI pytest tests/test_e2e_new_models_2026_05_08.py -v -s
+
+Notes:
+- Designed to skip automatically when ATLASCLOUD_API_KEY is not set.
+- WAN2.2 Turbo I2V should be fairly fast; keep timeout conservative to avoid hanging.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+_HAS_KEY = bool(os.getenv("ATLASCLOUD_API_KEY", "").strip())
+skip_no_key = pytest.mark.skipif(not _HAS_KEY, reason="ATLASCLOUD_API_KEY not set")
+
+from atlascloud_comfyui.client.atlas_client import AtlasClient
+from atlascloud_comfyui.nodes.auth.atlas_client_node import AtlasClientHandle
+
+
+def make_client() -> AtlasClientHandle:
+    client = AtlasClient.from_env()
+    return AtlasClientHandle(client=client)
+
+
+_image_url: str | None = None
+
+
+@skip_no_key
+def test_setup_image_fixture_imagen4_fast_t2i():
+    """Generate an image that can be used as input for I2V tests."""
+
+    global _image_url
+
+    from atlascloud_comfyui.nodes.image.imagen4_fast_t2i import AtlasImagen4FastTextToImage
+
+    node = AtlasImagen4FastTextToImage()
+    handle = make_client()
+
+    start = time.time()
+    image_url, prediction_id = node.run(
+        atlas_client=handle,
+        prompt="A clean studio photo of a toy car on a white background",
+        aspect_ratio="1:1",
+        num_images=1,
+        enable_base64_output=False,
+        poll_interval_sec=2.0,
+        timeout_sec=240,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  image_url:     {image_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert image_url
+
+    _image_url = image_url
+
+
+@skip_no_key
+def test_wan22_turbo_i2v_smoke():
+    """WAN2.2 Turbo Image-to-Video should return a video URL."""
+
+    image_url = _image_url
+    if not image_url:
+        pytest.skip("No image available (test_setup_image_fixture_imagen4_fast_t2i must run first)")
+
+    from atlascloud_comfyui.nodes.video.wan22_turbo_i2v import AtlasWan22TurboImageToVideo
+
+    node = AtlasWan22TurboImageToVideo()
+    handle = make_client()
+
+    start = time.time()
+    video_url, prediction_id = node.run(
+        atlas_client=handle,
+        image=image_url,
+        prompt="The toy car slowly rolls forward on the table, cinematic lighting",
+        resolution="720p",
+        duration=5,
+        seed=-1,
+        poll_interval_sec=2.5,
+        timeout_sec=600,
+    )
+    elapsed = time.time() - start
+
+    print(f"\n  prediction_id: {prediction_id}")
+    print(f"  video_url:     {video_url[:120]}...")
+    print(f"  elapsed:       {elapsed:.1f}s")
+
+    assert prediction_id
+    assert video_url
+    assert video_url.startswith("http"), video_url[:80]


### PR DESCRIPTION
## Summary\n- Add ComfyUI node for `atlascloud/wan-2.2-turbo/image-to-video` (I2V)\n- Register node + update README\n- Add metadata test + new-model E2E test file (may fail locally if key has insufficient balance)\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/ -v (non-E2E suite)\n- [ ] E2E (blocked: API key returned 402 insufficient balance)\n\n🤖 Generated with OpenClaw