### PR TITLE
sync: add 4 AtlasCloud MAI-Image-2.5 models (2026-06-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud Grok Imagine IQ Text-to-Image | xai/grok-imagine-image-quality/text-to-image |
 | AtlasCloud Grok Imagine Text-to-Image | xai/grok-imagine-image/text-to-image |
 | AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
+| AtlasCloud MAI-Image-2.5 Text-to-Image | microsoft/mai-image-2.5/text-to-image |
+| AtlasCloud MAI-Image-2.5-Flash Text-to-Image | microsoft/mai-image-2.5-flash/text-to-image |
 | AtlasCloud GPT Image-2 Text-to-Image | openai/gpt-image-2/text-to-image |
 | AtlasCloud GPT Image-2 Developer Text-to-Image | openai/gpt-image-2-developer/text-to-image |
 
@@ -355,6 +357,8 @@ With these nodes you can call AtlasCloud’s hosted models directly inside Comfy
 | AtlasCloud WAN2.7 Image-Edit | alibaba/wan-2.7/image-edit |
 | AtlasCloud WAN2.7 Pro Image-Edit | alibaba/wan-2.7-pro/image-edit |
 | AtlasCloud WAN2.5 Image-Edit | alibaba/wan-2.5/image-edit |
+| AtlasCloud MAI-Image-2.5 Edit | microsoft/mai-image-2.5/edit |
+| AtlasCloud MAI-Image-2.5-Flash Edit | microsoft/mai-image-2.5-flash/edit |
 | AtlasCloud Seedream V4 Edit | bytedance/seedream-v4/edit |
 | AtlasCloud Seedream V4 Edit Sequential | bytedance/seedream-v4/edit-sequential |
 | AtlasCloud Seedream V4.5 Edit | bytedance/seedream-v4.5/edit |

--- a/src/atlascloud_comfyui/nodes/image/mai_image_25_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/mai_image_25_edit.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMAIImage25Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "image": ("STRING", {"default": "", "tooltip": "Reference image URL or base64 (JPEG/PNG) to edit"}),
+            },
+            "optional": {
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for MAI-Image-2.5 Edit")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for MAI-Image-2.5 Edit")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "microsoft/mai-image-2.5/edit",
+            "prompt": prompt,
+            "image": image,
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/mai_image_25_flash_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/mai_image_25_flash_edit.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMAIImage25FlashEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "image": ("STRING", {"default": "", "tooltip": "Reference image URL or base64 (JPEG/PNG) to edit"}),
+            },
+            "optional": {
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for MAI-Image-2.5-Flash Edit")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for MAI-Image-2.5-Flash Edit")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "microsoft/mai-image-2.5-flash/edit",
+            "prompt": prompt,
+            "image": image,
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/mai_image_25_flash_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/mai_image_25_flash_t2i.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMAIImage25FlashTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the image to generate"}),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "1024*1024",
+                        "tooltip": "Image dimensions WIDTH*HEIGHT (min 768, width*height <= 1,049,088)",
+                    },
+                ),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1024*1024",
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for MAI-Image-2.5-Flash Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "microsoft/mai-image-2.5-flash/text-to-image",
+            "prompt": prompt,
+            "size": str(size).strip(),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/mai_image_25_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/mai_image_25_t2i.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMAIImage25TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the image to generate"}),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "1024*1024",
+                        "tooltip": "Image dimensions WIDTH*HEIGHT (min 768, width*height <= 1,049,088)",
+                    },
+                ),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1024*1024",
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for MAI-Image-2.5 Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "microsoft/mai-image-2.5/text-to-image",
+            "prompt": prompt,
+            "size": str(size).strip(),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -300,6 +300,10 @@ from atlascloud_comfyui.nodes.video.pixverse_c1_start_end import AtlasPixVerseC1
 from atlascloud_comfyui.nodes.video.pixverse_v6_start_end import AtlasPixVerseV6StartEndToVideo
 from atlascloud_comfyui.nodes.video.midjourney_v81_i2v import AtlasMidjourneyV81ImageToVideo
 from atlascloud_comfyui.nodes.image.midjourney_v81_t2i import AtlasMidjourneyV81TextToImage
+from atlascloud_comfyui.nodes.image.mai_image_25_t2i import AtlasMAIImage25TextToImage
+from atlascloud_comfyui.nodes.image.mai_image_25_flash_t2i import AtlasMAIImage25FlashTextToImage
+from atlascloud_comfyui.nodes.image.mai_image_25_edit import AtlasMAIImage25Edit
+from atlascloud_comfyui.nodes.image.mai_image_25_flash_edit import AtlasMAIImage25FlashEdit
 from atlascloud_comfyui.nodes.video.vidu_q1_t2v import AtlasViduQ1TextToVideo
 from atlascloud_comfyui.nodes.video.vidu_q1_i2v import AtlasViduQ1ImageToVideo
 from atlascloud_comfyui.nodes.video.vidu_q1_start_end import AtlasViduQ1StartEndToVideo
@@ -345,6 +349,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.7 Pro Image-Edit": AtlasWan27ProImageEdit,
     "AtlasCloud WAN2.5 Text-to-Image": AtlasWan25TextToImage,
     "AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image": AtlasBaiduERNIEImageTurboTextToImage,
+    "AtlasCloud MAI-Image-2.5 Text-to-Image": AtlasMAIImage25TextToImage,
+    "AtlasCloud MAI-Image-2.5-Flash Text-to-Image": AtlasMAIImage25FlashTextToImage,
+    "AtlasCloud MAI-Image-2.5 Edit": AtlasMAIImage25Edit,
+    "AtlasCloud MAI-Image-2.5-Flash Edit": AtlasMAIImage25FlashEdit,
     "AtlasCloud WAN2.5 Image-Edit": AtlasWan25ImageEdit,
     "AtlasCloud WAN2.6 Image-Edit": AtlasWAN26ImageEdit,
     "AtlasCloud WAN2.6 Image-to-Video": AtlasWAN26ImageToVideo,
@@ -640,6 +648,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.7 Pro Image-Edit": "AtlasCloud WAN2.7 Pro Image-Edit",
     "AtlasCloud WAN2.5 Text-to-Image": "AtlasCloud WAN2.5 Text-to-Image",
     "AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image": "AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image",
+    "AtlasCloud MAI-Image-2.5 Text-to-Image": "AtlasCloud MAI-Image-2.5 Text-to-Image",
+    "AtlasCloud MAI-Image-2.5-Flash Text-to-Image": "AtlasCloud MAI-Image-2.5-Flash Text-to-Image",
+    "AtlasCloud MAI-Image-2.5 Edit": "AtlasCloud MAI-Image-2.5 Edit",
+    "AtlasCloud MAI-Image-2.5-Flash Edit": "AtlasCloud MAI-Image-2.5-Flash Edit",
     "AtlasCloud WAN2.5 Image-Edit": "AtlasCloud WAN2.5 Image-Edit",
     "AtlasCloud WAN2.6 Image-Edit": "AtlasCloud WAN2.6 Image-Edit",
     "AtlasCloud WAN2.6 Image-to-Video": "AtlasCloud WAN2.6 Image-to-Video",

--- a/tests/test_new_nodes_2026_06_11.py
+++ b/tests/test_new_nodes_2026_06_11.py
@@ -1,0 +1,89 @@
+"""Metadata-only tests for newly added nodes (2026-06-11).
+
+Microsoft MAI-Image-2.5 family: text-to-image and edit, standard and flash.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_mai_image_25_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.mai_image_25_t2i import (
+        AtlasMAIImage25TextToImage,
+    )
+
+    required = AtlasMAIImage25TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasMAIImage25TextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMAIImage25TextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_mai_image_25_flash_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.mai_image_25_flash_t2i import (
+        AtlasMAIImage25FlashTextToImage,
+    )
+
+    required = AtlasMAIImage25FlashTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasMAIImage25FlashTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMAIImage25FlashTextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_mai_image_25_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.mai_image_25_edit import (
+        AtlasMAIImage25Edit,
+    )
+
+    required = AtlasMAIImage25Edit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert AtlasMAIImage25Edit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMAIImage25Edit.CATEGORY == "AtlasCloud/Image"
+
+
+def test_mai_image_25_flash_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.mai_image_25_flash_edit import (
+        AtlasMAIImage25FlashEdit,
+    )
+
+    required = AtlasMAIImage25FlashEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image" in required
+    assert AtlasMAIImage25FlashEdit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMAIImage25FlashEdit.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_2026_06_11_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud MAI-Image-2.5 Text-to-Image",
+        "AtlasCloud MAI-Image-2.5-Flash Text-to-Image",
+        "AtlasCloud MAI-Image-2.5 Edit",
+        "AtlasCloud MAI-Image-2.5-Flash Edit",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_06_11_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.mai_image_25_t2i import AtlasMAIImage25TextToImage
+    from src.atlascloud_comfyui.nodes.image.mai_image_25_flash_t2i import AtlasMAIImage25FlashTextToImage
+    from src.atlascloud_comfyui.nodes.image.mai_image_25_edit import AtlasMAIImage25Edit
+    from src.atlascloud_comfyui.nodes.image.mai_image_25_flash_edit import AtlasMAIImage25FlashEdit
+
+    expected = {
+        AtlasMAIImage25TextToImage: "microsoft/mai-image-2.5/text-to-image",
+        AtlasMAIImage25FlashTextToImage: "microsoft/mai-image-2.5-flash/text-to-image",
+        AtlasMAIImage25Edit: "microsoft/mai-image-2.5/edit",
+        AtlasMAIImage25FlashEdit: "microsoft/mai-image-2.5-flash/edit",
+    }
+    for cls, model_id in expected.items():
+        assert model_id in inspect.getsource(cls.run)


### PR DESCRIPTION
## New models (Microsoft MAI-Image-2.5 family)

| Node | Model |
| --- | --- |
| AtlasCloud MAI-Image-2.5 Text-to-Image | `microsoft/mai-image-2.5/text-to-image` |
| AtlasCloud MAI-Image-2.5-Flash Text-to-Image | `microsoft/mai-image-2.5-flash/text-to-image` |
| AtlasCloud MAI-Image-2.5 Edit | `microsoft/mai-image-2.5/edit` |
| AtlasCloud MAI-Image-2.5-Flash Edit | `microsoft/mai-image-2.5-flash/edit` |

These were the only visual models present in the AtlasCloud `/api/v1/models` endpoint but missing from the repo (diff against 283 supported model ids).

- T2I nodes: `prompt` (required) + `size` (WIDTH*HEIGHT, default 1024*1024).
- Edit nodes: `prompt` + single `image` (URL/base64), both required and validated.
- All follow the existing image-node pattern: import-safe, `generate_image` + `poll_prediction`, `outputs[0]`.

## Tests
- `ruff check .` ✅
- `pytest -k "not e2e"` ✅ — 278 passed, 26 deselected (e2e skipped; no ComfyUI source on sync host)
- Added `tests/test_new_nodes_2026_06_11.py` (metadata-only, no API key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)