### PR TITLE
sync: add AtlasCloud wan-2.7-spicy/image-to-video node (2026-06-17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Kling Effects | kwaivgi/kling-effects |
 | AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
 | AtlasCloud WAN2.6 Spicy Image-to-Video | atlascloud/wan-2.6-spicy/image-to-video |
+| AtlasCloud WAN2.7 Spicy Image-to-Video | atlascloud/wan-2.7-spicy/image-to-video |
 | AtlasCloud WAN2.7 Image-to-Video | alibaba/wan-2.7/image-to-video |
 | AtlasCloud HappyHorse 1.0 Image-to-Video | alibaba/happyhorse-1.0/image-to-video |
 | AtlasCloud HappyHorse 1.0 Reference-to-Video | alibaba/happyhorse-1.0/reference-to-video |

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_7_spicy_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_7_spicy_i2v.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27SpicyImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image (URL/base64)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "resolution": (
+                    ["720P", "1080P", "1080P-SR", "1440P-SR"],
+                    {"default": "720P", "tooltip": "Output resolution (SR variants use super-resolution)"},
+                ),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "duration": ("INT", {"default": 5, "min": 2, "max": 15, "tooltip": "Duration (seconds)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        resolution: str,
+        negative_prompt: str = "",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud WAN2.7 Spicy Image-to-Video")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.7-spicy/image-to-video",
+            "image": image,
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -217,6 +217,7 @@ from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_spicy_infinite_i2v_
     AtlasWan22TurboSpicyInfiniteImageToVideoLoRA,
 )
 from atlascloud_comfyui.nodes.video.atlascloud_wan_2_6_spicy_i2v import AtlasWan26SpicyImageToVideo
+from atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_i2v import AtlasWan27SpicyImageToVideo
 from atlascloud_comfyui.nodes.video.van25_t2v import AtlasAtlascloudVan25TextToVideo
 from atlascloud_comfyui.nodes.video.van25_i2v import AtlasAtlascloudVan25ImageToVideo
 from atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
@@ -542,6 +543,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video": AtlasWan22TurboSpicyInfiniteImageToVideo,
     "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA": AtlasWan22TurboSpicyInfiniteImageToVideoLoRA,
     "AtlasCloud WAN2.6 Spicy Image-to-Video": AtlasWan26SpicyImageToVideo,
+    "AtlasCloud WAN2.7 Spicy Image-to-Video": AtlasWan27SpicyImageToVideo,
     "AtlasCloud Imagen4 Ultra Text-to-Image": AtlasImagen4UltraTextToImage,
     "AtlasCloud Imagen3 Text-to-Image": AtlasImagen3TextToImage,
     "AtlasCloud Imagen3 Fast Text-to-Image": AtlasImagen3FastTextToImage,
@@ -849,6 +851,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video": "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video",
     "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA": "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA",
     "AtlasCloud WAN2.6 Spicy Image-to-Video": "AtlasCloud WAN2.6 Spicy Image-to-Video",
+    "AtlasCloud WAN2.7 Spicy Image-to-Video": "AtlasCloud WAN2.7 Spicy Image-to-Video",
     "AtlasCloud Imagen4 Ultra Text-to-Image": "AtlasCloud Imagen4 Ultra Text-to-Image",
     "AtlasCloud Imagen3 Text-to-Image": "AtlasCloud Imagen3 Text-to-Image",
     "AtlasCloud Imagen3 Fast Text-to-Image": "AtlasCloud Imagen3 Fast Text-to-Image",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -213,6 +213,16 @@ def test_wan26_spicy_i2v_node_metadata():
     assert AtlasWan26SpicyImageToVideo.RETURN_TYPES == ("STRING", "STRING")
 
 
+def test_wan27_spicy_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_i2v import AtlasWan27SpicyImageToVideo
+
+    assert "atlas_client" in AtlasWan27SpicyImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasWan27SpicyImageToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasWan27SpicyImageToVideo.INPUT_TYPES()["required"]
+    assert "resolution" in AtlasWan27SpicyImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasWan27SpicyImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
 # --- Batch: 2026-05-13 (NEW) ---
 
 


### PR DESCRIPTION
## Daily AtlasCloud → ComfyUI sync (2026-06-17)

API total: 386 / visual: 255. Repo supported: 295. Missing visual diff: 1 actionable (5 others are `*-to-3d`, out of scope — no image-node infra fits mesh outputs).

### New node
- \`atlascloud/wan-2.7-spicy/image-to-video\` → **AtlasCloud WAN2.7 Spicy Image-to-Video**
  - Modeled on the existing 2.6-spicy I2V node; required `image`+`prompt`, resolution enum `720P/1080P/1080P-SR/1440P-SR`, duration 2–15, optional seed/negative_prompt.

### Tests
- ruff: ✅ (all checks passed)
- pytest (metadata only, e2e deselected): ✅ 289 passed, 26 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)