### PR TITLE
sync: add 2 AtlasCloud Gemini Omni Flash video models (2026-05-26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3.1 Text-to-Video | google/veo3.1/text-to-video |
 | AtlasCloud VEO3.1 Lite Text-to-Video | google/veo3.1-lite/text-to-video |
 | AtlasCloud VEO3.1 Fast Text-to-Video | google/veo3.1-fast/text-to-video |
+| AtlasCloud Gemini Omni Flash Text-to-Video Developer | google/gemini-omni-flash/text-to-video-developer |
 | AtlasCloud VEO2 Text-to-Video | google/veo2 |
 | AtlasCloud WAN2.6 Text-to-Video | alibaba/wan-2.6/text-to-video |
 | AtlasCloud WAN2.7 Text-to-Video | alibaba/wan-2.7/text-to-video |
@@ -138,6 +139,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3 Image-to-Video | google/veo3/image-to-video |
 | AtlasCloud VEO3 Fast Image-to-Video | google/veo3-fast/image-to-video |
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
+| AtlasCloud Gemini Omni Flash Image-to-Video Developer | google/gemini-omni-flash/image-to-video-developer |
 | AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |
 | AtlasCloud Seedance 2.0 Reference-to-Video | bytedance/seedance-2.0/reference-to-video |
 | AtlasCloud Seedance 2.0 Fast Reference-to-Video | bytedance/seedance-2.0-fast/reference-to-video |

--- a/src/atlascloud_comfyui/nodes/video/google_gemini_omni_flash_i2v_dev.py
+++ b/src/atlascloud_comfyui/nodes/video/google_gemini_omni_flash_i2v_dev.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGeminiOmniFlashImageToVideoDev:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (max 20,000 chars)"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-7 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "duration": ([4, 6, 8, 10], {"default": 8, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["720p", "1080p", "4k"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        duration: int = 8,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-7 lines)")
+        if len(image_list) > 7:
+            raise RuntimeError("images maxItems is 7")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/gemini-omni-flash/image-to-video-developer",
+            "prompt": prompt,
+            "images": image_list,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_gemini_omni_flash_t2v_dev.py
+++ b/src/atlascloud_comfyui/nodes/video/google_gemini_omni_flash_t2v_dev.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGeminiOmniFlashTextToVideoDev:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (max 20,000 chars)"}),
+            },
+            "optional": {
+                "duration": ([4, 6, 8, 10], {"default": 8, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["720p", "1080p", "4k"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 8,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/gemini-omni-flash/text-to-video-developer",
+            "prompt": prompt,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -87,6 +87,8 @@ from atlascloud_comfyui.nodes.video.veo31_i2v import AtlasVeo31ImageToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_fast_t2v import AtlasVeo31FastTextToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_fast_i2v import AtlasVeo31FastImageToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_r2v import AtlasVeo31ReferenceToVideo
+from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_t2v_dev import AtlasGeminiOmniFlashTextToVideoDev
+from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_i2v_dev import AtlasGeminiOmniFlashImageToVideoDev
 from atlascloud_comfyui.nodes.video.veo3_i2v import AtlasVeo3ImageToVideo
 from atlascloud_comfyui.nodes.video.veo2_t2v import AtlasVeo2TextToVideo
 from atlascloud_comfyui.nodes.video.veo2_i2v import AtlasVeo2ImageToVideo
@@ -436,6 +438,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud VEO3 Fast Text-to-Video": AtlasVeo3FastTextToVideo,
     "AtlasCloud VEO3.1 Fast Text-to-Video": AtlasVeo31FastTextToVideo,
     "AtlasCloud VEO3.1 Fast Image-to-Video": AtlasVeo31FastImageToVideo,
+    "AtlasCloud Gemini Omni Flash Text-to-Video Developer": AtlasGeminiOmniFlashTextToVideoDev,
+    "AtlasCloud Gemini Omni Flash Image-to-Video Developer": AtlasGeminiOmniFlashImageToVideoDev,
     "AtlasCloud VEO3.1 Reference-to-Video": AtlasVeo31ReferenceToVideo,
     "AtlasCloud VEO3.1 Image-to-Video": AtlasVeo31ImageToVideo,
     "AtlasCloud VEO3 Image-to-Video": AtlasVeo3ImageToVideo,
@@ -703,6 +707,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud VEO3 Fast Text-to-Video": "AtlasCloud VEO3 Fast Text-to-Video",
     "AtlasCloud VEO3.1 Fast Text-to-Video": "AtlasCloud VEO3.1 Fast Text-to-Video",
     "AtlasCloud VEO3.1 Fast Image-to-Video": "AtlasCloud VEO3.1 Fast Image-to-Video",
+    "AtlasCloud Gemini Omni Flash Text-to-Video Developer": "AtlasCloud Gemini Omni Flash Text-to-Video Developer",
+    "AtlasCloud Gemini Omni Flash Image-to-Video Developer": "AtlasCloud Gemini Omni Flash Image-to-Video Developer",
     "AtlasCloud VEO3.1 Reference-to-Video": "AtlasCloud VEO3.1 Reference-to-Video",
     "AtlasCloud VEO3.1 Image-to-Video": "AtlasCloud VEO3.1 Image-to-Video",
     "AtlasCloud VEO3 Image-to-Video": "AtlasCloud VEO3 Image-to-Video",

--- a/tests/test_new_nodes_2026_05_26.py
+++ b/tests/test_new_nodes_2026_05_26.py
@@ -1,0 +1,43 @@
+"""Metadata-only tests for newly added nodes (2026-05-26).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_gemini_omni_flash_t2v_dev_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_gemini_omni_flash_t2v_dev import (
+        AtlasGeminiOmniFlashTextToVideoDev,
+    )
+
+    required = AtlasGeminiOmniFlashTextToVideoDev.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasGeminiOmniFlashTextToVideoDev.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGeminiOmniFlashTextToVideoDev.CATEGORY == "AtlasCloud/Video"
+
+
+def test_gemini_omni_flash_i2v_dev_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_gemini_omni_flash_i2v_dev import (
+        AtlasGeminiOmniFlashImageToVideoDev,
+    )
+
+    required = AtlasGeminiOmniFlashImageToVideoDev.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasGeminiOmniFlashImageToVideoDev.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGeminiOmniFlashImageToVideoDev.CATEGORY == "AtlasCloud/Video"
+
+
+def test_gemini_omni_flash_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Gemini Omni Flash Text-to-Video Developer",
+        "AtlasCloud Gemini Omni Flash Image-to-Video Developer",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS


### PR DESCRIPTION
## Summary

Adds ComfyUI nodes for 2 new AtlasCloud visual models discovered in today's API diff:

- `google/gemini-omni-flash/text-to-video-developer` → `AtlasCloud Gemini Omni Flash Text-to-Video Developer`
- `google/gemini-omni-flash/image-to-video-developer` (1–7 reference images) → `AtlasCloud Gemini Omni Flash Image-to-Video Developer`

Both nodes follow the existing video-node pattern (top-level imports limited to typing/auth handle, payload built inside `run()`, `poll_prediction` + `outputs[0]`). Schema fields used: `prompt`, `images` (I2V only, 1–7), `duration` (4/6/8/10), `aspect_ratio` (16:9/9:16), `resolution` (720p/1080p/4k), `seed`.

## Test plan
- [x] `ruff check .` clean
- [x] `pytest tests/ -v -k "not e2e and not test_e2e"` — 239 passed, 26 deselected
- [ ] CI green
- [ ] E2E skipped locally (no ComfyUI source on box); will run via remote CI if enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)