### PR TITLE
sync: add 4 AtlasCloud visual models (2026-05-29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3.1 Lite Text-to-Video | google/veo3.1-lite/text-to-video |
 | AtlasCloud VEO3.1 Fast Text-to-Video | google/veo3.1-fast/text-to-video |
 | AtlasCloud Gemini Omni Flash Text-to-Video Developer | google/gemini-omni-flash/text-to-video-developer |
+| AtlasCloud Grok Imagine Video Text-to-Video | xai/grok-imagine-video/text-to-video |
 | AtlasCloud VEO2 Text-to-Video | google/veo2 |
 | AtlasCloud WAN2.6 Text-to-Video | alibaba/wan-2.6/text-to-video |
 | AtlasCloud WAN2.7 Text-to-Video | alibaba/wan-2.7/text-to-video |
@@ -140,6 +141,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3 Fast Image-to-Video | google/veo3-fast/image-to-video |
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
 | AtlasCloud Gemini Omni Flash Image-to-Video Developer | google/gemini-omni-flash/image-to-video-developer |
+| AtlasCloud Grok Imagine Video Image-to-Video | xai/grok-imagine-video/image-to-video |
+| AtlasCloud Grok Imagine Video Reference-to-Video | xai/grok-imagine-video/reference-to-video |
 | AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |
 | AtlasCloud Seedance 2.0 Reference-to-Video | bytedance/seedance-2.0/reference-to-video |
 | AtlasCloud Seedance 2.0 Fast Reference-to-Video | bytedance/seedance-2.0-fast/reference-to-video |
@@ -294,6 +297,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Flux Dev Text-to-Image | black-forest-labs/flux-dev |
 | AtlasCloud Flux Dev LoRA Text-to-Image | black-forest-labs/flux-dev-lora |
 | AtlasCloud Flux Schnell Text-to-Image | black-forest-labs/flux-schnell |
+| AtlasCloud FLUX.2 Pro Text-to-Image | black-forest-labs/flux-2-pro/text-to-image |
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |

--- a/src/atlascloud_comfyui/nodes/image/flux2_pro_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/flux2_pro_t2i.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasFlux2ProTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "size": ("STRING", {"default": "1024*1024", "tooltip": "Image dimensions WIDTH*HEIGHT (256-2048)"}),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output image format"}),
+                "safety_tolerance": ("INT", {"default": 2, "min": 0, "max": 5, "tooltip": "0=strict, 5=least strict"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Wait for result inline if true"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1024*1024",
+        output_format: str = "jpeg",
+        safety_tolerance: int = 2,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-2-pro/text-to-image",
+            "prompt": p,
+            "size": str(size).strip(),
+            "output_format": output_format,
+            "safety_tolerance": int(safety_tolerance),
+            "seed": int(seed),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_i2v.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineVideoImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Motion prompt; first frame comes from image_url"}),
+                "image_url": ("STRING", {"default": "", "tooltip": "Starting-frame image (HTTPS URL or base64 data URI)"}),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 8, "min": 1, "max": 15, "tooltip": "Duration (seconds, 1-15)"}),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Output resolution"}),
+                "aspect_ratio": (
+                    ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"],
+                    {"default": "16:9", "tooltip": "Output aspect ratio"},
+                ),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_url: str,
+        duration: int = 8,
+        resolution: str = "720p",
+        aspect_ratio: str = "16:9",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image_url = (image_url or "").strip()
+        if not image_url:
+            raise RuntimeError("image_url is required (URL or base64 data URI)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-video/image-to-video",
+            "prompt": prompt,
+            "image_url": image_url,
+            "duration": int(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_r2v.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineVideoReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Video prompt; use <IMAGE_N> tags to reference inputs"}),
+                "image_urls": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "1-7 reference images, one per line (URL or base64)"},
+                ),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 8, "min": 1, "max": 10, "tooltip": "Duration (seconds, capped at 10)"}),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Output resolution"}),
+                "aspect_ratio": (
+                    ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"],
+                    {"default": "16:9", "tooltip": "Output aspect ratio"},
+                ),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_urls: str,
+        duration: int = 8,
+        resolution: str = "720p",
+        aspect_ratio: str = "16:9",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        urls: List[str] = [v.strip() for v in (image_urls or "").splitlines() if v.strip()]
+        if not urls:
+            raise RuntimeError("image_urls is required (1-7 lines)")
+        if len(urls) > 7:
+            raise RuntimeError("image_urls maxItems is 7")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-video/reference-to-video",
+            "prompt": prompt,
+            "image_urls": urls,
+            "duration": int(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_t2v.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineVideoTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 8, "min": 1, "max": 15, "tooltip": "Duration (seconds, 1-15)"}),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Output resolution"}),
+                "aspect_ratio": (
+                    ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"],
+                    {"default": "16:9", "tooltip": "Output aspect ratio"},
+                ),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 8,
+        resolution: str = "720p",
+        aspect_ratio: str = "16:9",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-video/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -89,6 +89,10 @@ from atlascloud_comfyui.nodes.video.google_veo31_fast_i2v import AtlasVeo31FastI
 from atlascloud_comfyui.nodes.video.google_veo31_r2v import AtlasVeo31ReferenceToVideo
 from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_t2v_dev import AtlasGeminiOmniFlashTextToVideoDev
 from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_i2v_dev import AtlasGeminiOmniFlashImageToVideoDev
+from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_t2v import AtlasGrokImagineVideoTextToVideo
+from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_i2v import AtlasGrokImagineVideoImageToVideo
+from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_r2v import AtlasGrokImagineVideoReferenceToVideo
+from atlascloud_comfyui.nodes.image.flux2_pro_t2i import AtlasFlux2ProTextToImage
 from atlascloud_comfyui.nodes.deprecated.video.veo3_i2v import AtlasVeo3ImageToVideo
 from atlascloud_comfyui.nodes.deprecated.video.veo2_t2v import AtlasVeo2TextToVideo
 from atlascloud_comfyui.nodes.deprecated.video.veo2_i2v import AtlasVeo2ImageToVideo
@@ -567,6 +571,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Seedance V1 Lite T2V 720p": AtlasSeedanceV1LiteT2V720p,
     "AtlasCloud Seedance V1 Lite I2V 1080p": AtlasSeedanceV1LiteI2V1080p,
     "AtlasCloud Kling V2.0 T2V Master": AtlasKlingV20T2VMaster,
+    "AtlasCloud Grok Imagine Video Text-to-Video": AtlasGrokImagineVideoTextToVideo,
+    "AtlasCloud Grok Imagine Video Image-to-Video": AtlasGrokImagineVideoImageToVideo,
+    "AtlasCloud Grok Imagine Video Reference-to-Video": AtlasGrokImagineVideoReferenceToVideo,
+    "AtlasCloud FLUX.2 Pro Text-to-Image": AtlasFlux2ProTextToImage,
 }
 
 
@@ -831,6 +839,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedance V1 Lite T2V 720p": "AtlasCloud Seedance V1 Lite T2V 720p",
     "AtlasCloud Seedance V1 Lite I2V 1080p": "AtlasCloud Seedance V1 Lite I2V 1080p",
     "AtlasCloud Kling V2.0 T2V Master": "AtlasCloud Kling V2.0 T2V Master",
+    "AtlasCloud Grok Imagine Video Text-to-Video": "AtlasCloud Grok Imagine Video Text-to-Video",
+    "AtlasCloud Grok Imagine Video Image-to-Video": "AtlasCloud Grok Imagine Video Image-to-Video",
+    "AtlasCloud Grok Imagine Video Reference-to-Video": "AtlasCloud Grok Imagine Video Reference-to-Video",
+    "AtlasCloud FLUX.2 Pro Text-to-Image": "AtlasCloud FLUX.2 Pro Text-to-Image",
 }
 
 

--- a/tests/test_new_nodes_2026_05_29.py
+++ b/tests/test_new_nodes_2026_05_29.py
@@ -1,0 +1,70 @@
+"""Metadata-only tests for newly added nodes (2026-05-29).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_grok_imagine_video_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_t2v import (
+        AtlasGrokImagineVideoTextToVideo,
+    )
+
+    required = AtlasGrokImagineVideoTextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasGrokImagineVideoTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGrokImagineVideoTextToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_grok_imagine_video_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_i2v import (
+        AtlasGrokImagineVideoImageToVideo,
+    )
+
+    required = AtlasGrokImagineVideoImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image_url" in required
+    assert AtlasGrokImagineVideoImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGrokImagineVideoImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_grok_imagine_video_r2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_r2v import (
+        AtlasGrokImagineVideoReferenceToVideo,
+    )
+
+    required = AtlasGrokImagineVideoReferenceToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image_urls" in required
+    assert AtlasGrokImagineVideoReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGrokImagineVideoReferenceToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_flux2_pro_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.flux2_pro_t2i import (
+        AtlasFlux2ProTextToImage,
+    )
+
+    required = AtlasFlux2ProTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasFlux2ProTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasFlux2ProTextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Grok Imagine Video Text-to-Video",
+        "AtlasCloud Grok Imagine Video Image-to-Video",
+        "AtlasCloud Grok Imagine Video Reference-to-Video",
+        "AtlasCloud FLUX.2 Pro Text-to-Image",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS


### PR DESCRIPTION
## Summary

Daily AtlasCloud → ComfyUI node sync for 2026-05-29.

API now lists **4 new visual models** not yet wrapped in this repo:

| Model ID | Kind | Node Class |
|---|---|---|
| `xai/grok-imagine-video/text-to-video` | T2V | `AtlasGrokImagineVideoTextToVideo` |
| `xai/grok-imagine-video/image-to-video` | I2V | `AtlasGrokImagineVideoImageToVideo` |
| `xai/grok-imagine-video/reference-to-video` | R2V | `AtlasGrokImagineVideoReferenceToVideo` |
| `black-forest-labs/flux-2-pro/text-to-image` | T2I | `AtlasFlux2ProTextToImage` |

All node payloads follow each model's published OpenAPI schema (duration 1–15, resolution 480p/720p, aspect_ratio enum, etc.) and reuse the standard `poll_prediction` + `outputs[0]` pattern.

## Changes

- New node files under `src/atlascloud_comfyui/nodes/{image,video}/`
- Registered in `src/atlascloud_comfyui/registry.py`
- Added to README "Available Nodes" tables
- Added metadata-only tests in `tests/test_new_nodes_2026_05_29.py`

## Test plan

- [x] `python3 -m ruff check .` — clean
- [x] `python3 -m pytest tests/ -k "not e2e"` — 244 passed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)