### PR TITLE
sync: add 5 AtlasCloud models (2026-06-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud PixVerse V6 Text-to-Video | pixverse/v6/text-to-video |
 | AtlasCloud PixVerse V6 Image-to-Video | pixverse/v6/image-to-video |
 | AtlasCloud PixVerse V6 Reference-to-Video | pixverse/v6/reference-to-video |
+| AtlasCloud PixVerse V6 Video-Extend | pixverse/v6/video-extend |
+| AtlasCloud PixVerse C1 Start-End-to-Video | pixverse/c1/start-end-to-video |
+| AtlasCloud PixVerse V6 Start-End-to-Video | pixverse/v6/start-end-to-video |
 | AtlasCloud Hailuo 02 T2V Pro | minimax/hailuo-02/t2v-pro |
 | AtlasCloud Hailuo 02 T2V Standard | minimax/hailuo-02/t2v-standard |
 | AtlasCloud Hailuo 02 Pro | minimax/hailuo-02/pro |
@@ -145,6 +148,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 |------|-------|
 | AtlasCloud VEO3 Image-to-Video | google/veo3/image-to-video |
 | AtlasCloud VEO3 Fast Image-to-Video | google/veo3-fast/image-to-video |
+| AtlasCloud Midjourney V8.1 Image-to-Video | midjourney/v8.1/image-to-video |
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
 | AtlasCloud Gemini Omni Flash Image-to-Video Developer | google/gemini-omni-flash/image-to-video-developer |
 | AtlasCloud Gemini Omni Flash Reference-to-Video Developer | google/gemini-omni-flash/reference-to-video-developer |
@@ -275,6 +279,7 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 
 | Node | Model |
 |------|-------|
+| AtlasCloud Midjourney V8.1 Text-to-Image | midjourney/v8.1/text-to-image |
 | AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
 | AtlasCloud WAN2.7 Text-to-Image | alibaba/wan-2.7/text-to-image |
 | AtlasCloud WAN2.7 Pro Text-to-Image | alibaba/wan-2.7-pro/text-to-image |

--- a/src/atlascloud_comfyui/nodes/image/midjourney_v81_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/midjourney_v81_t2i.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMidjourneyV81TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Natural-language description of the image to generate"}),
+            },
+            "optional": {
+                "sref": ("STRING", {"default": "", "tooltip": "Optional style-reference image URL (public https)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        sref: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Midjourney V8.1 Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "midjourney/v8.1/text-to-image",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        ref = (sref or "").strip()
+        if ref:
+            payload["sref"] = ref
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/midjourney_v81_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/midjourney_v81_i2v.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMidjourneyV81ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First-frame image to animate (public https URL or base64)"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "gentle camera push in, cinematic", "tooltip": "Optional motion / scene description"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Output resolution. 720p costs 3x of 480p"}),
+                "motion": (["low", "high"], {"default": "low", "tooltip": "Amount of motion in the generated video"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "gentle camera push in, cinematic",
+        resolution: str = "480p",
+        motion: str = "low",
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Midjourney V8.1 Image-to-Video (URL or base64)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "midjourney/v8.1/image-to-video",
+            "image": image,
+            "resolution": resolution,
+            "motion": motion,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/pixverse_c1_start_end.py
+++ b/src/atlascloud_comfyui/nodes/video/pixverse_c1_start_end.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasPixVerseC1StartEndToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame of the video (public URL or base64)"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "Last frame of the video (public URL or base64)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Positive prompt for the generation"}),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 5, "min": 1, "max": 15, "tooltip": "Duration (seconds, 1-15)"}),
+                "quality": (["360p", "540p", "720p", "1080p"], {"default": "720p", "tooltip": "Output resolution"}),
+                "sound": ("BOOLEAN", {"default": True, "tooltip": "Generate audio together with the video"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        end_image: str,
+        prompt: str,
+        duration: int = 5,
+        quality: str = "720p",
+        sound: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image (first frame) is required for AtlasCloud PixVerse C1 Start-End-to-Video")
+
+        end_image = (end_image or "").strip()
+        if not end_image:
+            raise RuntimeError("end_image (last frame) is required for AtlasCloud PixVerse C1 Start-End-to-Video")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud PixVerse C1 Start-End-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "pixverse/c1/start-end-to-video",
+            "image": image,
+            "end_image": end_image,
+            "prompt": prompt,
+            "duration": int(duration),
+            "quality": quality,
+            "sound": bool(sound),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/pixverse_v6_start_end.py
+++ b/src/atlascloud_comfyui/nodes/video/pixverse_v6_start_end.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasPixVerseV6StartEndToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame of the video (public URL or base64)"}),
+                "end_image": ("STRING", {"default": "", "tooltip": "Last frame of the video (public URL or base64)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Positive prompt for the generation"}),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 5, "min": 1, "max": 15, "tooltip": "Duration (seconds, 1-15)"}),
+                "quality": (["360p", "540p", "720p", "1080p"], {"default": "720p", "tooltip": "Output resolution"}),
+                "sound": ("BOOLEAN", {"default": True, "tooltip": "Generate audio together with the video"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        end_image: str,
+        prompt: str,
+        duration: int = 5,
+        quality: str = "720p",
+        sound: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image (first frame) is required for AtlasCloud PixVerse V6 Start-End-to-Video")
+
+        end_image = (end_image or "").strip()
+        if not end_image:
+            raise RuntimeError("end_image (last frame) is required for AtlasCloud PixVerse V6 Start-End-to-Video")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud PixVerse V6 Start-End-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "pixverse/v6/start-end-to-video",
+            "image": image,
+            "end_image": end_image,
+            "prompt": prompt,
+            "duration": int(duration),
+            "quality": quality,
+            "sound": bool(sound),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/pixverse_v6_video_extend.py
+++ b/src/atlascloud_comfyui/nodes/video/pixverse_v6_video_extend.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasPixVerseV6VideoExtend:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video": ("STRING", {"default": "", "tooltip": "Source video URL to extend"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Positive prompt for the generation"}),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 5, "min": 1, "max": 15, "tooltip": "Duration (seconds, 1-15)"}),
+                "quality": (["360p", "540p", "720p", "1080p"], {"default": "720p", "tooltip": "Output resolution"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video: str,
+        prompt: str,
+        duration: int = 5,
+        quality: str = "720p",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required for AtlasCloud PixVerse V6 Video-Extend (URL)")
+
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud PixVerse V6 Video-Extend")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "pixverse/v6/video-extend",
+            "video": video,
+            "prompt": prompt,
+            "duration": int(duration),
+            "quality": quality,
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -295,6 +295,11 @@ from atlascloud_comfyui.nodes.video.pixverse_c1_r2v import AtlasPixVerseC1Refere
 from atlascloud_comfyui.nodes.video.pixverse_v6_t2v import AtlasPixVerseV6TextToVideo
 from atlascloud_comfyui.nodes.video.pixverse_v6_i2v import AtlasPixVerseV6ImageToVideo
 from atlascloud_comfyui.nodes.video.pixverse_v6_r2v import AtlasPixVerseV6ReferenceToVideo
+from atlascloud_comfyui.nodes.video.pixverse_v6_video_extend import AtlasPixVerseV6VideoExtend
+from atlascloud_comfyui.nodes.video.pixverse_c1_start_end import AtlasPixVerseC1StartEndToVideo
+from atlascloud_comfyui.nodes.video.pixverse_v6_start_end import AtlasPixVerseV6StartEndToVideo
+from atlascloud_comfyui.nodes.video.midjourney_v81_i2v import AtlasMidjourneyV81ImageToVideo
+from atlascloud_comfyui.nodes.image.midjourney_v81_t2i import AtlasMidjourneyV81TextToImage
 from atlascloud_comfyui.nodes.video.vidu_q1_t2v import AtlasViduQ1TextToVideo
 from atlascloud_comfyui.nodes.video.vidu_q1_i2v import AtlasViduQ1ImageToVideo
 from atlascloud_comfyui.nodes.video.vidu_q1_start_end import AtlasViduQ1StartEndToVideo
@@ -470,6 +475,11 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud PixVerse V6 Text-to-Video": AtlasPixVerseV6TextToVideo,
     "AtlasCloud PixVerse V6 Image-to-Video": AtlasPixVerseV6ImageToVideo,
     "AtlasCloud PixVerse V6 Reference-to-Video": AtlasPixVerseV6ReferenceToVideo,
+    "AtlasCloud PixVerse V6 Video-Extend": AtlasPixVerseV6VideoExtend,
+    "AtlasCloud PixVerse C1 Start-End-to-Video": AtlasPixVerseC1StartEndToVideo,
+    "AtlasCloud PixVerse V6 Start-End-to-Video": AtlasPixVerseV6StartEndToVideo,
+    "AtlasCloud Midjourney V8.1 Image-to-Video": AtlasMidjourneyV81ImageToVideo,
+    "AtlasCloud Midjourney V8.1 Text-to-Image": AtlasMidjourneyV81TextToImage,
     "AtlasCloud Hailuo 02 T2V Pro": AtlasHailuo02T2VPro,
     "AtlasCloud Sora 2 Image-to-Video": AtlasSora2ImageToVideo,
     "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video": AtlasKlingV25TurboProTextToVideo,
@@ -760,6 +770,11 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud PixVerse V6 Text-to-Video": "AtlasCloud PixVerse V6 Text-to-Video",
     "AtlasCloud PixVerse V6 Image-to-Video": "AtlasCloud PixVerse V6 Image-to-Video",
     "AtlasCloud PixVerse V6 Reference-to-Video": "AtlasCloud PixVerse V6 Reference-to-Video",
+    "AtlasCloud PixVerse V6 Video-Extend": "AtlasCloud PixVerse V6 Video-Extend",
+    "AtlasCloud PixVerse C1 Start-End-to-Video": "AtlasCloud PixVerse C1 Start-End-to-Video",
+    "AtlasCloud PixVerse V6 Start-End-to-Video": "AtlasCloud PixVerse V6 Start-End-to-Video",
+    "AtlasCloud Midjourney V8.1 Image-to-Video": "AtlasCloud Midjourney V8.1 Image-to-Video",
+    "AtlasCloud Midjourney V8.1 Text-to-Image": "AtlasCloud Midjourney V8.1 Text-to-Image",
     "AtlasCloud Hailuo 02 T2V Pro": "AtlasCloud Hailuo 02 T2V Pro",
     "AtlasCloud Sora 2 Image-to-Video": "AtlasCloud Sora 2 Image-to-Video",
     "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video": "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video",

--- a/tests/test_new_nodes_2026_06_10.py
+++ b/tests/test_new_nodes_2026_06_10.py
@@ -1,0 +1,107 @@
+"""Metadata-only tests for newly added nodes (2026-06-10).
+
+Midjourney V8.1 (text-to-image, image-to-video) and PixVerse extend / start-end families.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_midjourney_v81_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_t2i import (
+        AtlasMidjourneyV81TextToImage,
+    )
+
+    required = AtlasMidjourneyV81TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasMidjourneyV81TextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMidjourneyV81TextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_midjourney_v81_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.midjourney_v81_i2v import (
+        AtlasMidjourneyV81ImageToVideo,
+    )
+
+    required = AtlasMidjourneyV81ImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasMidjourneyV81ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMidjourneyV81ImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_pixverse_v6_video_extend_metadata():
+    from src.atlascloud_comfyui.nodes.video.pixverse_v6_video_extend import (
+        AtlasPixVerseV6VideoExtend,
+    )
+
+    required = AtlasPixVerseV6VideoExtend.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "video" in required
+    assert "prompt" in required
+    assert AtlasPixVerseV6VideoExtend.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasPixVerseV6VideoExtend.CATEGORY == "AtlasCloud/Video"
+
+
+def test_pixverse_c1_start_end_metadata():
+    from src.atlascloud_comfyui.nodes.video.pixverse_c1_start_end import (
+        AtlasPixVerseC1StartEndToVideo,
+    )
+
+    required = AtlasPixVerseC1StartEndToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "end_image" in required
+    assert "prompt" in required
+    assert AtlasPixVerseC1StartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasPixVerseC1StartEndToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_pixverse_v6_start_end_metadata():
+    from src.atlascloud_comfyui.nodes.video.pixverse_v6_start_end import (
+        AtlasPixVerseV6StartEndToVideo,
+    )
+
+    required = AtlasPixVerseV6StartEndToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "end_image" in required
+    assert "prompt" in required
+    assert AtlasPixVerseV6StartEndToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasPixVerseV6StartEndToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_new_nodes_2026_06_10_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Midjourney V8.1 Text-to-Image",
+        "AtlasCloud Midjourney V8.1 Image-to-Video",
+        "AtlasCloud PixVerse V6 Video-Extend",
+        "AtlasCloud PixVerse C1 Start-End-to-Video",
+        "AtlasCloud PixVerse V6 Start-End-to-Video",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_06_10_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_t2i import AtlasMidjourneyV81TextToImage
+    from src.atlascloud_comfyui.nodes.video.midjourney_v81_i2v import AtlasMidjourneyV81ImageToVideo
+    from src.atlascloud_comfyui.nodes.video.pixverse_v6_video_extend import AtlasPixVerseV6VideoExtend
+    from src.atlascloud_comfyui.nodes.video.pixverse_c1_start_end import AtlasPixVerseC1StartEndToVideo
+    from src.atlascloud_comfyui.nodes.video.pixverse_v6_start_end import AtlasPixVerseV6StartEndToVideo
+
+    expected = {
+        AtlasMidjourneyV81TextToImage: "midjourney/v8.1/text-to-image",
+        AtlasMidjourneyV81ImageToVideo: "midjourney/v8.1/image-to-video",
+        AtlasPixVerseV6VideoExtend: "pixverse/v6/video-extend",
+        AtlasPixVerseC1StartEndToVideo: "pixverse/c1/start-end-to-video",
+        AtlasPixVerseV6StartEndToVideo: "pixverse/v6/start-end-to-video",
+    }
+    for cls, model_id in expected.items():
+        assert model_id in inspect.getsource(cls.run)


### PR DESCRIPTION
## Summary
Daily AtlasCloud → ComfyUI sync. Adds 5 missing visual models discovered via the AtlasCloud models API.

### New nodes
| Display name | Model ID |
|---|---|
| AtlasCloud Midjourney V8.1 Text-to-Image | midjourney/v8.1/text-to-image |
| AtlasCloud Midjourney V8.1 Image-to-Video | midjourney/v8.1/image-to-video |
| AtlasCloud PixVerse V6 Video-Extend | pixverse/v6/video-extend |
| AtlasCloud PixVerse C1 Start-End-to-Video | pixverse/c1/start-end-to-video |
| AtlasCloud PixVerse V6 Start-End-to-Video | pixverse/v6/start-end-to-video |

### Changes
- New node files under `nodes/image/` and `nodes/video/`
- Registered in `registry.py` (class + display-name mappings)
- README Available Nodes tables updated
- Metadata-only tests in `tests/test_new_nodes_2026_06_10.py`

### Tests
- `ruff check .` → ✅ All checks passed
- `pytest -k "not e2e"` → ✅ 272 passed, 26 deselected
- E2E skipped (no local ComfyUI source on sync host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)