### PR TITLE
deprecate: mark catalog-missing model nodes

### DIFF
--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_edit_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_edit_dev.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -44,6 +51,13 @@ class AtlasNanoBanana2EditDev:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/nano-banana-2/edit-developer. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_t2i_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_t2i_dev.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -42,6 +49,13 @@ class AtlasNanoBanana2TextToImageDev:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/nano-banana-2/text-to-image-developer. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_edit_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_edit_dev.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, List, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -54,6 +61,13 @@ class AtlasNanoBananaEditDeveloper:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/nano-banana/edit-developer. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
         if not image_list:
             raise RuntimeError("images is required (1-10 lines)")

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_pro_edit_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_pro_edit_dev.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, List, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -56,6 +63,13 @@ class AtlasNanoBananaProEditDeveloper:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/nano-banana-pro/edit-developer. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
         if not image_list:
             raise RuntimeError("images is required (1-10 lines)")

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i_dev.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -54,6 +61,13 @@ class AtlasNanoBananaProTextToImageDeveloper:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/nano-banana-pro/text-to-image-developer. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         p = (prompt or "").strip()

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i_ultra.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_pro_t2i_ultra.py
@@ -1,12 +1,5 @@
 from __future__ import annotations
 
-# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
-# It is kept for backward compatibility with existing ComfyUI workflows.
-DEPRECATED_MODEL_ID = True
-DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
-
-import os
-
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -53,13 +46,6 @@ class AtlasNanoBananaProTextToImageUltra:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
-        # Deprecated model guard
-        if os.getenv('ATLAS_ALLOW_DEPRECATED_MODELS', '').lower() not in ('1', 'true', 'yes'):
-            raise RuntimeError(
-                "Deprecated model id: google/nano-banana-pro/text-to-image-ultra. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
-                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
-            )
-
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/image/nano_banana_t2i_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana_t2i_dev.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -52,6 +59,13 @@ class AtlasNanoBananaTextToImageDeveloper:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/nano-banana/text-to-image-developer. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         p = (prompt or "").strip()

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_dev_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_dev_edit.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, List, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -67,6 +74,13 @@ class AtlasOpenAIGPTImage2DeveloperEdit:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: openai/gpt-image-2-developer/edit. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         p = (prompt or "").strip()

--- a/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_dev_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/openai_gpt_image_2_dev_t2i.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -61,6 +68,13 @@ class AtlasOpenAIGPTImage2DeveloperTextToImage:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 300,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: openai/gpt-image-2-developer/text-to-image. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         p = (prompt or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_i2v_480p.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_i2v_480p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -16,11 +23,14 @@ class AtlasAlibabaWan22I2V480p:
         return {
             "required": {
                 "atlas_client": ("ATLAS_CLIENT",),
-                "prompt": ("STRING", {"multiline": True, "tooltip": 'The prompt for generating the output.'}),
-                "image": ("STRING", {"default": "", "tooltip": 'The image for generating the output.'}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "The prompt for generating the output."}),
+                "image": ("STRING", {"default": "", "tooltip": "The image for generating the output."}),
             },
             "optional": {
-                "seed": ("INT", {"default": -1, "tooltip": 'The random seed to use for the generation. -1 means a random seed will be used.'}),
+                "seed": (
+                    "INT",
+                    {"default": -1, "tooltip": "The random seed to use for the generation. -1 means a random seed will be used."},
+                ),
                 "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
                 "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
             },
@@ -35,6 +45,13 @@ class AtlasAlibabaWan22I2V480p:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: alibaba/wan-2.2/i2v-480p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()
@@ -61,8 +78,6 @@ class AtlasAlibabaWan22I2V480p:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_i2v_720p.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_i2v_720p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -16,11 +23,14 @@ class AtlasAlibabaWan22I2V720p:
         return {
             "required": {
                 "atlas_client": ("ATLAS_CLIENT",),
-                "prompt": ("STRING", {"multiline": True, "tooltip": 'The prompt for generating the output.'}),
-                "image": ("STRING", {"default": "", "tooltip": 'The image for generating the output.'}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "The prompt for generating the output."}),
+                "image": ("STRING", {"default": "", "tooltip": "The image for generating the output."}),
             },
             "optional": {
-                "seed": ("INT", {"default": -1, "tooltip": 'The random seed to use for the generation. -1 means a random seed will be used.'}),
+                "seed": (
+                    "INT",
+                    {"default": -1, "tooltip": "The random seed to use for the generation. -1 means a random seed will be used."},
+                ),
                 "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
                 "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
             },
@@ -35,6 +45,13 @@ class AtlasAlibabaWan22I2V720p:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: alibaba/wan-2.2/i2v-720p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()
@@ -61,8 +78,6 @@ class AtlasAlibabaWan22I2V720p:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_t2v_480p.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_2_2_t2v_480p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -16,10 +23,13 @@ class AtlasAlibabaWan22T2V480p:
         return {
             "required": {
                 "atlas_client": ("ATLAS_CLIENT",),
-                "prompt": ("STRING", {"multiline": True, "tooltip": 'The prompt for generating the output.'}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "The prompt for generating the output."}),
             },
             "optional": {
-                "seed": ("INT", {"default": -1, "tooltip": 'The random seed to use for the generation. -1 means a random seed will be used.'}),
+                "seed": (
+                    "INT",
+                    {"default": -1, "tooltip": "The random seed to use for the generation. -1 means a random seed will be used."},
+                ),
                 "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
                 "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
             },
@@ -33,6 +43,13 @@ class AtlasAlibabaWan22T2V480p:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: alibaba/wan-2.2/t2v-480p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
@@ -54,8 +71,6 @@ class AtlasAlibabaWan22T2V480p:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_i2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_i2v_upscaled.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -31,9 +38,9 @@ class AtlasSeedance20FastImageToVideoUpscaled:
                     [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
                     {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
                 ),
-                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "resolution": (["1080p", "2k"], {"default": "1080p", "tooltip": "Resolution"}),
                 "ratio": (
-                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9', 'adaptive'],
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
                     {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
                 ),
                 "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
@@ -69,6 +76,13 @@ class AtlasSeedance20FastImageToVideoUpscaled:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-2.0-fast/image-to-video-upscaled. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         image = (image or "").strip()
         if not image:
             raise RuntimeError("image is required for AtlasCloud Seedance 2.0 Fast Image-to-Video Upscaled")
@@ -107,8 +121,6 @@ class AtlasSeedance20FastImageToVideoUpscaled:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_r2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_r2v_upscaled.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, List, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -39,9 +46,9 @@ class AtlasSeedance20FastReferenceToVideoUpscaled:
                     [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
                     {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
                 ),
-                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "resolution": (["1080p", "2k"], {"default": "1080p", "tooltip": "Resolution"}),
                 "ratio": (
-                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9', 'adaptive'],
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
                     {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
                 ),
                 "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
@@ -72,6 +79,13 @@ class AtlasSeedance20FastReferenceToVideoUpscaled:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-2.0-fast/reference-to-video-upscaled. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
         ref_vids: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
         if not ref_imgs and not ref_vids:
@@ -114,8 +128,6 @@ class AtlasSeedance20FastReferenceToVideoUpscaled:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_t2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_fast_t2v_upscaled.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -30,9 +37,9 @@ class AtlasSeedance20FastTextToVideoUpscaled:
                     [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
                     {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
                 ),
-                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "resolution": (["1080p", "2k"], {"default": "1080p", "tooltip": "Resolution"}),
                 "ratio": (
-                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9"],
                     {"default": "16:9", "tooltip": "Aspect ratio"},
                 ),
                 "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
@@ -41,7 +48,6 @@ class AtlasSeedance20FastTextToVideoUpscaled:
                     "BOOLEAN",
                     {"default": False, "tooltip": "Return last frame (if supported)"},
                 ),
-
                 "poll_interval_sec": (
                     "FLOAT",
                     {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
@@ -63,10 +69,16 @@ class AtlasSeedance20FastTextToVideoUpscaled:
         generate_audio: bool = True,
         watermark: bool = False,
         return_last_frame: bool = False,
-
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-2.0-fast/text-to-video-upscaled. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         prompt = (prompt or "").strip()
         if not prompt:
             raise RuntimeError("prompt is required for AtlasCloud Seedance 2.0 Fast Text-to-Video Upscaled")
@@ -82,7 +94,6 @@ class AtlasSeedance20FastTextToVideoUpscaled:
             "generate_audio": bool(generate_audio),
             "watermark": bool(watermark),
             "return_last_frame": bool(return_last_frame),
-
         }
 
         prediction_id = client.generate_video(payload)
@@ -98,8 +109,6 @@ class AtlasSeedance20FastTextToVideoUpscaled:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_i2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_i2v_upscaled.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -31,9 +38,9 @@ class AtlasSeedance20ImageToVideoUpscaled:
                     [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
                     {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
                 ),
-                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "resolution": (["1080p", "2k"], {"default": "1080p", "tooltip": "Resolution"}),
                 "ratio": (
-                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9', 'adaptive'],
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
                     {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
                 ),
                 "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
@@ -69,6 +76,13 @@ class AtlasSeedance20ImageToVideoUpscaled:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-2.0/image-to-video-upscaled. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         image = (image or "").strip()
         if not image:
             raise RuntimeError("image is required for AtlasCloud Seedance 2.0 Image-to-Video Upscaled")
@@ -107,8 +121,6 @@ class AtlasSeedance20ImageToVideoUpscaled:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_r2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_r2v_upscaled.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, List, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -39,9 +46,9 @@ class AtlasSeedance20ReferenceToVideoUpscaled:
                     [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
                     {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
                 ),
-                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "resolution": (["1080p", "2k"], {"default": "1080p", "tooltip": "Resolution"}),
                 "ratio": (
-                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9', 'adaptive'],
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
                     {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
                 ),
                 "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
@@ -72,6 +79,13 @@ class AtlasSeedance20ReferenceToVideoUpscaled:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-2.0/reference-to-video-upscaled. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
         ref_vids: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
         if not ref_imgs and not ref_vids:
@@ -114,8 +128,6 @@ class AtlasSeedance20ReferenceToVideoUpscaled:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_t2v_upscaled.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_t2v_upscaled.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -30,9 +37,9 @@ class AtlasSeedance20TextToVideoUpscaled:
                     [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
                     {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
                 ),
-                "resolution": (['1080p', '2k'], {"default": "1080p", "tooltip": "Resolution"}),
+                "resolution": (["1080p", "2k"], {"default": "1080p", "tooltip": "Resolution"}),
                 "ratio": (
-                    ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9"],
                     {"default": "16:9", "tooltip": "Aspect ratio"},
                 ),
                 "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
@@ -42,7 +49,6 @@ class AtlasSeedance20TextToVideoUpscaled:
                     {"default": False, "tooltip": "Return last frame (if supported)"},
                 ),
                 "web_search": ("BOOLEAN", {"default": False, "tooltip": "Enable web search (seedance-2.0 only)"}),
-
                 "poll_interval_sec": (
                     "FLOAT",
                     {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
@@ -65,10 +71,16 @@ class AtlasSeedance20TextToVideoUpscaled:
         watermark: bool = False,
         return_last_frame: bool = False,
         web_search: bool = False,
-
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-2.0/text-to-video-upscaled. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         prompt = (prompt or "").strip()
         if not prompt:
             raise RuntimeError("prompt is required for AtlasCloud Seedance 2.0 Text-to-Video Upscaled")
@@ -85,7 +97,6 @@ class AtlasSeedance20TextToVideoUpscaled:
             "watermark": bool(watermark),
             "return_last_frame": bool(return_last_frame),
             "web_search": bool(web_search),
-
         }
 
         prediction_id = client.generate_video(payload)
@@ -101,8 +112,6 @@ class AtlasSeedance20TextToVideoUpscaled:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_v1_lite_i2v_480p.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_v1_lite_i2v_480p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -16,13 +23,22 @@ class AtlasBytedanceSeedanceV1LiteI2V480p:
         return {
             "required": {
                 "atlas_client": ("ATLAS_CLIENT",),
-                "image": ("STRING", {"default": "", "tooltip": 'Input image supports both URL and Base64 format; Supported image formats include .jpg/.jpeg/.png; The image file size cannot exceed 10MB, and the image resolution should not be less than 300*300px'}),
-                "prompt": ("STRING", {"multiline": True, "tooltip": 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters'}),
+                "image": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Input image supports both URL and Base64 format; Supported image formats include .jpg/.jpeg/.png; The image file size cannot exceed 10MB, and the image resolution should not be less than 300*300px",
+                    },
+                ),
+                "prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters"},
+                ),
             },
             "optional": {
-                "duration": ("INT", {"default": 5, "tooltip": 'Generate video duration length seconds.'}),
-                "aspect_ratio": (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {"tooltip": 'The aspect ratio of the generated media.'}),
-                "seed": ("INT", {"default": -1, "tooltip": 'The seed for random number generation.'}),
+                "duration": ("INT", {"default": 5, "tooltip": "Generate video duration length seconds."}),
+                "aspect_ratio": (["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"], {"tooltip": "The aspect ratio of the generated media."}),
+                "seed": ("INT", {"default": -1, "tooltip": "The seed for random number generation."}),
                 "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
                 "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
             },
@@ -39,6 +55,13 @@ class AtlasBytedanceSeedanceV1LiteI2V480p:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-v1-lite-i2v-480p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()
@@ -67,8 +90,6 @@ class AtlasBytedanceSeedanceV1LiteI2V480p:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_v1_lite_i2v_720p.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_v1_lite_i2v_720p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -16,13 +23,22 @@ class AtlasBytedanceSeedanceV1LiteI2V720p:
         return {
             "required": {
                 "atlas_client": ("ATLAS_CLIENT",),
-                "image": ("STRING", {"default": "", "tooltip": 'Input image supports both URL and Base64 format; Supported image formats include .jpg/.jpeg/.png; The image file size cannot exceed 10MB, and the image resolution should not be less than 300*300px'}),
-                "prompt": ("STRING", {"multiline": True, "tooltip": 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters'}),
+                "image": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Input image supports both URL and Base64 format; Supported image formats include .jpg/.jpeg/.png; The image file size cannot exceed 10MB, and the image resolution should not be less than 300*300px",
+                    },
+                ),
+                "prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters"},
+                ),
             },
             "optional": {
-                "duration": ("INT", {"default": 5, "tooltip": 'Generate video duration length seconds.'}),
-                "aspect_ratio": (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {"tooltip": 'The aspect ratio of the generated media.'}),
-                "seed": ("INT", {"default": -1, "tooltip": 'The seed for random number generation.'}),
+                "duration": ("INT", {"default": 5, "tooltip": "Generate video duration length seconds."}),
+                "aspect_ratio": (["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"], {"tooltip": "The aspect ratio of the generated media."}),
+                "seed": ("INT", {"default": -1, "tooltip": "The seed for random number generation."}),
                 "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
                 "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
             },
@@ -39,6 +55,13 @@ class AtlasBytedanceSeedanceV1LiteI2V720p:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-v1-lite-i2v-720p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()
@@ -67,8 +90,6 @@ class AtlasBytedanceSeedanceV1LiteI2V720p:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_v1_lite_t2v_480p.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_v1_lite_t2v_480p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -16,12 +23,18 @@ class AtlasBytedanceSeedanceV1LiteT2V480p:
         return {
             "required": {
                 "atlas_client": ("ATLAS_CLIENT",),
-                "prompt": ("STRING", {"multiline": True, "tooltip": 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters'}),
-                "duration": ("INT", {"default": 5, "tooltip": 'Generate video duration length seconds.'}),
+                "prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters"},
+                ),
+                "duration": ("INT", {"default": 5, "tooltip": "Generate video duration length seconds."}),
             },
             "optional": {
-                "aspect_ratio": (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {"default": '16:9', "tooltip": 'The aspect ratio of the generated video'}),
-                "seed": ("INT", {"default": -1, "tooltip": 'The seed for random number generation.'}),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "The aspect ratio of the generated video"},
+                ),
+                "seed": ("INT", {"default": -1, "tooltip": "The seed for random number generation."}),
                 "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
                 "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
             },
@@ -32,11 +45,18 @@ class AtlasBytedanceSeedanceV1LiteT2V480p:
         atlas_client: AtlasClientHandle,
         prompt: str,
         duration: int,
-        aspect_ratio: str = '16:9',
+        aspect_ratio: str = "16:9",
         seed: int = -1,
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-v1-lite-t2v-480p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
@@ -60,8 +80,6 @@ class AtlasBytedanceSeedanceV1LiteT2V480p:
 
         first = outputs[0]
         if not isinstance(first, str):
-            raise RuntimeError(
-                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
-            )
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
 
         return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_i2v_1080p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_i2v_1080p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -15,18 +22,41 @@ class AtlasSeedanceV1LiteI2V1080p:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                'atlas_client': ('ATLAS_CLIENT',),
-                'image': ('STRING', {'default': 'https://static.atlascloud.ai/media/images/1750082346497865541_Xl0XTQMK.jpg', 'tooltip': 'Input image supports both URL and Base64 format; The image file size cannot exceed 30MB, and the image resolution should not be less than 300*300px.'}),
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {
+                        "default": "https://static.atlascloud.ai/media/images/1750082346497865541_Xl0XTQMK.jpg",
+                        "tooltip": "Input image supports both URL and Base64 format; The image file size cannot exceed 30MB, and the image resolution should not be less than 300*300px.",
+                    },
+                ),
             },
             "optional": {
-                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
-                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
-                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.'}),
-                'duration': ('INT', {'default': 5, 'min': 1, 'max': 120, 'tooltip': 'The duration of the generated media in seconds.'}),
-                'aspect_ratio': (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {'default': '16:9', 'tooltip': 'The aspect ratio of the generated video.'}),
-                'camera_fixed': ('BOOLEAN', {'default': False, 'tooltip': 'Whether to fix the camera position.'}),
-                'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'The random seed to use for the generation. -1 means a random seed will be used.'}),
-                'last_image': ('STRING', {'default': '', 'tooltip': 'URL of the ending image.'}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "tooltip": "Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.",
+                    },
+                ),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 120, "tooltip": "The duration of the generated media in seconds."}),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "The aspect ratio of the generated video."},
+                ),
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Whether to fix the camera position."}),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2147483647,
+                        "tooltip": "The random seed to use for the generation. -1 means a random seed will be used.",
+                    },
+                ),
+                "last_image": ("STRING", {"default": "", "tooltip": "URL of the ending image."}),
             },
         }
 
@@ -34,15 +64,22 @@ class AtlasSeedanceV1LiteI2V1080p:
         self,
         atlas_client: AtlasClientHandle,
         image: str,
-        prompt: str = 'Slow zoom on twitching paws dreaming, cut to wide shot as owner gently places a chew toy beside it',
+        prompt: str = "Slow zoom on twitching paws dreaming, cut to wide shot as owner gently places a chew toy beside it",
         duration: int = 5,
-        aspect_ratio: str = '16:9',
+        aspect_ratio: str = "16:9",
         camera_fixed: bool = False,
         seed: int = -1,
-        last_image: str = '',
+        last_image: str = "",
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-v1-lite-i2v-1080p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         image = (image or "").strip()
         if not image:
             raise RuntimeError("image is required for AtlasCloud Seedance v1 Lite I2V 1080p")

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_1080p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_1080p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -15,16 +22,33 @@ class AtlasSeedanceV1LiteT2V1080p:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                'atlas_client': ('ATLAS_CLIENT',),
-                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.'}),
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "tooltip": "Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.",
+                    },
+                ),
             },
             "optional": {
-                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
-                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
-                'duration': ('INT', {'default': 5, 'min': 1, 'max': 120, 'tooltip': 'The duration of the generated media in seconds.'}),
-                'aspect_ratio': (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {'default': '16:9', 'tooltip': 'The aspect ratio of the generated video.'}),
-                'camera_fixed': ('BOOLEAN', {'default': False, 'tooltip': 'Whether to fix the camera position.'}),
-                'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'The random seed to use for the generation. -1 means a random seed will be used.'}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 120, "tooltip": "The duration of the generated media in seconds."}),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "The aspect ratio of the generated video."},
+                ),
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Whether to fix the camera position."}),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2147483647,
+                        "tooltip": "The random seed to use for the generation. -1 means a random seed will be used.",
+                    },
+                ),
             },
         }
 
@@ -33,12 +57,19 @@ class AtlasSeedanceV1LiteT2V1080p:
         atlas_client: AtlasClientHandle,
         prompt: str,
         duration: int = 5,
-        aspect_ratio: str = '16:9',
+        aspect_ratio: str = "16:9",
         camera_fixed: bool = False,
         seed: int = -1,
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-v1-lite-t2v-1080p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_720p.py
+++ b/src/atlascloud_comfyui/nodes/video/seedance_v1_lite_t2v_720p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -15,16 +22,33 @@ class AtlasSeedanceV1LiteT2V720p:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                'atlas_client': ('ATLAS_CLIENT',),
-                'prompt': ('STRING', {'multiline': True, 'tooltip': 'Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.'}),
-                'duration': ('INT', {'default': 5, 'min': 1, 'max': 120, 'tooltip': 'The duration of the generated media in seconds.'}),
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "tooltip": "Text prompt for video generation; Positive text prompt; Cannot exceed 2000 characters.",
+                    },
+                ),
+                "duration": ("INT", {"default": 5, "min": 1, "max": 120, "tooltip": "The duration of the generated media in seconds."}),
             },
             "optional": {
-                'poll_interval_sec': ('FLOAT', {'default': 2.0, 'min': 0.5, 'max': 10.0, 'tooltip': 'Polling interval (seconds)'}),
-                'timeout_sec': ('INT', {'default': 900, 'min': 30, 'max': 7200, 'tooltip': 'Timeout (seconds)'}),
-                'aspect_ratio': (['21:9', '16:9', '4:3', '1:1', '3:4', '9:16'], {'default': '16:9', 'tooltip': 'The aspect ratio of the generated video.'}),
-                'camera_fixed': ('BOOLEAN', {'default': False, 'tooltip': 'Whether to fix the camera position.'}),
-                'seed': ('INT', {'default': -1, 'min': -1, 'max': 2147483647, 'tooltip': 'The random seed to use for the generation. -1 means a random seed will be used.'}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+                "aspect_ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "16:9", "tooltip": "The aspect ratio of the generated video."},
+                ),
+                "camera_fixed": ("BOOLEAN", {"default": False, "tooltip": "Whether to fix the camera position."}),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2147483647,
+                        "tooltip": "The random seed to use for the generation. -1 means a random seed will be used.",
+                    },
+                ),
             },
         }
 
@@ -33,12 +57,19 @@ class AtlasSeedanceV1LiteT2V720p:
         atlas_client: AtlasClientHandle,
         prompt: str,
         duration: int,
-        aspect_ratio: str = '16:9',
+        aspect_ratio: str = "16:9",
         camera_fixed: bool = False,
         seed: int = -1,
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: bytedance/seedance-v1-lite-t2v-720p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/veo2_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veo2_i2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -45,6 +52,13 @@ class AtlasVeo2ImageToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/veo2/image-to-video. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/veo2_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veo2_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -43,6 +50,13 @@ class AtlasVeo2TextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/veo2. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/veo3_fast_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veo3_fast_i2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -51,6 +58,13 @@ class AtlasVeo3FastImageToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/veo3-fast/image-to-video. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         image = (image or "").strip()
         if not image:
             raise RuntimeError("image is required (URL or base64)")

--- a/src/atlascloud_comfyui/nodes/video/veo3_fast_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veo3_fast_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -43,6 +50,13 @@ class AtlasVeo3FastTextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/veo3-fast. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/veo3_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veo3_i2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -43,6 +50,13 @@ class AtlasVeo3ImageToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/veo3/image-to-video. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         image = (image or "").strip()

--- a/src/atlascloud_comfyui/nodes/video/veo3_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/veo3_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -43,6 +50,13 @@ class AtlasVeo3TextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: google/veo3. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload: Dict[str, Any] = {

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_fast_reference_to_video.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_fast_reference_to_video.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, List, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -43,6 +50,13 @@ class AtlasViduQ2ProFastReferenceToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: vidu/q2-pro-fast/reference-to-video. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
         if not imgs:
             raise RuntimeError("images is required (provide 1-7 lines)")

--- a/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_fast_reference_to_video_with_audio.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q2_pro_fast_reference_to_video_with_audio.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, List, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -45,6 +52,13 @@ class AtlasViduQ2ProFastReferenceToVideoWithAudio:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: vidu/q2-pro-fast/reference-to-video-with-audio. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         imgs: List[str] = [ln.strip() for ln in (images or "").splitlines() if ln.strip()]
         if not imgs:
             raise RuntimeError("images is required (provide 1-7 lines)")

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_i2v_v2.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_i2v_v2.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -48,6 +55,13 @@ class AtlasViduQ3ImageToVideoV2:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: vidu/q3/image-to-video. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         image = (image or "").strip()
         if not image:
             raise RuntimeError("image is required (URL or base64)")

--- a/src/atlascloud_comfyui/nodes/video/vidu_q3_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/vidu_q3_t2v.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Any, Dict, Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -50,6 +57,13 @@ class AtlasViduQ3TextToVideo:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: vidu/q3/text-to-video. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         prompt = (prompt or "").strip()
         if not prompt:
             raise RuntimeError("prompt is required")

--- a/src/atlascloud_comfyui/nodes/video/wan22_t2v_720p.py
+++ b/src/atlascloud_comfyui/nodes/video/wan22_t2v_720p.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+# NOTE: This node targets a model id that is no longer present in AtlasCloud /api/v1/models
+# It is kept for backward compatibility with existing ComfyUI workflows.
+DEPRECATED_MODEL_ID = True
+DEPRECATION_REASON = "Model id not returned by AtlasCloud /api/v1/models; likely deprecated or removed upstream."
+
+import os
+
 from typing import Tuple
 
 from ..auth.atlas_client_node import AtlasClientHandle
@@ -35,6 +42,13 @@ class AtlasWAN22T2V720p:
         poll_interval_sec: float = 2.0,
         timeout_sec: int = 900,
     ) -> Tuple[str, str]:
+        # Deprecated model guard
+        if os.getenv("ATLAS_ALLOW_DEPRECATED_MODELS", "").lower() not in ("1", "true", "yes"):
+            raise RuntimeError(
+                "Deprecated model id: alibaba/wan-2.2/t2v-720p. This node is kept for backward compatibility, but the model is not returned by AtlasCloud /api/v1/models. "
+                "Set ATLAS_ALLOW_DEPRECATED_MODELS=1 to force execution at your own risk."
+            )
+
         client = atlas_client.client
 
         payload = {


### PR DESCRIPTION
## Summary

Adds the existing deprecation marker pattern (`DEPRECATED_MODEL_ID = True` + runtime guard, mirroring `sora2_*.py` / `luma_ray2_*.py` / `pika_*.py`) to every node whose `model` identifier is not currently returned by `https://api.atlascloud.ai/api/v1/models`.

- **34 nodes** newly marked as deprecated (previously the marker covered only 22 of the 55 catalog-missing nodes).
- **1 node** reverted: `nano_banana_pro_t2i_ultra.py` — its model id (`google/nano-banana-pro/text-to-image-ultra`) is back in the catalog, so the stale marker is removed.

## Behavior

- Nodes still load in ComfyUI (no removed `NODE_CLASS_MAPPINGS` keys), so existing workflows keep importing.
- Calling `.run()` on a deprecated node now raises a clear message and refuses to call the API.
- Users who explicitly want to keep trying can set `ATLAS_ALLOW_DEPRECATED_MODELS=1`.

## Compatibility

Passes `comfy-org/node-diff` backwards-compat check by design:
- No `NODE_CLASS_MAPPINGS` keys removed
- No `RETURN_TYPES` changes
- Only an in-method runtime guard + module-level metadata flag

## Test plan
- [x] `pytest tests/ -q --ignore-glob='tests/test_e2e*'` → 239 passed locally
- [x] `python -m py_compile` clean on every touched file
- [x] Pre-commit (`ruff`, `ruff-format`) clean

Refs #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)