### PR TITLE
sync: add 4 AtlasCloud visual models (2026-05-30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Gemini Omni Flash Image-to-Video Developer | google/gemini-omni-flash/image-to-video-developer |
 | AtlasCloud Grok Imagine Video Image-to-Video | xai/grok-imagine-video/image-to-video |
 | AtlasCloud Grok Imagine Video Reference-to-Video | xai/grok-imagine-video/reference-to-video |
+| AtlasCloud Grok Imagine Video Edit | xai/grok-imagine-video/edit-video |
+| AtlasCloud Grok Imagine Video Extend | xai/grok-imagine-video/extend-video |
 | AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |
 | AtlasCloud Seedance 2.0 Reference-to-Video | bytedance/seedance-2.0/reference-to-video |
 | AtlasCloud Seedance 2.0 Fast Reference-to-Video | bytedance/seedance-2.0-fast/reference-to-video |
@@ -298,6 +300,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Flux Dev LoRA Text-to-Image | black-forest-labs/flux-dev-lora |
 | AtlasCloud Flux Schnell Text-to-Image | black-forest-labs/flux-schnell |
 | AtlasCloud FLUX.2 Pro Text-to-Image | black-forest-labs/flux-2-pro/text-to-image |
+| AtlasCloud FLUX.2 Flex Edit | black-forest-labs/flux-2-flex/edit |
+| AtlasCloud FLUX.2 Pro Edit | black-forest-labs/flux-2-pro/edit |
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |

--- a/src/atlascloud_comfyui/nodes/image/flux2_flex_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/flux2_flex_edit.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasFlux2FlexEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt for image editing"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-8 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "enable_prompt_expansion": ("BOOLEAN", {"default": True, "tooltip": "Use prompt upsampling before generation"}),
+                "size": ("STRING", {"default": "1024*1024", "tooltip": "Image dimensions WIDTH*HEIGHT (256-2048)"}),
+                "guidance_scale": ("FLOAT", {"default": 5.0, "min": 1.5, "max": 10.0, "tooltip": "Guidance scale"}),
+                "num_inference_steps": ("INT", {"default": 50, "min": 1, "max": 50, "tooltip": "Inference steps"}),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output image format"}),
+                "safety_tolerance": ("INT", {"default": 2, "min": 0, "max": 5, "tooltip": "0=strict, 5=least strict"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Wait for result inline if true"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        enable_prompt_expansion: bool = True,
+        size: str = "1024*1024",
+        guidance_scale: float = 5.0,
+        num_inference_steps: int = 50,
+        output_format: str = "jpeg",
+        safety_tolerance: int = 2,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-8 lines)")
+        if len(image_list) > 8:
+            raise RuntimeError("images maxItems is 8")
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-2-flex/edit",
+            "prompt": p,
+            "images": image_list,
+            "enable_prompt_expansion": bool(enable_prompt_expansion),
+            "size": str(size).strip(),
+            "guidance_scale": float(guidance_scale),
+            "num_inference_steps": int(num_inference_steps),
+            "output_format": output_format,
+            "safety_tolerance": int(safety_tolerance),
+            "seed": int(seed),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/flux2_pro_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/flux2_pro_edit.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasFlux2ProEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt for image editing"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-8 image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "size": ("STRING", {"default": "1024*1024", "tooltip": "Image dimensions WIDTH*HEIGHT (256-2048)"}),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output image format"}),
+                "safety_tolerance": ("INT", {"default": 2, "min": 0, "max": 5, "tooltip": "0=strict, 5=least strict"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL"}),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Wait for result inline if true"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        size: str = "1024*1024",
+        output_format: str = "jpeg",
+        safety_tolerance: int = 2,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        enable_sync_mode: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-8 lines)")
+        if len(image_list) > 8:
+            raise RuntimeError("images maxItems is 8")
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-2-pro/edit",
+            "prompt": p,
+            "images": image_list,
+            "size": str(size).strip(),
+            "output_format": output_format,
+            "safety_tolerance": int(safety_tolerance),
+            "seed": int(seed),
+            "enable_base64_output": bool(enable_base64_output),
+            "enable_sync_mode": bool(enable_sync_mode),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_edit_video.py
+++ b/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_edit_video.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineVideoEdit:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Editing instruction (e.g. 'add a silver necklace')"}),
+                "video_url": ("STRING", {"default": "", "tooltip": "Public mp4 URL; duration must not exceed 8.7s"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video_url: str,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        video_url = (video_url or "").strip()
+        if not video_url:
+            raise RuntimeError("video_url is required (public mp4 URL)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-video/edit-video",
+            "prompt": prompt,
+            "video_url": video_url,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_extend_video.py
+++ b/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_extend_video.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineVideoExtend:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "What should happen after the input video's last frame"}),
+                "video_url": ("STRING", {"default": "", "tooltip": "Public mp4 URL; input duration must be 2-15s"}),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 6, "min": 2, "max": 10, "tooltip": "Extension length in seconds (2-10)"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video_url: str,
+        duration: int = 6,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        video_url = (video_url or "").strip()
+        if not video_url:
+            raise RuntimeError("video_url is required (public mp4 URL)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-video/extend-video",
+            "prompt": prompt,
+            "video_url": video_url,
+            "duration": int(duration),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -93,6 +93,10 @@ from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_t2v import AtlasGrokI
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_i2v import AtlasGrokImagineVideoImageToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_r2v import AtlasGrokImagineVideoReferenceToVideo
 from atlascloud_comfyui.nodes.image.flux2_pro_t2i import AtlasFlux2ProTextToImage
+from atlascloud_comfyui.nodes.image.flux2_flex_edit import AtlasFlux2FlexEdit
+from atlascloud_comfyui.nodes.image.flux2_pro_edit import AtlasFlux2ProEdit
+from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_edit_video import AtlasGrokImagineVideoEdit
+from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_extend_video import AtlasGrokImagineVideoExtend
 from atlascloud_comfyui.nodes.deprecated.video.veo3_i2v import AtlasVeo3ImageToVideo
 from atlascloud_comfyui.nodes.deprecated.video.veo2_t2v import AtlasVeo2TextToVideo
 from atlascloud_comfyui.nodes.deprecated.video.veo2_i2v import AtlasVeo2ImageToVideo
@@ -575,6 +579,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Grok Imagine Video Image-to-Video": AtlasGrokImagineVideoImageToVideo,
     "AtlasCloud Grok Imagine Video Reference-to-Video": AtlasGrokImagineVideoReferenceToVideo,
     "AtlasCloud FLUX.2 Pro Text-to-Image": AtlasFlux2ProTextToImage,
+    "AtlasCloud FLUX.2 Flex Edit": AtlasFlux2FlexEdit,
+    "AtlasCloud FLUX.2 Pro Edit": AtlasFlux2ProEdit,
+    "AtlasCloud Grok Imagine Video Edit": AtlasGrokImagineVideoEdit,
+    "AtlasCloud Grok Imagine Video Extend": AtlasGrokImagineVideoExtend,
 }
 
 
@@ -843,6 +851,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Grok Imagine Video Image-to-Video": "AtlasCloud Grok Imagine Video Image-to-Video",
     "AtlasCloud Grok Imagine Video Reference-to-Video": "AtlasCloud Grok Imagine Video Reference-to-Video",
     "AtlasCloud FLUX.2 Pro Text-to-Image": "AtlasCloud FLUX.2 Pro Text-to-Image",
+    "AtlasCloud FLUX.2 Flex Edit": "AtlasCloud FLUX.2 Flex Edit",
+    "AtlasCloud FLUX.2 Pro Edit": "AtlasCloud FLUX.2 Pro Edit",
+    "AtlasCloud Grok Imagine Video Edit": "AtlasCloud Grok Imagine Video Edit",
+    "AtlasCloud Grok Imagine Video Extend": "AtlasCloud Grok Imagine Video Extend",
 }
 
 

--- a/tests/test_new_nodes_2026_05_30.py
+++ b/tests/test_new_nodes_2026_05_30.py
@@ -1,0 +1,68 @@
+"""Metadata-only tests for newly added nodes (2026-05-30).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_flux2_flex_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.flux2_flex_edit import AtlasFlux2FlexEdit
+
+    required = AtlasFlux2FlexEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasFlux2FlexEdit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasFlux2FlexEdit.CATEGORY == "AtlasCloud/Image"
+
+
+def test_flux2_pro_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.flux2_pro_edit import AtlasFlux2ProEdit
+
+    required = AtlasFlux2ProEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasFlux2ProEdit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasFlux2ProEdit.CATEGORY == "AtlasCloud/Image"
+
+
+def test_grok_imagine_video_edit_metadata():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_edit_video import (
+        AtlasGrokImagineVideoEdit,
+    )
+
+    required = AtlasGrokImagineVideoEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "video_url" in required
+    assert AtlasGrokImagineVideoEdit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGrokImagineVideoEdit.CATEGORY == "AtlasCloud/Video"
+
+
+def test_grok_imagine_video_extend_metadata():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_extend_video import (
+        AtlasGrokImagineVideoExtend,
+    )
+
+    required = AtlasGrokImagineVideoExtend.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "video_url" in required
+    assert AtlasGrokImagineVideoExtend.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGrokImagineVideoExtend.CATEGORY == "AtlasCloud/Video"
+
+
+def test_new_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud FLUX.2 Flex Edit",
+        "AtlasCloud FLUX.2 Pro Edit",
+        "AtlasCloud Grok Imagine Video Edit",
+        "AtlasCloud Grok Imagine Video Extend",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS


### PR DESCRIPTION
## New AtlasCloud visual models (2026-05-30)

Daily sync diff found 4 new visual models in the AtlasCloud catalog. Each gets a metadata-safe ComfyUI node (no top-level comfy/folder_paths/requests imports), registry wiring, README row, and metadata-only test.

| Display name | model id | type |
|---|---|---|
| AtlasCloud FLUX.2 Flex Edit | `black-forest-labs/flux-2-flex/edit` | image-edit |
| AtlasCloud FLUX.2 Pro Edit | `black-forest-labs/flux-2-pro/edit` | image-edit |
| AtlasCloud Grok Imagine Video Edit | `xai/grok-imagine-video/edit-video` | video-edit |
| AtlasCloud Grok Imagine Video Extend | `xai/grok-imagine-video/extend-video` | video-edit |

Inputs derived from each model's published OpenAPI schema. Edit nodes require `images` (1-8); video edit/extend require `video_url`.

## Tests
- `ruff check .` ✅
- `pytest tests/ -v -k "not e2e and not test_e2e"` ✅ — 249 passed, 26 deselected
- E2E skipped (no local ComfyUI source on sync host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)