### PR TITLE
sync: add HappyHorse 1.1 video nodes (2026-06-22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud WAN2.6 Text-to-Video | alibaba/wan-2.6/text-to-video |
 | AtlasCloud WAN2.7 Text-to-Video | alibaba/wan-2.7/text-to-video |
 | AtlasCloud HappyHorse 1.0 Text-to-Video | alibaba/happyhorse-1.0/text-to-video |
+| AtlasCloud HappyHorse 1.1 Text-to-Video | alibaba/happyhorse-1.1/text-to-video |
 | AtlasCloud WAN2.6 Video-to-Video | alibaba/wan-2.6/video-to-video |
 | AtlasCloud Kling Video O3 Pro Text-to-Video | kwaivgi/kling-video-o3-pro/text-to-video |
 | AtlasCloud Kling Video O3 Std Text-to-Video | kwaivgi/kling-video-o3-std/text-to-video |
@@ -261,7 +262,9 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud WAN2.7 Spicy Image-to-Video | atlascloud/wan-2.7-spicy/image-to-video |
 | AtlasCloud WAN2.7 Image-to-Video | alibaba/wan-2.7/image-to-video |
 | AtlasCloud HappyHorse 1.0 Image-to-Video | alibaba/happyhorse-1.0/image-to-video |
+| AtlasCloud HappyHorse 1.1 Image-to-Video | alibaba/happyhorse-1.1/image-to-video |
 | AtlasCloud HappyHorse 1.0 Reference-to-Video | alibaba/happyhorse-1.0/reference-to-video |
+| AtlasCloud HappyHorse 1.1 Reference-to-Video | alibaba/happyhorse-1.1/reference-to-video |
 | AtlasCloud WAN2.7 Reference-to-Video | alibaba/wan-2.7/reference-to-video |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
 | AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |

--- a/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_1_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_1_i2v.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHappyHorse11ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image (URL/base64)"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Prompt (optional)"}),
+                "resolution": (
+                    ["720P", "1080P"],
+                    {"default": "1080P", "tooltip": "Resolution"},
+                ),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "",
+        resolution: str = "1080P",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for Alibaba HappyHorse-1.1 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/happyhorse-1.1/image-to-video",
+            "image": image,
+            "resolution": resolution,
+            "duration": int(duration),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_1_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_1_r2v.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHappyHorse11ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "images": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": "1+ reference image URLs/base64, one per line",
+                    },
+                ),
+            },
+            "optional": {
+                "resolution": (
+                    ["720P", "1080P"],
+                    {"default": "1080P", "tooltip": "Resolution"},
+                ),
+                "ratio": (
+                    ["16:9", "9:16", "1:1", "4:3", "3:4", "4:5", "5:4", "9:21", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        images: str,
+        resolution: str = "1080P",
+        ratio: str = "16:9",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba HappyHorse-1.1 Reference-to-Video")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required for Alibaba HappyHorse-1.1 Reference-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/happyhorse-1.1/reference-to-video",
+            "prompt": prompt,
+            "images": image_list,
+            "resolution": resolution,
+            "ratio": ratio,
+            "duration": int(duration),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_1_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_happyhorse_1_1_t2v.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasHappyHorse11TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+            },
+            "optional": {
+                "resolution": (
+                    ["720P", "1080P"],
+                    {"default": "1080P", "tooltip": "Resolution"},
+                ),
+                "ratio": (
+                    ["16:9", "9:16", "1:1", "4:3", "3:4", "4:5", "5:4", "9:21", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": 1, "max": 60, "tooltip": "Duration (seconds)"},
+                ),
+                "seed": (
+                    "INT",
+                    {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str = "1080P",
+        ratio: str = "16:9",
+        duration: int = 5,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for Alibaba HappyHorse-1.1 Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/happyhorse-1.1/text-to-video",
+            "prompt": prompt,
+            "resolution": resolution,
+            "ratio": ratio,
+            "duration": int(duration),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -284,6 +284,9 @@ from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_t2v import AtlasHappy
 from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_i2v import AtlasHappyHorse10ImageToVideo
 from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_r2v import AtlasHappyHorse10ReferenceToVideo
 from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_video_edit import AtlasHappyHorse10VideoEdit
+from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_1_t2v import AtlasHappyHorse11TextToVideo
+from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_1_i2v import AtlasHappyHorse11ImageToVideo
+from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_1_r2v import AtlasHappyHorse11ReferenceToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_lite_t2v import AtlasVeo31LiteTextToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_lite_i2v import AtlasVeo31LiteImageToVideo
 from atlascloud_comfyui.nodes.video.google_veo31_lite_start_end_frame_t2v import AtlasVeo31LiteStartEndFrameToVideo
@@ -422,6 +425,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud HappyHorse 1.0 Image-to-Video": AtlasHappyHorse10ImageToVideo,
     "AtlasCloud HappyHorse 1.0 Reference-to-Video": AtlasHappyHorse10ReferenceToVideo,
     "AtlasCloud HappyHorse 1.0 Video-Edit": AtlasHappyHorse10VideoEdit,
+    "AtlasCloud HappyHorse 1.1 Text-to-Video": AtlasHappyHorse11TextToVideo,
+    "AtlasCloud HappyHorse 1.1 Image-to-Video": AtlasHappyHorse11ImageToVideo,
+    "AtlasCloud HappyHorse 1.1 Reference-to-Video": AtlasHappyHorse11ReferenceToVideo,
     "AtlasCloud VEO3.1 Lite Text-to-Video": AtlasVeo31LiteTextToVideo,
     "AtlasCloud VEO3.1 Lite Image-to-Video": AtlasVeo31LiteImageToVideo,
     "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video": AtlasVeo31LiteStartEndFrameToVideo,
@@ -732,6 +738,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud HappyHorse 1.0 Image-to-Video": "AtlasCloud HappyHorse 1.0 Image-to-Video",
     "AtlasCloud HappyHorse 1.0 Reference-to-Video": "AtlasCloud HappyHorse 1.0 Reference-to-Video",
     "AtlasCloud HappyHorse 1.0 Video-Edit": "AtlasCloud HappyHorse 1.0 Video-Edit",
+    "AtlasCloud HappyHorse 1.1 Text-to-Video": "AtlasCloud HappyHorse 1.1 Text-to-Video",
+    "AtlasCloud HappyHorse 1.1 Image-to-Video": "AtlasCloud HappyHorse 1.1 Image-to-Video",
+    "AtlasCloud HappyHorse 1.1 Reference-to-Video": "AtlasCloud HappyHorse 1.1 Reference-to-Video",
     "AtlasCloud VEO3.1 Lite Text-to-Video": "AtlasCloud VEO3.1 Lite Text-to-Video",
     "AtlasCloud VEO3.1 Lite Image-to-Video": "AtlasCloud VEO3.1 Lite Image-to-Video",
     "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video": "AtlasCloud VEO3.1 Lite Start-End Frame-to-Video",

--- a/tests/test_atlascloud_comfyui.py
+++ b/tests/test_atlascloud_comfyui.py
@@ -599,6 +599,31 @@ def test_happyhorse_10_video_edit_node_metadata():
     assert AtlasHappyHorse10VideoEdit.RETURN_TYPES == ("STRING", "STRING")
 
 
+def test_happyhorse_11_t2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_1_t2v import AtlasHappyHorse11TextToVideo
+
+    assert "atlas_client" in AtlasHappyHorse11TextToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasHappyHorse11TextToVideo.INPUT_TYPES()["required"]
+    assert AtlasHappyHorse11TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_happyhorse_11_i2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_1_i2v import AtlasHappyHorse11ImageToVideo
+
+    assert "atlas_client" in AtlasHappyHorse11ImageToVideo.INPUT_TYPES()["required"]
+    assert "image" in AtlasHappyHorse11ImageToVideo.INPUT_TYPES()["required"]
+    assert AtlasHappyHorse11ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
+def test_happyhorse_11_r2v_node_metadata():
+    from src.atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_1_r2v import AtlasHappyHorse11ReferenceToVideo
+
+    assert "atlas_client" in AtlasHappyHorse11ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasHappyHorse11ReferenceToVideo.INPUT_TYPES()["required"]
+    assert "images" in AtlasHappyHorse11ReferenceToVideo.INPUT_TYPES()["required"]
+    assert AtlasHappyHorse11ReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+
+
 def test_veo31_lite_t2v_node_metadata():
     from src.atlascloud_comfyui.nodes.video.google_veo31_lite_t2v import AtlasVeo31LiteTextToVideo
 


### PR DESCRIPTION
## New AtlasCloud models

Adds ComfyUI nodes for 3 newly-available HappyHorse 1.1 video models:

- \`alibaba/happyhorse-1.1/text-to-video\`
- \`alibaba/happyhorse-1.1/image-to-video\`
- \`alibaba/happyhorse-1.1/reference-to-video\`

Mirrors the existing HappyHorse 1.0 node family; t2v/r2v expose the expanded 1.1 aspect-ratio set (adds 4:5, 5:4, 9:21, 21:9). Registry + README updated.

### Excluded from this sync
5 other newly-listed models are \`*-to-3d\` (Seed3D 2.0, Hunyuan 3D Rapid/Pro) — they output mesh zips, not images/video, so no ComfyUI image/video node infra fits. Skipped intentionally.

### Tests
- \`ruff check .\` ✅
- \`pytest -k "not e2e"\` ✅ 296 passed (added 3 metadata tests)
- E2E skipped (no local ComfyUI source on the sync host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)