### PR TITLE
sync: add 3 AtlasCloud visual models (2026-06-03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud VEO3 Fast Image-to-Video | google/veo3-fast/image-to-video |
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
 | AtlasCloud Gemini Omni Flash Image-to-Video Developer | google/gemini-omni-flash/image-to-video-developer |
+| AtlasCloud Gemini Omni Flash Reference-to-Video Developer | google/gemini-omni-flash/reference-to-video-developer |
 | AtlasCloud Grok Imagine Video Image-to-Video | xai/grok-imagine-video/image-to-video |
 | AtlasCloud Grok Imagine Video v1.5 Image-to-Video | xai/grok-imagine-video-v1.5/image-to-video |
 | AtlasCloud Grok Imagine Video Reference-to-Video | xai/grok-imagine-video/reference-to-video |
@@ -334,6 +335,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 |------|-------|
 | AtlasCloud Nano Banana 2 Edit | google/nano-banana-2/edit |
 | AtlasCloud Nano Banana 2 Edit Developer | google/nano-banana-2/edit-developer |
+| AtlasCloud Nano Banana 2 Reference-to-Image | google/nano-banana-2/reference-to-image |
+| AtlasCloud Nano Banana 2 Reference-to-Image Developer | google/nano-banana-2/reference-to-image-developer |
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |
 | AtlasCloud Seedream V5.0 Lite Edit Sequential | bytedance/seedream-v5.0-lite/edit-sequential |
 | AtlasCloud WAN2.6 Image-Edit | alibaba/wan-2.6/image-edit |

--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_r2i.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_r2i.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBanana2ReferenceToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt for generation"}),
+                "video_url": ("STRING", {"default": "", "tooltip": "Source video clip URL (HTTP <=15MB or YouTube URL)"}),
+            },
+            "optional": {
+                "video_start": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 86400.0, "tooltip": "Trim start (seconds)"}),
+                "video_ends": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 86400.0, "tooltip": "Trim end (seconds); 0 = whole video"}),
+                "video_fps": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 24.0, "tooltip": "FPS of the video clip"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional 0-10 reference image URLs/base64, one per line"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+                "output_format": (["default", "png", "jpeg"], {"default": "default", "tooltip": "Output format"}),
+                "enable_web_search": ("BOOLEAN", {"default": False, "tooltip": "Ground generation with web search"}),
+                "enable_image_search": ("BOOLEAN", {"default": False, "tooltip": "Ground generation with image search"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video_url: str,
+        video_start: float = 0.0,
+        video_ends: float = 0.0,
+        video_fps: float = 1.0,
+        images: str = "",
+        aspect_ratio: str = "1:1",
+        resolution: str = "1k",
+        output_format: str = "default",
+        enable_web_search: bool = False,
+        enable_image_search: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        video_url = (video_url or "").strip()
+        if not video_url:
+            raise RuntimeError("video_url is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-2/reference-to-image",
+            "prompt": prompt,
+            "video_clips": [
+                {
+                    "url": video_url,
+                    "start": float(video_start),
+                    "ends": float(video_ends),
+                    "fps": float(video_fps),
+                }
+            ],
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": output_format,
+            "enable_web_search": bool(enable_web_search),
+            "enable_image_search": bool(enable_image_search),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        if image_list:
+            payload["images"] = image_list
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_r2i_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_r2i_dev.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBanana2ReferenceToImageDev:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt for generation"}),
+                "video_url": ("STRING", {"default": "", "tooltip": "Source video clip URL (HTTP <=15MB or YouTube URL)"}),
+            },
+            "optional": {
+                "video_start": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 86400.0, "tooltip": "Trim start (seconds)"}),
+                "video_ends": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 86400.0, "tooltip": "Trim end (seconds); 0 = whole video"}),
+                "video_fps": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 24.0, "tooltip": "FPS of the video clip"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional 0-10 reference image URLs/base64, one per line"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+                "enable_web_search": ("BOOLEAN", {"default": False, "tooltip": "Ground generation with web search"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video_url: str,
+        video_start: float = 0.0,
+        video_ends: float = 0.0,
+        video_fps: float = 1.0,
+        images: str = "",
+        aspect_ratio: str = "1:1",
+        resolution: str = "1k",
+        enable_web_search: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        video_url = (video_url or "").strip()
+        if not video_url:
+            raise RuntimeError("video_url is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-2/reference-to-image-developer",
+            "prompt": prompt,
+            "video_clips": [
+                {
+                    "url": video_url,
+                    "start": float(video_start),
+                    "ends": float(video_ends),
+                    "fps": float(video_fps),
+                }
+            ],
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "enable_web_search": bool(enable_web_search),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        if image_list:
+            payload["images"] = image_list
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_gemini_omni_flash_r2v_dev.py
+++ b/src/atlascloud_comfyui/nodes/video/google_gemini_omni_flash_r2v_dev.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGeminiOmniFlashReferenceToVideoDev:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (max 20,000 chars)"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-5 reference image URLs/base64, one per line"}),
+                "video_url": ("STRING", {"default": "", "tooltip": "Source video clip URL (<=100MB, <=30s)"}),
+            },
+            "optional": {
+                "video_start": ("INT", {"default": 0, "min": 0, "max": 29, "tooltip": "Trim start (seconds)"}),
+                "video_ends": ("INT", {"default": 10, "min": 1, "max": 30, "tooltip": "Trim end (seconds); ends-start must be <= 10"}),
+                "duration": ([4, 6, 8, 10], {"default": 8, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["720p", "1080p", "4k"], {"default": "720p", "tooltip": "Resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        video_url: str,
+        video_start: int = 0,
+        video_ends: int = 10,
+        duration: int = 8,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-5 lines)")
+        if len(image_list) > 5:
+            raise RuntimeError("images maxItems is 5")
+
+        video_url = (video_url or "").strip()
+        if not video_url:
+            raise RuntimeError("video_url is required")
+        if int(video_ends) - int(video_start) > 10:
+            raise RuntimeError("video_ends - video_start must not exceed 10 seconds")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/gemini-omni-flash/reference-to-video-developer",
+            "prompt": prompt,
+            "images": image_list,
+            "video_clips": [
+                {"url": video_url, "start": int(video_start), "ends": int(video_ends)}
+            ],
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -89,6 +89,7 @@ from atlascloud_comfyui.nodes.video.google_veo31_fast_i2v import AtlasVeo31FastI
 from atlascloud_comfyui.nodes.video.google_veo31_r2v import AtlasVeo31ReferenceToVideo
 from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_t2v_dev import AtlasGeminiOmniFlashTextToVideoDev
 from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_i2v_dev import AtlasGeminiOmniFlashImageToVideoDev
+from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_r2v_dev import AtlasGeminiOmniFlashReferenceToVideoDev
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_t2v import AtlasGrokImagineVideoTextToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_i2v import AtlasGrokImagineVideoImageToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_i2v import AtlasGrokImagineVideoV15ImageToVideo
@@ -149,6 +150,8 @@ from atlascloud_comfyui.nodes.image.flux_dev_lora_t2i import AtlasFluxDevLoraTex
 from atlascloud_comfyui.nodes.image.nano_banana2_t2i import AtlasNanoBanana2TextToImage
 from atlascloud_comfyui.nodes.deprecated.image.nano_banana2_t2i_dev import AtlasNanoBanana2TextToImageDev
 from atlascloud_comfyui.nodes.image.nano_banana2_edit import AtlasNanoBanana2Edit
+from atlascloud_comfyui.nodes.image.nano_banana2_r2i import AtlasNanoBanana2ReferenceToImage
+from atlascloud_comfyui.nodes.image.nano_banana2_r2i_dev import AtlasNanoBanana2ReferenceToImageDev
 from atlascloud_comfyui.nodes.deprecated.image.nano_banana2_edit_dev import AtlasNanoBanana2EditDev
 from atlascloud_comfyui.nodes.image.seedream_v50_lite_t2i import AtlasSeedreamV50LiteTextToImage
 from atlascloud_comfyui.nodes.image.seedream_v50_lite_edit import AtlasSeedreamV50LiteEdit
@@ -419,6 +422,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Nano Banana 2 Text-to-Image Developer": AtlasNanoBanana2TextToImageDev,
     "AtlasCloud Nano Banana 2 Edit": AtlasNanoBanana2Edit,
     "AtlasCloud Nano Banana 2 Edit Developer": AtlasNanoBanana2EditDev,
+    "AtlasCloud Nano Banana 2 Reference-to-Image": AtlasNanoBanana2ReferenceToImage,
+    "AtlasCloud Nano Banana 2 Reference-to-Image Developer": AtlasNanoBanana2ReferenceToImageDev,
     "AtlasCloud Seedream V5.0 Lite Text-to-Image": AtlasSeedreamV50LiteTextToImage,
     "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image": AtlasSeedreamV50LiteSequentialTextToImage,
     "AtlasCloud Seedream V5.0 Lite Edit": AtlasSeedreamV50LiteEdit,
@@ -453,6 +458,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud VEO3.1 Fast Image-to-Video": AtlasVeo31FastImageToVideo,
     "AtlasCloud Gemini Omni Flash Text-to-Video Developer": AtlasGeminiOmniFlashTextToVideoDev,
     "AtlasCloud Gemini Omni Flash Image-to-Video Developer": AtlasGeminiOmniFlashImageToVideoDev,
+    "AtlasCloud Gemini Omni Flash Reference-to-Video Developer": AtlasGeminiOmniFlashReferenceToVideoDev,
     "AtlasCloud VEO3.1 Reference-to-Video": AtlasVeo31ReferenceToVideo,
     "AtlasCloud VEO3.1 Image-to-Video": AtlasVeo31ImageToVideo,
     "AtlasCloud VEO3 Image-to-Video": AtlasVeo3ImageToVideo,
@@ -695,6 +701,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Nano Banana 2 Text-to-Image Developer": "AtlasCloud Nano Banana 2 Text-to-Image Developer",
     "AtlasCloud Nano Banana 2 Edit": "AtlasCloud Nano Banana 2 Edit",
     "AtlasCloud Nano Banana 2 Edit Developer": "AtlasCloud Nano Banana 2 Edit Developer",
+    "AtlasCloud Nano Banana 2 Reference-to-Image": "AtlasCloud Nano Banana 2 Reference-to-Image",
+    "AtlasCloud Nano Banana 2 Reference-to-Image Developer": "AtlasCloud Nano Banana 2 Reference-to-Image Developer",
     "AtlasCloud Seedream V5.0 Lite Text-to-Image": "AtlasCloud Seedream V5.0 Lite Text-to-Image",
     "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image": "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image",
     "AtlasCloud Seedream V5.0 Lite Edit": "AtlasCloud Seedream V5.0 Lite Edit",
@@ -729,6 +737,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud VEO3.1 Fast Image-to-Video": "AtlasCloud VEO3.1 Fast Image-to-Video",
     "AtlasCloud Gemini Omni Flash Text-to-Video Developer": "AtlasCloud Gemini Omni Flash Text-to-Video Developer",
     "AtlasCloud Gemini Omni Flash Image-to-Video Developer": "AtlasCloud Gemini Omni Flash Image-to-Video Developer",
+    "AtlasCloud Gemini Omni Flash Reference-to-Video Developer": "AtlasCloud Gemini Omni Flash Reference-to-Video Developer",
     "AtlasCloud VEO3.1 Reference-to-Video": "AtlasCloud VEO3.1 Reference-to-Video",
     "AtlasCloud VEO3.1 Image-to-Video": "AtlasCloud VEO3.1 Image-to-Video",
     "AtlasCloud VEO3 Image-to-Video": "AtlasCloud VEO3 Image-to-Video",

--- a/tests/test_new_nodes_2026_06_03.py
+++ b/tests/test_new_nodes_2026_06_03.py
@@ -1,0 +1,59 @@
+"""Metadata-only tests for newly added nodes (2026-06-03).
+
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_gemini_omni_flash_r2v_dev_metadata():
+    from src.atlascloud_comfyui.nodes.video.google_gemini_omni_flash_r2v_dev import (
+        AtlasGeminiOmniFlashReferenceToVideoDev,
+    )
+
+    required = AtlasGeminiOmniFlashReferenceToVideoDev.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert "video_url" in required
+    assert AtlasGeminiOmniFlashReferenceToVideoDev.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGeminiOmniFlashReferenceToVideoDev.CATEGORY == "AtlasCloud/Video"
+
+
+def test_nano_banana2_r2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_r2i import (
+        AtlasNanoBanana2ReferenceToImage,
+    )
+
+    required = AtlasNanoBanana2ReferenceToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "video_url" in required
+    assert AtlasNanoBanana2ReferenceToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasNanoBanana2ReferenceToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_nano_banana2_r2i_dev_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_r2i_dev import (
+        AtlasNanoBanana2ReferenceToImageDev,
+    )
+
+    required = AtlasNanoBanana2ReferenceToImageDev.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "video_url" in required
+    assert AtlasNanoBanana2ReferenceToImageDev.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasNanoBanana2ReferenceToImageDev.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Gemini Omni Flash Reference-to-Video Developer",
+        "AtlasCloud Nano Banana 2 Reference-to-Image",
+        "AtlasCloud Nano Banana 2 Reference-to-Image Developer",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS


### PR DESCRIPTION
## Summary
Daily AtlasCloud → ComfyUI sync. API diff surfaced 3 missing visual models; all implemented as new nodes.

### New nodes
- **google/gemini-omni-flash/reference-to-video-developer** — `AtlasGeminiOmniFlashReferenceToVideoDev` (Video). Requires prompt, 1-5 reference images, and a source video clip (url + start/ends trim).
- **google/nano-banana-2/reference-to-image** — `AtlasNanoBanana2ReferenceToImage` (Image). Video-clip-to-image; requires prompt + video_url, optional reference images, web/image search toggles.
- **google/nano-banana-2/reference-to-image-developer** — `AtlasNanoBanana2ReferenceToImageDev` (Image). Developer variant.

Payload fields modeled from each model's published JSON schema (`video_clips` array, required-field validation).

### Changes
- 3 new node files under `nodes/{image,video}/`
- `registry.py`: imports + `NODE_CLASS_MAPPINGS` + `NODE_DISPLAY_NAME_MAPPINGS`
- `README.md` Available Nodes table
- `tests/test_new_nodes_2026_06_03.py` (metadata-only)

### Testing
- `ruff check .` ✅ All checks passed
- `pytest -k "not e2e"` ✅ 255 passed, 26 deselected

E2E skipped (no local ComfyUI source on sync host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)