### PR TITLE
docs: add requirements.txt referenced in install instructions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+numpy
+pillow


### PR DESCRIPTION
## Summary

The README install instructions (both Desktop and Source paths) tell users to run `pip install -r requirements.txt`, but the file was missing from the repo — users following the docs literally hit `ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'`.

This PR adds a minimal `requirements.txt` mirroring the runtime dependencies already declared in `pyproject.toml` under `[project].dependencies`:

```
requests
numpy
pillow
```

Verified by grepping `src/` for non-stdlib imports — only `requests`, `numpy`, and `PIL` are used at runtime, matching `pyproject.toml`.

Refs #27 (the "can't find the requirements.txt during the install" half). The timeout half of that issue is a separate concern that needs more repro info from the reporter (which models, durations/resolutions, error output) — happy to follow up there separately.

## Test plan
- [x] `pip install -r requirements.txt` resolves cleanly
- [x] Matches `pyproject.toml` `[project].dependencies` exactly
- [x] No code/runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)