### PR TITLE
feat: add nodes for 4 new AtlasCloud visual models

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V2.1 I2V Standard | kwaivgi/kling-v2.1-i2v-standard |
 | AtlasCloud WAN2.2 Animate Mix | alibaba/wan-2.2/animate-mix |
 | AtlasCloud WAN2.2 Animate Move | alibaba/wan-2.2/animate-move |
+| AtlasCloud Veed Fabric 1.0 Fast Image-to-Video | veed/fabric-1.0/fast/image-to-video |
+| AtlasCloud Video Upscaler (Video-to-Video) | atlascloud/video-upscaler |
 | AtlasCloud WAN2.2 Image-to-Video 720p | alibaba/wan-2.2/i2v-720p |
 | AtlasCloud WAN2.2 Image-to-Video 480p | alibaba/wan-2.2/i2v-480p |
 | AtlasCloud Wan 2.2 Turbo Infinite Image-to-Video | atlascloud/wan-2.2-turbo/infinite-image-to-video |
@@ -292,6 +294,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
+| AtlasCloud Grok Imagine IQ Text-to-Image | xai/grok-imagine-image-quality/text-to-image |
 | AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
 | AtlasCloud GPT Image-2 Text-to-Image | openai/gpt-image-2/text-to-image |
 | AtlasCloud GPT Image-2 Developer Text-to-Image | openai/gpt-image-2-developer/text-to-image |
@@ -340,6 +343,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Flux Kontext Dev Edit | black-forest-labs/flux-kontext-dev |
 | AtlasCloud Flux Kontext Dev LoRA Edit | black-forest-labs/flux-kontext-dev-lora |
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
+| AtlasCloud Grok Imagine IQ Edit | xai/grok-imagine-image-quality/edit |
 | AtlasCloud GPT Image-2 Edit | openai/gpt-image-2/edit |
 | AtlasCloud GPT Image-2 Developer Edit | openai/gpt-image-2-developer/edit |
 

--- a/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_quality_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_quality_edit.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineImageQualityEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit prompt"}),
+                "image_urls": ("STRING", {"multiline": True, "tooltip": "1-8 image URLs (one per line)"}),
+                "resolution": (["1k", "2k"], {"default": "1k"}),
+                "aspect_ratio": (
+                    ["1:1", "3:4", "4:3", "9:16", "16:9", "2:3", "3:2", "9:19.5", "19.5:9", "9:20", "20:9", "1:2", "2:1"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "num_images": ([1, 2, 3, 4], {"default": 1}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_urls: str,
+        resolution: str,
+        aspect_ratio: str,
+        num_images: int,
+        enable_base64_output: bool,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        images: List[str] = [u.strip() for u in (image_urls or "").splitlines() if u.strip()]
+        if not images:
+            raise RuntimeError("image_urls is required (provide 1-8 URLs, one per line)")
+        if len(images) > 8:
+            raise RuntimeError("image_urls maxItems is 8")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-image-quality/edit",
+            "prompt": prompt,
+            "image_urls": images,
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "num_images": int(num_images),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_quality_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_quality_t2i.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineImageQualityTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["1k", "2k"], {"default": "1k"}),
+                "aspect_ratio": (
+                    ["1:1", "3:4", "4:3", "9:16", "16:9", "2:3", "3:2", "9:19.5", "19.5:9", "9:20", "20:9", "1:2", "2:1"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "num_images": ([1, 2, 3, 4], {"default": 1}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str,
+        aspect_ratio: str,
+        num_images: int,
+        enable_base64_output: bool,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-image-quality/text-to-image",
+            "prompt": prompt,
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "num_images": int(num_images),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_video_upscaler_v2v.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_video_upscaler_v2v.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVideoUpscalerVideoToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video": ("STRING", {"default": "", "tooltip": "Video URL or base64"}),
+                "target_resolution": (["1080p", "2k"], {"default": "1080p"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video: str,
+        target_resolution: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (video or "").strip():
+            raise RuntimeError("video is required for Video Upscaler")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/video-upscaler",
+            "video": video,
+            "target_resolution": target_resolution,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/veed_fabric_10_fast_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veed_fabric_10_fast_i2v.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeedFabric10FastImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Image URL or base64"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Audio URL"}),
+                "resolution": (["480p", "720p"], {"default": "720p"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        audio: str,
+        resolution: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Veed Fabric 1.0 Fast Image-to-Video")
+        if not (audio or "").strip():
+            raise RuntimeError("audio is required for Veed Fabric 1.0 Fast Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "veed/fabric-1.0/fast/image-to-video",
+            "image_url": image,
+            "audio_url": audio,
+            "resolution": resolution,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -220,6 +220,12 @@ from atlascloud_comfyui.nodes.video.kling_v21_i2v_master import AtlasKlingV21I2V
 from atlascloud_comfyui.nodes.video.kling_v21_i2v_pro_start_end_frame import AtlasKlingV21I2VProStartEndFrame
 from atlascloud_comfyui.nodes.video.kwaivgi_kling_v2_1_i2v_pro import AtlasKwaivgiKlingV21I2VPro
 from atlascloud_comfyui.nodes.video.kwaivgi_kling_v2_1_i2v_standard import AtlasKwaivgiKlingV21I2VStandard
+
+from atlascloud_comfyui.nodes.video.atlascloud_video_upscaler_v2v import AtlasVideoUpscalerVideoToVideo
+from atlascloud_comfyui.nodes.video.veed_fabric_10_fast_i2v import AtlasVeedFabric10FastImageToVideo
+from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_t2i import AtlasGrokImagineImageQualityTextToImage
+from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_edit import AtlasGrokImagineImageQualityEdit
+
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_pro import AtlasKlingV16MultiI2VPro
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_standard import AtlasKlingV16MultiI2VStandard
 from atlascloud_comfyui.nodes.video.kling_v16_i2v_standard import AtlasKlingV16I2VStandard
@@ -525,6 +531,13 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video": AtlasViduQ2ProFastReferenceToVideo,
     "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video (with Audio)": AtlasViduQ2ProFastReferenceToVideoWithAudio,
     "AtlasCloud Vidu Start-End-to-Video 2.0": AtlasViduStartEndToVideoV2,
+
+    "AtlasCloud Video Upscaler (Video-to-Video)": AtlasVideoUpscalerVideoToVideo,
+    "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video": AtlasVeedFabric10FastImageToVideo,
+
+    "AtlasCloud Grok Imagine IQ Text-to-Image": AtlasGrokImagineImageQualityTextToImage,
+    "AtlasCloud Grok Imagine IQ Edit": AtlasGrokImagineImageQualityEdit,
+
     "AtlasCloud Kling V2.0 I2V Master": AtlasKlingV20I2VMaster,
     "AtlasCloud VEO3 Fast Image-to-Video": AtlasVeo3FastImageToVideo,
     "AtlasCloud Kling V2.1 T2V Master": AtlasKlingV21T2VMaster,
@@ -782,6 +795,13 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video": "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video",
     "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video (with Audio)": "AtlasCloud Vidu Q2-Pro-Fast Reference-to-Video (with Audio)",
     "AtlasCloud Vidu Start-End-to-Video 2.0": "AtlasCloud Vidu Start-End-to-Video 2.0",
+
+    "AtlasCloud Video Upscaler (Video-to-Video)": "AtlasCloud Video Upscaler (Video-to-Video)",
+    "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video": "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video",
+
+    "AtlasCloud Grok Imagine IQ Text-to-Image": "AtlasCloud Grok Imagine IQ Text-to-Image",
+    "AtlasCloud Grok Imagine IQ Edit": "AtlasCloud Grok Imagine IQ Edit",
+
     "AtlasCloud Kling V2.0 I2V Master": "AtlasCloud Kling V2.0 I2V Master",
     "AtlasCloud VEO3 Fast Image-to-Video": "AtlasCloud VEO3 Fast Image-to-Video",
     "AtlasCloud Kling V2.1 T2V Master": "AtlasCloud Kling V2.1 T2V Master",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -190,6 +190,44 @@ def test_wan26_spicy_i2v_node_metadata():
     assert AtlasWan26SpicyImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
 
+# --- Batch: 2026-05-13 (NEW) ---
+
+def test_video_upscaler_v2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_video_upscaler_v2v import AtlasVideoUpscalerVideoToVideo
+
+    assert "atlas_client" in AtlasVideoUpscalerVideoToVideo.INPUT_TYPES()["required"]
+    assert "video" in AtlasVideoUpscalerVideoToVideo.INPUT_TYPES()["required"]
+    assert AtlasVideoUpscalerVideoToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_veed_fabric_10_fast_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.veed_fabric_10_fast_i2v import AtlasVeedFabric10FastImageToVideo
+
+    assert "atlas_client" in AtlasVeedFabric10FastImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasVeedFabric10FastImageToVideo.INPUT_TYPES()["required"]
+    assert "audio" in AtlasVeedFabric10FastImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeedFabric10FastImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_grok_imagine_iq_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_t2i import (
+        AtlasGrokImagineImageQualityTextToImage,
+    )
+
+    assert "atlas_client" in AtlasGrokImagineImageQualityTextToImage.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasGrokImagineImageQualityTextToImage.INPUT_TYPES()["required"]
+    assert AtlasGrokImagineImageQualityTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_grok_imagine_iq_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_edit import AtlasGrokImagineImageQualityEdit
+
+    assert "atlas_client" in AtlasGrokImagineImageQualityEdit.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasGrokImagineImageQualityEdit.INPUT_TYPES()["required"]
+    assert "image_urls" in AtlasGrokImagineImageQualityEdit.INPUT_TYPES()["required"]
+    assert AtlasGrokImagineImageQualityEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
 # --- Batch: Wan 2.2 Turbo Infinite I2V (2026-05-07) ---
 
 def test_wan22_turbo_infinite_i2v_node_metadata():


### PR DESCRIPTION
## Summary
- Added ComfyUI node support for 4 newly listed visual models:
  - atlascloud/video-upscaler (video-to-video)
  - veed/fabric-1.0/fast/image-to-video
  - xai/grok-imagine-image-quality/text-to-image
  - xai/grok-imagine-image-quality/edit
- Updated registry mappings + README Available Nodes
- Added metadata-only tests (no API key required)

## Test plan
- [x] ruff check .
- [x] pytest tests/ -v (metadata tests)
- [!] E2E (tests/test_e2e.py, tests/test_e2e_new_models.py) attempted with ATLASCLOUD_RUN_E2E=1 but failed due to API returning 402 insufficient balance

🤖 Generated with OpenClaw