### PR TITLE
sync: add 1 AtlasCloud visual model (2026-06-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
 | AtlasCloud Gemini Omni Flash Image-to-Video Developer | google/gemini-omni-flash/image-to-video-developer |
 | AtlasCloud Grok Imagine Video Image-to-Video | xai/grok-imagine-video/image-to-video |
+| AtlasCloud Grok Imagine Video v1.5 Image-to-Video | xai/grok-imagine-video-v1.5/image-to-video |
 | AtlasCloud Grok Imagine Video Reference-to-Video | xai/grok-imagine-video/reference-to-video |
 | AtlasCloud Grok Imagine Video Edit | xai/grok-imagine-video/edit-video |
 | AtlasCloud Grok Imagine Video Extend | xai/grok-imagine-video/extend-video |

--- a/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_v15_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_v15_i2v.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineVideoV15ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Motion prompt; first frame comes from image_url"}),
+                "image_url": ("STRING", {"default": "", "tooltip": "Starting-frame image (HTTPS URL or base64 data URI)"}),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 8, "min": 1, "max": 15, "tooltip": "Duration (seconds, 1-15)"}),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Output resolution"}),
+                "aspect_ratio": (
+                    ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"],
+                    {"default": "16:9", "tooltip": "Output aspect ratio"},
+                ),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_url: str,
+        duration: int = 8,
+        resolution: str = "720p",
+        aspect_ratio: str = "16:9",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image_url = (image_url or "").strip()
+        if not image_url:
+            raise RuntimeError("image_url is required (URL or base64 data URI)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-video-v1.5/image-to-video",
+            "prompt": prompt,
+            "image_url": image_url,
+            "duration": int(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -91,6 +91,7 @@ from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_t2v_dev import Atla
 from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_i2v_dev import AtlasGeminiOmniFlashImageToVideoDev
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_t2v import AtlasGrokImagineVideoTextToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_i2v import AtlasGrokImagineVideoImageToVideo
+from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_i2v import AtlasGrokImagineVideoV15ImageToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_r2v import AtlasGrokImagineVideoReferenceToVideo
 from atlascloud_comfyui.nodes.image.flux2_pro_t2i import AtlasFlux2ProTextToImage
 from atlascloud_comfyui.nodes.image.flux2_flex_edit import AtlasFlux2FlexEdit
@@ -577,6 +578,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Kling V2.0 T2V Master": AtlasKlingV20T2VMaster,
     "AtlasCloud Grok Imagine Video Text-to-Video": AtlasGrokImagineVideoTextToVideo,
     "AtlasCloud Grok Imagine Video Image-to-Video": AtlasGrokImagineVideoImageToVideo,
+    "AtlasCloud Grok Imagine Video v1.5 Image-to-Video": AtlasGrokImagineVideoV15ImageToVideo,
     "AtlasCloud Grok Imagine Video Reference-to-Video": AtlasGrokImagineVideoReferenceToVideo,
     "AtlasCloud FLUX.2 Pro Text-to-Image": AtlasFlux2ProTextToImage,
     "AtlasCloud FLUX.2 Flex Edit": AtlasFlux2FlexEdit,
@@ -849,6 +851,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Kling V2.0 T2V Master": "AtlasCloud Kling V2.0 T2V Master",
     "AtlasCloud Grok Imagine Video Text-to-Video": "AtlasCloud Grok Imagine Video Text-to-Video",
     "AtlasCloud Grok Imagine Video Image-to-Video": "AtlasCloud Grok Imagine Video Image-to-Video",
+    "AtlasCloud Grok Imagine Video v1.5 Image-to-Video": "AtlasCloud Grok Imagine Video v1.5 Image-to-Video",
     "AtlasCloud Grok Imagine Video Reference-to-Video": "AtlasCloud Grok Imagine Video Reference-to-Video",
     "AtlasCloud FLUX.2 Pro Text-to-Image": "AtlasCloud FLUX.2 Pro Text-to-Image",
     "AtlasCloud FLUX.2 Flex Edit": "AtlasCloud FLUX.2 Flex Edit",

--- a/tests/test_new_nodes_2026_06_01.py
+++ b/tests/test_new_nodes_2026_06_01.py
@@ -1,0 +1,28 @@
+"""Metadata-only tests for newly added nodes (2026-06-01).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_grok_imagine_video_v15_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_i2v import (
+        AtlasGrokImagineVideoV15ImageToVideo,
+    )
+
+    required = AtlasGrokImagineVideoV15ImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image_url" in required
+    assert AtlasGrokImagineVideoV15ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGrokImagineVideoV15ImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_new_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in ("AtlasCloud Grok Imagine Video v1.5 Image-to-Video",):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS


### PR DESCRIPTION
## New AtlasCloud visual model

| Display name | model id |
|---|---|
| AtlasCloud Grok Imagine Video v1.5 Image-to-Video | `xai/grok-imagine-video-v1.5/image-to-video` |

Schema is identical to the existing Grok Imagine Video Image-to-Video node (prompt + image_url required; duration/resolution/aspect_ratio optional).

### Changes
- New node: `nodes/video/xai_grok_imagine_video_v15_i2v.py`
- registry.py: import + NODE_CLASS_MAPPINGS + NODE_DISPLAY_NAME_MAPPINGS
- README.md: Available Nodes row
- tests/test_new_nodes_2026_06_01.py: metadata-only tests

### Test summary
- ruff check: ✅ All checks passed
- pytest (metadata, e2e deselected): ✅ 251 passed, 26 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)