### PR TITLE
sync: add 8 AtlasCloud models (2026-06-16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Sora 2 Text-to-Video | openai/sora-2/text-to-video |
 | AtlasCloud Sora 2 Text-to-Video Pro | openai/sora-2/text-to-video-pro |
 | AtlasCloud Kling V3.0 Pro Text-to-Video | kwaivgi/kling-v3.0-pro/text-to-video |
+| AtlasCloud Kling V3.0 4K Text-to-Video | kwaivgi/kling-v3.0-4k/text-to-video |
+| AtlasCloud Kling V3.0 4K Image-to-Video | kwaivgi/kling-v3.0-4k/image-to-video |
+| AtlasCloud Kling Video O3 4K Text-to-Video | kwaivgi/kling-video-o3-4k/text-to-video |
+| AtlasCloud Kling Video O3 4K Image-to-Video | kwaivgi/kling-video-o3-4k/image-to-video |
 | AtlasCloud Kling V3.0 Std Text-to-Video | kwaivgi/kling-v3.0-std/text-to-video |
 | AtlasCloud Kling V2.6 Pro Text-to-Video | kwaivgi/kling-v2.6-pro/text-to-video |
 | AtlasCloud Kling V2.6 Pro Avatar | kwaivgi/kling-v2.6-pro/avatar |
@@ -316,6 +320,10 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | Node | Model |
 |------|-------|
 | AtlasCloud Midjourney V8.1 Text-to-Image | midjourney/v8.1/text-to-image |
+| AtlasCloud Midjourney V8.1 Image-to-Image | midjourney/v8.1/image-to-image |
+| AtlasCloud Midjourney V8.1 Blend | midjourney/v8.1/blend |
+| AtlasCloud Midjourney V8.1 Remove Background | midjourney/v8.1/remove-background |
+| AtlasCloud Midjourney V8.1 Style Transfer | midjourney/v8.1/style-transfer |
 | AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
 | AtlasCloud WAN2.7 Text-to-Image | alibaba/wan-2.7/text-to-image |
 | AtlasCloud WAN2.7 Pro Text-to-Image | alibaba/wan-2.7-pro/text-to-image |

--- a/src/atlascloud_comfyui/nodes/image/midjourney_v81_blend.py
+++ b/src/atlascloud_comfyui/nodes/image/midjourney_v81_blend.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMidjourneyV81Blend:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "2-5 input image URLs to blend, one per line"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional text prompt guiding the blend (max 1024 chars)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) < 2:
+            raise RuntimeError("images requires at least 2 URLs (one per line) for Midjourney V8.1 Blend")
+        if len(image_list) > 5:
+            raise RuntimeError("images maxItems is 5 for Midjourney V8.1 Blend")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "midjourney/v8.1/blend",
+            "images": image_list,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/midjourney_v81_i2i.py
+++ b/src/atlascloud_comfyui/nodes/image/midjourney_v81_i2i.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMidjourneyV81ImageToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image to re-imagine (public https URL)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt guiding the generation (max 1024 chars)"}),
+            },
+            "optional": {
+                "sref": ("STRING", {"default": "", "tooltip": "Optional style-reference image URL (public https)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        sref: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Midjourney V8.1 Image-to-Image")
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Midjourney V8.1 Image-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "midjourney/v8.1/image-to-image",
+            "image": image,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        ref = (sref or "").strip()
+        if ref:
+            payload["sref"] = ref
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/midjourney_v81_remove_bg.py
+++ b/src/atlascloud_comfyui/nodes/image/midjourney_v81_remove_bg.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMidjourneyV81RemoveBackground:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image whose background will be removed (public https URL)"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Midjourney V8.1 Remove Background")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "midjourney/v8.1/remove-background",
+            "image": image,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/midjourney_v81_style_transfer.py
+++ b/src/atlascloud_comfyui/nodes/image/midjourney_v81_style_transfer.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMidjourneyV81StyleTransfer:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image to restyle (public https URL)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Description of the target artistic style"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Midjourney V8.1 Style Transfer")
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Midjourney V8.1 Style Transfer")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "midjourney/v8.1/style-transfer",
+            "image": image,
+            "prompt": prompt,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v30_4k_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v30_4k_i2v.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV304KImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                # Kling I2V: base image is required
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "duration": ([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "cfg_scale": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01, "tooltip": "Classifier-free guidance scale"}),
+                "sound": ("BOOLEAN", {"default": True, "tooltip": "Generate sound track"}),
+            },
+            "optional": {
+                "end_image": ("STRING", {"default": "", "tooltip": "Optional end image URL or base64"}),
+                "negative_prompt": ("STRING", {"default": "", "multiline": True, "tooltip": "Negative prompt (optional)"}),
+                "resolution": (["1080P", "4K"], {"default": "1080P", "tooltip": "Output resolution"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Polling timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        duration: int,
+        cfg_scale: float,
+        sound: bool,
+        end_image: str = "",
+        negative_prompt: str = "",
+        resolution: str = "1080P",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for Kling V3.0 4K Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v3.0-4k/image-to-video",
+            "image": image,
+            "prompt": (prompt or "").strip(),
+            "duration": int(duration),
+            "cfg_scale": float(cfg_scale),
+            "sound": bool(sound),
+            "resolution": resolution,
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        end_img = (end_image or "").strip()
+        if end_img:
+            payload["end_image"] = end_img
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v30_4k_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v30_4k_t2v.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV304KTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "duration": ([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "cfg_scale": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01, "tooltip": "Classifier-free guidance scale"}),
+                "sound": ("BOOLEAN", {"default": True, "tooltip": "Generate sound track"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"default": "", "multiline": True, "tooltip": "Negative prompt (optional)"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Polling timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int,
+        aspect_ratio: str,
+        cfg_scale: float,
+        sound: bool,
+        negative_prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Kling V3.0 4K Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v3.0-4k/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "cfg_scale": float(cfg_scale),
+            "sound": bool(sound),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_4k_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_4k_i2v.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO34KImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL"}),
+            },
+            "optional": {
+                "end_image": ("STRING", {"default": "", "tooltip": "Last frame image URL (optional)"}),
+                "duration": ([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "sound": ("BOOLEAN", {"default": True, "tooltip": "Automatically add audio to the generated video"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        end_image: str = "",
+        duration: int = 5,
+        sound: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        if not (image or "").strip():
+            raise RuntimeError("image is required for Kling Video O3 4K Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-4k/image-to-video",
+            "prompt": prompt,
+            "image": image,
+            "duration": int(duration),
+            "sound": bool(sound),
+        }
+
+        if (end_image or "").strip():
+            payload["end_image"] = end_image
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_video_o3_4k_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_video_o3_4k_t2v.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingVideoO34KTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True}),
+            },
+            "optional": {
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "duration": ([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "sound": ("BOOLEAN", {"default": True, "tooltip": "Generate audio for the video"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str = "16:9",
+        duration: int = 5,
+        sound: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Kling Video O3 4K Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-video-o3-4k/text-to-video",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "duration": int(duration),
+            "sound": bool(sound),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -300,6 +300,14 @@ from atlascloud_comfyui.nodes.video.pixverse_c1_start_end import AtlasPixVerseC1
 from atlascloud_comfyui.nodes.video.pixverse_v6_start_end import AtlasPixVerseV6StartEndToVideo
 from atlascloud_comfyui.nodes.video.midjourney_v81_i2v import AtlasMidjourneyV81ImageToVideo
 from atlascloud_comfyui.nodes.image.midjourney_v81_t2i import AtlasMidjourneyV81TextToImage
+from atlascloud_comfyui.nodes.image.midjourney_v81_i2i import AtlasMidjourneyV81ImageToImage
+from atlascloud_comfyui.nodes.image.midjourney_v81_blend import AtlasMidjourneyV81Blend
+from atlascloud_comfyui.nodes.image.midjourney_v81_remove_bg import AtlasMidjourneyV81RemoveBackground
+from atlascloud_comfyui.nodes.image.midjourney_v81_style_transfer import AtlasMidjourneyV81StyleTransfer
+from atlascloud_comfyui.nodes.video.kling_v30_4k_i2v import AtlasKlingV304KImageToVideo
+from atlascloud_comfyui.nodes.video.kling_v30_4k_t2v import AtlasKlingV304KTextToVideo
+from atlascloud_comfyui.nodes.video.kling_video_o3_4k_i2v import AtlasKlingVideoO34KImageToVideo
+from atlascloud_comfyui.nodes.video.kling_video_o3_4k_t2v import AtlasKlingVideoO34KTextToVideo
 from atlascloud_comfyui.nodes.image.mai_image_25_t2i import AtlasMAIImage25TextToImage
 from atlascloud_comfyui.nodes.image.mai_image_25_flash_t2i import AtlasMAIImage25FlashTextToImage
 from atlascloud_comfyui.nodes.image.mai_image_25_edit import AtlasMAIImage25Edit
@@ -490,6 +498,14 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud PixVerse V6 Start-End-to-Video": AtlasPixVerseV6StartEndToVideo,
     "AtlasCloud Midjourney V8.1 Image-to-Video": AtlasMidjourneyV81ImageToVideo,
     "AtlasCloud Midjourney V8.1 Text-to-Image": AtlasMidjourneyV81TextToImage,
+    "AtlasCloud Midjourney V8.1 Image-to-Image": AtlasMidjourneyV81ImageToImage,
+    "AtlasCloud Midjourney V8.1 Blend": AtlasMidjourneyV81Blend,
+    "AtlasCloud Midjourney V8.1 Remove Background": AtlasMidjourneyV81RemoveBackground,
+    "AtlasCloud Midjourney V8.1 Style Transfer": AtlasMidjourneyV81StyleTransfer,
+    "AtlasCloud Kling V3.0 4K Image-to-Video": AtlasKlingV304KImageToVideo,
+    "AtlasCloud Kling V3.0 4K Text-to-Video": AtlasKlingV304KTextToVideo,
+    "AtlasCloud Kling Video O3 4K Image-to-Video": AtlasKlingVideoO34KImageToVideo,
+    "AtlasCloud Kling Video O3 4K Text-to-Video": AtlasKlingVideoO34KTextToVideo,
     "AtlasCloud Hailuo 02 T2V Pro": AtlasHailuo02T2VPro,
     "AtlasCloud Sora 2 Image-to-Video": AtlasSora2ImageToVideo,
     "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video": AtlasKlingV25TurboProTextToVideo,
@@ -789,6 +805,14 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud PixVerse V6 Start-End-to-Video": "AtlasCloud PixVerse V6 Start-End-to-Video",
     "AtlasCloud Midjourney V8.1 Image-to-Video": "AtlasCloud Midjourney V8.1 Image-to-Video",
     "AtlasCloud Midjourney V8.1 Text-to-Image": "AtlasCloud Midjourney V8.1 Text-to-Image",
+    "AtlasCloud Midjourney V8.1 Image-to-Image": "AtlasCloud Midjourney V8.1 Image-to-Image",
+    "AtlasCloud Midjourney V8.1 Blend": "AtlasCloud Midjourney V8.1 Blend",
+    "AtlasCloud Midjourney V8.1 Remove Background": "AtlasCloud Midjourney V8.1 Remove Background",
+    "AtlasCloud Midjourney V8.1 Style Transfer": "AtlasCloud Midjourney V8.1 Style Transfer",
+    "AtlasCloud Kling V3.0 4K Image-to-Video": "AtlasCloud Kling V3.0 4K Image-to-Video",
+    "AtlasCloud Kling V3.0 4K Text-to-Video": "AtlasCloud Kling V3.0 4K Text-to-Video",
+    "AtlasCloud Kling Video O3 4K Image-to-Video": "AtlasCloud Kling Video O3 4K Image-to-Video",
+    "AtlasCloud Kling Video O3 4K Text-to-Video": "AtlasCloud Kling Video O3 4K Text-to-Video",
     "AtlasCloud Hailuo 02 T2V Pro": "AtlasCloud Hailuo 02 T2V Pro",
     "AtlasCloud Sora 2 Image-to-Video": "AtlasCloud Sora 2 Image-to-Video",
     "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video": "AtlasCloud Kling V2.5 Turbo Pro Text-to-Video",

--- a/tests/test_new_nodes_2026_06_16.py
+++ b/tests/test_new_nodes_2026_06_16.py
@@ -1,0 +1,150 @@
+"""Metadata-only tests for newly added nodes (2026-06-16).
+
+Kling V3.0 4K + Kling Video O3 4K (text/image-to-video) and Midjourney V8.1
+image-to-image / blend / remove-background / style-transfer.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_kling_v30_4k_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v30_4k_i2v import (
+        AtlasKlingV304KImageToVideo,
+    )
+
+    required = AtlasKlingV304KImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasKlingV304KImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasKlingV304KImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_kling_v30_4k_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v30_4k_t2v import (
+        AtlasKlingV304KTextToVideo,
+    )
+
+    required = AtlasKlingV304KTextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasKlingV304KTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasKlingV304KTextToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_kling_video_o3_4k_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_4k_i2v import (
+        AtlasKlingVideoO34KImageToVideo,
+    )
+
+    required = AtlasKlingVideoO34KImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasKlingVideoO34KImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasKlingVideoO34KImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_kling_video_o3_4k_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_4k_t2v import (
+        AtlasKlingVideoO34KTextToVideo,
+    )
+
+    required = AtlasKlingVideoO34KTextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasKlingVideoO34KTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasKlingVideoO34KTextToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_midjourney_v81_i2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_i2i import (
+        AtlasMidjourneyV81ImageToImage,
+    )
+
+    required = AtlasMidjourneyV81ImageToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasMidjourneyV81ImageToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMidjourneyV81ImageToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_midjourney_v81_blend_metadata():
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_blend import (
+        AtlasMidjourneyV81Blend,
+    )
+
+    required = AtlasMidjourneyV81Blend.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert AtlasMidjourneyV81Blend.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMidjourneyV81Blend.CATEGORY == "AtlasCloud/Image"
+
+
+def test_midjourney_v81_remove_bg_metadata():
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_remove_bg import (
+        AtlasMidjourneyV81RemoveBackground,
+    )
+
+    required = AtlasMidjourneyV81RemoveBackground.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasMidjourneyV81RemoveBackground.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMidjourneyV81RemoveBackground.CATEGORY == "AtlasCloud/Image"
+
+
+def test_midjourney_v81_style_transfer_metadata():
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_style_transfer import (
+        AtlasMidjourneyV81StyleTransfer,
+    )
+
+    required = AtlasMidjourneyV81StyleTransfer.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasMidjourneyV81StyleTransfer.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMidjourneyV81StyleTransfer.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_2026_06_16_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Kling V3.0 4K Image-to-Video",
+        "AtlasCloud Kling V3.0 4K Text-to-Video",
+        "AtlasCloud Kling Video O3 4K Image-to-Video",
+        "AtlasCloud Kling Video O3 4K Text-to-Video",
+        "AtlasCloud Midjourney V8.1 Image-to-Image",
+        "AtlasCloud Midjourney V8.1 Blend",
+        "AtlasCloud Midjourney V8.1 Remove Background",
+        "AtlasCloud Midjourney V8.1 Style Transfer",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_06_16_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.video.kling_v30_4k_i2v import AtlasKlingV304KImageToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_v30_4k_t2v import AtlasKlingV304KTextToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_4k_i2v import AtlasKlingVideoO34KImageToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_video_o3_4k_t2v import AtlasKlingVideoO34KTextToVideo
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_i2i import AtlasMidjourneyV81ImageToImage
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_blend import AtlasMidjourneyV81Blend
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_remove_bg import AtlasMidjourneyV81RemoveBackground
+    from src.atlascloud_comfyui.nodes.image.midjourney_v81_style_transfer import AtlasMidjourneyV81StyleTransfer
+
+    expected = {
+        AtlasKlingV304KImageToVideo: "kwaivgi/kling-v3.0-4k/image-to-video",
+        AtlasKlingV304KTextToVideo: "kwaivgi/kling-v3.0-4k/text-to-video",
+        AtlasKlingVideoO34KImageToVideo: "kwaivgi/kling-video-o3-4k/image-to-video",
+        AtlasKlingVideoO34KTextToVideo: "kwaivgi/kling-video-o3-4k/text-to-video",
+        AtlasMidjourneyV81ImageToImage: "midjourney/v8.1/image-to-image",
+        AtlasMidjourneyV81Blend: "midjourney/v8.1/blend",
+        AtlasMidjourneyV81RemoveBackground: "midjourney/v8.1/remove-background",
+        AtlasMidjourneyV81StyleTransfer: "midjourney/v8.1/style-transfer",
+    }
+    for cls, model_id in expected.items():
+        assert model_id in inspect.getsource(cls.run)


### PR DESCRIPTION
## New AtlasCloud visual models (2026-06-16)

Daily AtlasCloud → ComfyUI sync. 8 new visual model nodes (3D models out of scope; remaining diff already covered).

### Video
- \`kwaivgi/kling-v3.0-4k/image-to-video\` — AtlasCloud Kling V3.0 4K Image-to-Video
- \`kwaivgi/kling-v3.0-4k/text-to-video\` — AtlasCloud Kling V3.0 4K Text-to-Video
- \`kwaivgi/kling-video-o3-4k/image-to-video\` — AtlasCloud Kling Video O3 4K Image-to-Video
- \`kwaivgi/kling-video-o3-4k/text-to-video\` — AtlasCloud Kling Video O3 4K Text-to-Video

### Image
- \`midjourney/v8.1/image-to-image\` — AtlasCloud Midjourney V8.1 Image-to-Image
- \`midjourney/v8.1/blend\` — AtlasCloud Midjourney V8.1 Blend
- \`midjourney/v8.1/remove-background\` — AtlasCloud Midjourney V8.1 Remove Background
- \`midjourney/v8.1/style-transfer\` — AtlasCloud Midjourney V8.1 Style Transfer

### Tests
- Added \`tests/test_new_nodes_2026_06_16.py\` (metadata-only, no live API).
- \`ruff check .\` ✅ · \`pytest -k "not e2e"\` ✅ 288 passed.
- Registry + README Available Nodes table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)