### PR TITLE
sync: add Kling V3.0 Turbo text/image-to-video nodes (2026-06-18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Kling V3.0 Pro Text-to-Video | kwaivgi/kling-v3.0-pro/text-to-video |
 | AtlasCloud Kling V3.0 4K Text-to-Video | kwaivgi/kling-v3.0-4k/text-to-video |
 | AtlasCloud Kling V3.0 4K Image-to-Video | kwaivgi/kling-v3.0-4k/image-to-video |
+| AtlasCloud Kling V3.0 Turbo Text-to-Video | kwaivgi/kling-v3.0-turbo/text-to-video |
+| AtlasCloud Kling V3.0 Turbo Image-to-Video | kwaivgi/kling-v3.0-turbo/image-to-video |
 | AtlasCloud Kling Video O3 4K Text-to-Video | kwaivgi/kling-video-o3-4k/text-to-video |
 | AtlasCloud Kling Video O3 4K Image-to-Video | kwaivgi/kling-video-o3-4k/image-to-video |
 | AtlasCloud Kling V3.0 Std Text-to-Video | kwaivgi/kling-v3.0-std/text-to-video |

--- a/src/atlascloud_comfyui/nodes/video/kling_v30_turbo_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v30_turbo_i2v.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV30TurboImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                # Kling I2V: base image is required
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL or base64"}),
+                "duration": ([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "resolution": (["720p", "1080p"], {"default": "1080p", "tooltip": "Output resolution"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"default": "", "multiline": True, "tooltip": "Text prompt (optional)"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Polling timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        duration: int,
+        resolution: str = "1080p",
+        prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for Kling V3.0 Turbo Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v3.0-turbo/image-to-video",
+            "image": image,
+            "duration": int(duration),
+            "resolution": resolution,
+        }
+
+        prompt = (prompt or "").strip()
+        if prompt:
+            payload["prompt"] = prompt
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v30_turbo_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v30_turbo_t2v.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKlingV30TurboTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "duration": ([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16", "1:1"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["720p", "1080p"], {"default": "1080p", "tooltip": "Output resolution"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Polling timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int,
+        aspect_ratio: str,
+        resolution: str = "1080p",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Kling V3.0 Turbo Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v3.0-turbo/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -309,6 +309,8 @@ from atlascloud_comfyui.nodes.video.kling_v30_4k_i2v import AtlasKlingV304KImage
 from atlascloud_comfyui.nodes.video.kling_v30_4k_t2v import AtlasKlingV304KTextToVideo
 from atlascloud_comfyui.nodes.video.kling_video_o3_4k_i2v import AtlasKlingVideoO34KImageToVideo
 from atlascloud_comfyui.nodes.video.kling_video_o3_4k_t2v import AtlasKlingVideoO34KTextToVideo
+from atlascloud_comfyui.nodes.video.kling_v30_turbo_i2v import AtlasKlingV30TurboImageToVideo
+from atlascloud_comfyui.nodes.video.kling_v30_turbo_t2v import AtlasKlingV30TurboTextToVideo
 from atlascloud_comfyui.nodes.image.mai_image_25_t2i import AtlasMAIImage25TextToImage
 from atlascloud_comfyui.nodes.image.mai_image_25_flash_t2i import AtlasMAIImage25FlashTextToImage
 from atlascloud_comfyui.nodes.image.mai_image_25_edit import AtlasMAIImage25Edit
@@ -505,6 +507,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Midjourney V8.1 Style Transfer": AtlasMidjourneyV81StyleTransfer,
     "AtlasCloud Kling V3.0 4K Image-to-Video": AtlasKlingV304KImageToVideo,
     "AtlasCloud Kling V3.0 4K Text-to-Video": AtlasKlingV304KTextToVideo,
+    "AtlasCloud Kling V3.0 Turbo Image-to-Video": AtlasKlingV30TurboImageToVideo,
+    "AtlasCloud Kling V3.0 Turbo Text-to-Video": AtlasKlingV30TurboTextToVideo,
     "AtlasCloud Kling Video O3 4K Image-to-Video": AtlasKlingVideoO34KImageToVideo,
     "AtlasCloud Kling Video O3 4K Text-to-Video": AtlasKlingVideoO34KTextToVideo,
     "AtlasCloud Hailuo 02 T2V Pro": AtlasHailuo02T2VPro,
@@ -813,6 +817,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Midjourney V8.1 Style Transfer": "AtlasCloud Midjourney V8.1 Style Transfer",
     "AtlasCloud Kling V3.0 4K Image-to-Video": "AtlasCloud Kling V3.0 4K Image-to-Video",
     "AtlasCloud Kling V3.0 4K Text-to-Video": "AtlasCloud Kling V3.0 4K Text-to-Video",
+    "AtlasCloud Kling V3.0 Turbo Image-to-Video": "AtlasCloud Kling V3.0 Turbo Image-to-Video",
+    "AtlasCloud Kling V3.0 Turbo Text-to-Video": "AtlasCloud Kling V3.0 Turbo Text-to-Video",
     "AtlasCloud Kling Video O3 4K Image-to-Video": "AtlasCloud Kling Video O3 4K Image-to-Video",
     "AtlasCloud Kling Video O3 4K Text-to-Video": "AtlasCloud Kling Video O3 4K Text-to-Video",
     "AtlasCloud Hailuo 02 T2V Pro": "AtlasCloud Hailuo 02 T2V Pro",

--- a/tests/test_new_nodes_2026_06_18.py
+++ b/tests/test_new_nodes_2026_06_18.py
@@ -1,0 +1,57 @@
+"""Metadata-only tests for newly added nodes (2026-06-18).
+
+Kling V3.0 Turbo (text/image-to-video).
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_kling_v30_turbo_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v30_turbo_t2v import (
+        AtlasKlingV30TurboTextToVideo,
+    )
+
+    required = AtlasKlingV30TurboTextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasKlingV30TurboTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasKlingV30TurboTextToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_kling_v30_turbo_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.kling_v30_turbo_i2v import (
+        AtlasKlingV30TurboImageToVideo,
+    )
+
+    required = AtlasKlingV30TurboImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasKlingV30TurboImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasKlingV30TurboImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_new_nodes_2026_06_18_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Kling V3.0 Turbo Image-to-Video",
+        "AtlasCloud Kling V3.0 Turbo Text-to-Video",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_06_18_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.video.kling_v30_turbo_i2v import AtlasKlingV30TurboImageToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_v30_turbo_t2v import AtlasKlingV30TurboTextToVideo
+
+    expected = {
+        AtlasKlingV30TurboImageToVideo: "kwaivgi/kling-v3.0-turbo/image-to-video",
+        AtlasKlingV30TurboTextToVideo: "kwaivgi/kling-v3.0-turbo/text-to-video",
+    }
+    for cls, model_id in expected.items():
+        assert model_id in inspect.getsource(cls.run)


### PR DESCRIPTION
## Summary
Daily AtlasCloud → ComfyUI sync. Adds the 2 missing visual models from the AtlasCloud API.

New nodes:
- \`kwaivgi/kling-v3.0-turbo/text-to-video\` → AtlasCloud Kling V3.0 Turbo Text-to-Video
- \`kwaivgi/kling-v3.0-turbo/image-to-video\` → AtlasCloud Kling V3.0 Turbo Image-to-Video

Implemented per each model's published schema (duration 3-15, resolution 720p/1080p; t2v adds aspect_ratio; i2v requires image, prompt optional). Registry, README table, and metadata-only tests updated.

Out of scope this run: 5 \`*-to-3d\` models (Seed3D / Hunyuan3D) output mesh zips — no fitting image-node infra.

## Tests
- ruff: ✅ All checks passed
- pytest (metadata, no e2e): ✅ 293 passed, 26 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)