### PR TITLE
sync: add 2 AtlasCloud Grok Imagine Image models (2026-06-08)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
 | AtlasCloud Grok Imagine IQ Text-to-Image | xai/grok-imagine-image-quality/text-to-image |
+| AtlasCloud Grok Imagine Text-to-Image | xai/grok-imagine-image/text-to-image |
 | AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
 | AtlasCloud GPT Image-2 Text-to-Image | openai/gpt-image-2/text-to-image |
 | AtlasCloud GPT Image-2 Developer Text-to-Image | openai/gpt-image-2-developer/text-to-image |
@@ -359,6 +360,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Flux Kontext Dev LoRA Edit | black-forest-labs/flux-kontext-dev-lora |
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
 | AtlasCloud Grok Imagine IQ Edit | xai/grok-imagine-image-quality/edit |
+| AtlasCloud Grok Imagine Edit | xai/grok-imagine-image/edit |
 | AtlasCloud GPT Image-2 Edit | openai/gpt-image-2/edit |
 | AtlasCloud GPT Image-2 Developer Edit | openai/gpt-image-2-developer/edit |
 

--- a/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_edit.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineImageEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit prompt"}),
+                "image_urls": ("STRING", {"multiline": True, "tooltip": "1-8 image URLs (one per line)"}),
+                "resolution": (["1k", "2k"], {"default": "1k"}),
+                "aspect_ratio": (
+                    ["auto", "1:1", "3:4", "4:3", "9:16", "16:9", "2:3", "3:2", "9:19.5", "19.5:9", "9:20", "20:9", "1:2", "2:1"],
+                    {"default": "auto", "tooltip": "Aspect ratio"},
+                ),
+                "num_images": ([1, 2, 3, 4], {"default": 1}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_urls: str,
+        resolution: str,
+        aspect_ratio: str,
+        num_images: int,
+        enable_base64_output: bool,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        images: List[str] = [u.strip() for u in (image_urls or "").splitlines() if u.strip()]
+        if not images:
+            raise RuntimeError("image_urls is required (provide 1-8 URLs, one per line)")
+        if len(images) > 8:
+            raise RuntimeError("image_urls maxItems is 8")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-image/edit",
+            "prompt": prompt,
+            "image_urls": images,
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "num_images": int(num_images),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_t2i.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineImageTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (["1k", "2k"], {"default": "1k"}),
+                "aspect_ratio": (
+                    ["1:1", "3:4", "4:3", "9:16", "16:9", "2:3", "3:2", "9:19.5", "19.5:9", "9:20", "20:9", "1:2", "2:1"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "num_images": ([1, 2, 3, 4], {"default": 1}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str,
+        aspect_ratio: str,
+        num_images: int,
+        enable_base64_output: bool,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-image/text-to-image",
+            "prompt": prompt,
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "num_images": int(num_images),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -242,6 +242,8 @@ from atlascloud_comfyui.nodes.video.veed_fabric_10_fast_i2v import AtlasVeedFabr
 from atlascloud_comfyui.nodes.video.veed_fabric_10_i2v import AtlasVeedFabric10ImageToVideo
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_t2i import AtlasGrokImagineImageQualityTextToImage
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_edit import AtlasGrokImagineImageQualityEdit
+from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_t2i import AtlasGrokImagineImageTextToImage
+from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_edit import AtlasGrokImagineImageEdit
 
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_pro import AtlasKlingV16MultiI2VPro
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_standard import AtlasKlingV16MultiI2VStandard
@@ -562,6 +564,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video": AtlasVeedFabric10FastImageToVideo,
     "AtlasCloud Grok Imagine IQ Text-to-Image": AtlasGrokImagineImageQualityTextToImage,
     "AtlasCloud Grok Imagine IQ Edit": AtlasGrokImagineImageQualityEdit,
+    "AtlasCloud Grok Imagine Text-to-Image": AtlasGrokImagineImageTextToImage,
+    "AtlasCloud Grok Imagine Edit": AtlasGrokImagineImageEdit,
     "AtlasCloud Kling V2.0 I2V Master": AtlasKlingV20I2VMaster,
     "AtlasCloud VEO3 Fast Image-to-Video": AtlasVeo3FastImageToVideo,
     "AtlasCloud Kling V2.1 T2V Master": AtlasKlingV21T2VMaster,
@@ -840,6 +844,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video": "AtlasCloud Veed Fabric 1.0 Fast Image-to-Video",
     "AtlasCloud Grok Imagine IQ Text-to-Image": "AtlasCloud Grok Imagine IQ Text-to-Image",
     "AtlasCloud Grok Imagine IQ Edit": "AtlasCloud Grok Imagine IQ Edit",
+    "AtlasCloud Grok Imagine Text-to-Image": "AtlasCloud Grok Imagine Text-to-Image",
+    "AtlasCloud Grok Imagine Edit": "AtlasCloud Grok Imagine Edit",
     "AtlasCloud Kling V2.0 I2V Master": "AtlasCloud Kling V2.0 I2V Master",
     "AtlasCloud VEO3 Fast Image-to-Video": "AtlasCloud VEO3 Fast Image-to-Video",
     "AtlasCloud Kling V2.1 T2V Master": "AtlasCloud Kling V2.1 T2V Master",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -261,6 +261,25 @@ def test_grok_imagine_iq_edit_node_metadata():
     assert AtlasGrokImagineImageQualityEdit.RETURN_TYPES == ("STRING", "STRING")
 
 
+def test_grok_imagine_t2i_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_t2i import (
+        AtlasGrokImagineImageTextToImage,
+    )
+
+    assert "atlas_client" in AtlasGrokImagineImageTextToImage.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasGrokImagineImageTextToImage.INPUT_TYPES()["required"]
+    assert AtlasGrokImagineImageTextToImage.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_grok_imagine_edit_node_metadata():
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_edit import AtlasGrokImagineImageEdit
+
+    assert "atlas_client" in AtlasGrokImagineImageEdit.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasGrokImagineImageEdit.INPUT_TYPES()["required"]
+    assert "image_urls" in AtlasGrokImagineImageEdit.INPUT_TYPES()["required"]
+    assert AtlasGrokImagineImageEdit.RETURN_TYPES == ("STRING", "STRING")
+
+
 # --- Batch: Wan 2.2 Turbo Infinite I2V (2026-05-07) ---
 
 


### PR DESCRIPTION
## New AtlasCloud visual models (2026-06-08)

Daily AtlasCloud → ComfyUI sync. API total 344 / visual 226; repo missing 2 visual models, both added here:

- `xai/grok-imagine-image/text-to-image` → **AtlasCloud Grok Imagine Text-to-Image**
- `xai/grok-imagine-image/edit` → **AtlasCloud Grok Imagine Edit**

These are the base (non-`-quality`) Grok Imagine Image variants; nodes mirror the existing `-quality` nodes. Edit node validates 1-8 `image_urls` and its `aspect_ratio` includes the `auto` option per schema.

## Changes
- New nodes under `nodes/image/`
- registry.py: imports + NODE_CLASS_MAPPINGS + NODE_DISPLAY_NAME_MAPPINGS
- README Available Nodes table
- Metadata-only tests

## Testing
- ruff check: ✅ All checks passed
- pytest (metadata, no e2e): ✅ 257 passed, 26 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)