### PR TITLE
feat: add Veed Fabric 1.0 Image-to-Video node

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Kling V2.1 I2V Standard | kwaivgi/kling-v2.1-i2v-standard |
 | AtlasCloud WAN2.2 Animate Mix | alibaba/wan-2.2/animate-mix |
 | AtlasCloud WAN2.2 Animate Move | alibaba/wan-2.2/animate-move |
+| AtlasCloud Veed Fabric 1.0 Image-to-Video | veed/fabric-1.0/image-to-video |
 | AtlasCloud Veed Fabric 1.0 Fast Image-to-Video | veed/fabric-1.0/fast/image-to-video |
 | AtlasCloud Video Upscaler (Video-to-Video) | atlascloud/video-upscaler |
 | AtlasCloud WAN2.2 Image-to-Video 720p | alibaba/wan-2.2/i2v-720p |

--- a/src/atlascloud_comfyui/nodes/video/veed_fabric_10_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veed_fabric_10_i2v.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasVeedFabric10ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Image URL or base64"}),
+                "audio": ("STRING", {"default": "", "tooltip": "Audio URL"}),
+                "resolution": (["480p", "720p"], {"default": "720p"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        audio: str,
+        resolution: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Veed Fabric 1.0 Image-to-Video")
+        if not (audio or "").strip():
+            raise RuntimeError("audio is required for Veed Fabric 1.0 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "veed/fabric-1.0/image-to-video",
+            "image_url": image,
+            "audio_url": audio,
+            "resolution": resolution,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("video") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -223,6 +223,7 @@ from atlascloud_comfyui.nodes.video.kwaivgi_kling_v2_1_i2v_standard import Atlas
 
 from atlascloud_comfyui.nodes.video.atlascloud_video_upscaler_v2v import AtlasVideoUpscalerVideoToVideo
 from atlascloud_comfyui.nodes.video.veed_fabric_10_fast_i2v import AtlasVeedFabric10FastImageToVideo
+from atlascloud_comfyui.nodes.video.veed_fabric_10_i2v import AtlasVeedFabric10ImageToVideo
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_t2i import AtlasGrokImagineImageQualityTextToImage
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_edit import AtlasGrokImagineImageQualityEdit
 
@@ -533,6 +534,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Vidu Start-End-to-Video 2.0": AtlasViduStartEndToVideoV2,
 
     "AtlasCloud Video Upscaler (Video-to-Video)": AtlasVideoUpscalerVideoToVideo,
+    "AtlasCloud Veed Fabric 1.0 Image-to-Video": AtlasVeedFabric10ImageToVideo,
     "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video": AtlasVeedFabric10FastImageToVideo,
 
     "AtlasCloud Grok Imagine IQ Text-to-Image": AtlasGrokImagineImageQualityTextToImage,
@@ -797,6 +799,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Vidu Start-End-to-Video 2.0": "AtlasCloud Vidu Start-End-to-Video 2.0",
 
     "AtlasCloud Video Upscaler (Video-to-Video)": "AtlasCloud Video Upscaler (Video-to-Video)",
+    "AtlasCloud Veed Fabric 1.0 Image-to-Video": "AtlasCloud Veed Fabric 1.0 Image-to-Video",
     "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video": "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video",
 
     "AtlasCloud Grok Imagine IQ Text-to-Image": "AtlasCloud Grok Imagine IQ Text-to-Image",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -200,6 +200,15 @@ def test_video_upscaler_v2v_node_metadata():
     assert AtlasVideoUpscalerVideoToVideo.RETURN_TYPES == ("STRING", "STRING")
 
 
+def test_veed_fabric_10_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.veed_fabric_10_i2v import AtlasVeedFabric10ImageToVideo
+
+    assert "atlas_client" in AtlasVeedFabric10ImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasVeedFabric10ImageToVideo.INPUT_TYPES()["required"]
+    assert "audio" in AtlasVeedFabric10ImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasVeedFabric10ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
 def test_veed_fabric_10_fast_i2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.veed_fabric_10_fast_i2v import AtlasVeedFabric10FastImageToVideo
 


### PR DESCRIPTION
## Summary\n- Add ComfyUI node for `veed/fabric-1.0/image-to-video`\n- Registry + README updated\n- Added metadata-only test\n\n## Test plan\n- [x] ruff check .\n- [x] pytest tests/ -v\n- [ ] E2E (ATLASCLOUD_RUN_E2E=1) — blocked: API returned 402 Payment Required (likely credits/key plan)\n\n🤖 Generated with OpenClaw