### PR TITLE
sync: add Youchuan V8.1 visual nodes (2026-06-24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud VEO3 Image-to-Video | google/veo3/image-to-video |
 | AtlasCloud VEO3 Fast Image-to-Video | google/veo3-fast/image-to-video |
 | AtlasCloud Midjourney V8.1 Image-to-Video | midjourney/v8.1/image-to-video |
+| AtlasCloud Youchuan V8.1 Image-to-Video | youchuan/v8.1/image-to-video |
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
 | AtlasCloud Gemini Omni Flash Image-to-Video Developer | google/gemini-omni-flash/image-to-video-developer |
 | AtlasCloud Gemini Omni Flash Reference-to-Video Developer | google/gemini-omni-flash/reference-to-video-developer |
@@ -330,6 +331,11 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Midjourney V8.1 Blend | midjourney/v8.1/blend |
 | AtlasCloud Midjourney V8.1 Remove Background | midjourney/v8.1/remove-background |
 | AtlasCloud Midjourney V8.1 Style Transfer | midjourney/v8.1/style-transfer |
+| AtlasCloud Youchuan V8.1 Text-to-Image | youchuan/v8.1/text-to-image |
+| AtlasCloud Youchuan V8.1 Image-to-Image | youchuan/v8.1/image-to-image |
+| AtlasCloud Youchuan V8.1 Blend | youchuan/v8.1/blend |
+| AtlasCloud Youchuan V8.1 Remove Background | youchuan/v8.1/remove-background |
+| AtlasCloud Youchuan V8.1 Style Transfer | youchuan/v8.1/style-transfer |
 | AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
 | AtlasCloud WAN2.7 Text-to-Image | alibaba/wan-2.7/text-to-image |
 | AtlasCloud WAN2.7 Pro Text-to-Image | alibaba/wan-2.7-pro/text-to-image |

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v81_blend.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v81_blend.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV81Blend:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "2-5 input image URLs to blend, one per line"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional text prompt guiding the blend (max 1024 chars)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) < 2:
+            raise RuntimeError("images requires at least 2 URLs (one per line) for Youchuan V8.1 Blend")
+        if len(image_list) > 5:
+            raise RuntimeError("images maxItems is 5 for Youchuan V8.1 Blend")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.1/blend",
+            "images": image_list,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v81_i2i.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v81_i2i.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV81ImageToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image to re-imagine (public https URL)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt guiding the generation (max 1024 chars)"}),
+            },
+            "optional": {
+                "sref": ("STRING", {"default": "", "tooltip": "Optional style-reference image URL (public https)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        sref: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Youchuan V8.1 Image-to-Image")
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Youchuan V8.1 Image-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.1/image-to-image",
+            "image": image,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        ref = (sref or "").strip()
+        if ref:
+            payload["sref"] = ref
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v81_remove_bg.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v81_remove_bg.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV81RemoveBackground:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image whose background will be removed (public https URL)"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Youchuan V8.1 Remove Background")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.1/remove-background",
+            "image": image,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v81_style_transfer.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v81_style_transfer.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV81StyleTransfer:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image to restyle (public https URL)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Description of the target artistic style"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Youchuan V8.1 Style Transfer")
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Youchuan V8.1 Style Transfer")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.1/style-transfer",
+            "image": image,
+            "prompt": prompt,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v81_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v81_t2i.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV81TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Natural-language description of the image to generate"}),
+            },
+            "optional": {
+                "sref": ("STRING", {"default": "", "tooltip": "Optional style-reference image URL (public https)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        sref: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Youchuan V8.1 Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.1/text-to-image",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        ref = (sref or "").strip()
+        if ref:
+            payload["sref"] = ref
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/youchuan_v81_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/youchuan_v81_i2v.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV81ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First-frame image to animate (public https URL or base64)"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "gentle camera push in, cinematic", "tooltip": "Optional motion / scene description"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Output resolution. 720p costs 3x of 480p"}),
+                "motion": (["low", "high"], {"default": "low", "tooltip": "Amount of motion in the generated video"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "gentle camera push in, cinematic",
+        resolution: str = "480p",
+        motion: str = "low",
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Youchuan V8.1 Image-to-Video (URL or base64)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.1/image-to-video",
+            "image": image,
+            "resolution": resolution,
+            "motion": motion,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -308,6 +308,12 @@ from atlascloud_comfyui.nodes.image.midjourney_v81_i2i import AtlasMidjourneyV81
 from atlascloud_comfyui.nodes.image.midjourney_v81_blend import AtlasMidjourneyV81Blend
 from atlascloud_comfyui.nodes.image.midjourney_v81_remove_bg import AtlasMidjourneyV81RemoveBackground
 from atlascloud_comfyui.nodes.image.midjourney_v81_style_transfer import AtlasMidjourneyV81StyleTransfer
+from atlascloud_comfyui.nodes.video.youchuan_v81_i2v import AtlasYouchuanV81ImageToVideo
+from atlascloud_comfyui.nodes.image.youchuan_v81_t2i import AtlasYouchuanV81TextToImage
+from atlascloud_comfyui.nodes.image.youchuan_v81_i2i import AtlasYouchuanV81ImageToImage
+from atlascloud_comfyui.nodes.image.youchuan_v81_blend import AtlasYouchuanV81Blend
+from atlascloud_comfyui.nodes.image.youchuan_v81_remove_bg import AtlasYouchuanV81RemoveBackground
+from atlascloud_comfyui.nodes.image.youchuan_v81_style_transfer import AtlasYouchuanV81StyleTransfer
 from atlascloud_comfyui.nodes.video.kling_v30_4k_i2v import AtlasKlingV304KImageToVideo
 from atlascloud_comfyui.nodes.video.kling_v30_4k_t2v import AtlasKlingV304KTextToVideo
 from atlascloud_comfyui.nodes.video.kling_video_o3_4k_i2v import AtlasKlingVideoO34KImageToVideo
@@ -511,6 +517,12 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Midjourney V8.1 Blend": AtlasMidjourneyV81Blend,
     "AtlasCloud Midjourney V8.1 Remove Background": AtlasMidjourneyV81RemoveBackground,
     "AtlasCloud Midjourney V8.1 Style Transfer": AtlasMidjourneyV81StyleTransfer,
+    "AtlasCloud Youchuan V8.1 Image-to-Video": AtlasYouchuanV81ImageToVideo,
+    "AtlasCloud Youchuan V8.1 Text-to-Image": AtlasYouchuanV81TextToImage,
+    "AtlasCloud Youchuan V8.1 Image-to-Image": AtlasYouchuanV81ImageToImage,
+    "AtlasCloud Youchuan V8.1 Blend": AtlasYouchuanV81Blend,
+    "AtlasCloud Youchuan V8.1 Remove Background": AtlasYouchuanV81RemoveBackground,
+    "AtlasCloud Youchuan V8.1 Style Transfer": AtlasYouchuanV81StyleTransfer,
     "AtlasCloud Kling V3.0 4K Image-to-Video": AtlasKlingV304KImageToVideo,
     "AtlasCloud Kling V3.0 4K Text-to-Video": AtlasKlingV304KTextToVideo,
     "AtlasCloud Kling V3.0 Turbo Image-to-Video": AtlasKlingV30TurboImageToVideo,
@@ -824,6 +836,12 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Midjourney V8.1 Blend": "AtlasCloud Midjourney V8.1 Blend",
     "AtlasCloud Midjourney V8.1 Remove Background": "AtlasCloud Midjourney V8.1 Remove Background",
     "AtlasCloud Midjourney V8.1 Style Transfer": "AtlasCloud Midjourney V8.1 Style Transfer",
+    "AtlasCloud Youchuan V8.1 Image-to-Video": "AtlasCloud Youchuan V8.1 Image-to-Video",
+    "AtlasCloud Youchuan V8.1 Text-to-Image": "AtlasCloud Youchuan V8.1 Text-to-Image",
+    "AtlasCloud Youchuan V8.1 Image-to-Image": "AtlasCloud Youchuan V8.1 Image-to-Image",
+    "AtlasCloud Youchuan V8.1 Blend": "AtlasCloud Youchuan V8.1 Blend",
+    "AtlasCloud Youchuan V8.1 Remove Background": "AtlasCloud Youchuan V8.1 Remove Background",
+    "AtlasCloud Youchuan V8.1 Style Transfer": "AtlasCloud Youchuan V8.1 Style Transfer",
     "AtlasCloud Kling V3.0 4K Image-to-Video": "AtlasCloud Kling V3.0 4K Image-to-Video",
     "AtlasCloud Kling V3.0 4K Text-to-Video": "AtlasCloud Kling V3.0 4K Text-to-Video",
     "AtlasCloud Kling V3.0 Turbo Image-to-Video": "AtlasCloud Kling V3.0 Turbo Image-to-Video",

--- a/tests/test_new_nodes_2026_06_24.py
+++ b/tests/test_new_nodes_2026_06_24.py
@@ -1,0 +1,120 @@
+"""Metadata-only tests for newly added nodes (2026-06-24).
+
+Youchuan V8.1 family (text-to-image, image-to-image, blend, style-transfer,
+remove-background, image-to-video).
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_youchuan_v81_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_t2i import (
+        AtlasYouchuanV81TextToImage,
+    )
+
+    required = AtlasYouchuanV81TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasYouchuanV81TextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasYouchuanV81TextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v81_i2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_i2i import (
+        AtlasYouchuanV81ImageToImage,
+    )
+
+    required = AtlasYouchuanV81ImageToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasYouchuanV81ImageToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasYouchuanV81ImageToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v81_blend_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_blend import (
+        AtlasYouchuanV81Blend,
+    )
+
+    required = AtlasYouchuanV81Blend.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert AtlasYouchuanV81Blend.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasYouchuanV81Blend.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v81_style_transfer_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_style_transfer import (
+        AtlasYouchuanV81StyleTransfer,
+    )
+
+    required = AtlasYouchuanV81StyleTransfer.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasYouchuanV81StyleTransfer.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasYouchuanV81StyleTransfer.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v81_remove_bg_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_remove_bg import (
+        AtlasYouchuanV81RemoveBackground,
+    )
+
+    required = AtlasYouchuanV81RemoveBackground.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasYouchuanV81RemoveBackground.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasYouchuanV81RemoveBackground.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v81_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.youchuan_v81_i2v import (
+        AtlasYouchuanV81ImageToVideo,
+    )
+
+    required = AtlasYouchuanV81ImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasYouchuanV81ImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasYouchuanV81ImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_new_nodes_2026_06_24_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Youchuan V8.1 Text-to-Image",
+        "AtlasCloud Youchuan V8.1 Image-to-Image",
+        "AtlasCloud Youchuan V8.1 Blend",
+        "AtlasCloud Youchuan V8.1 Style Transfer",
+        "AtlasCloud Youchuan V8.1 Remove Background",
+        "AtlasCloud Youchuan V8.1 Image-to-Video",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_06_24_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_blend import AtlasYouchuanV81Blend
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_i2i import AtlasYouchuanV81ImageToImage
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_remove_bg import AtlasYouchuanV81RemoveBackground
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_style_transfer import AtlasYouchuanV81StyleTransfer
+    from src.atlascloud_comfyui.nodes.image.youchuan_v81_t2i import AtlasYouchuanV81TextToImage
+    from src.atlascloud_comfyui.nodes.video.youchuan_v81_i2v import AtlasYouchuanV81ImageToVideo
+
+    expected = {
+        AtlasYouchuanV81TextToImage: "youchuan/v8.1/text-to-image",
+        AtlasYouchuanV81ImageToImage: "youchuan/v8.1/image-to-image",
+        AtlasYouchuanV81Blend: "youchuan/v8.1/blend",
+        AtlasYouchuanV81StyleTransfer: "youchuan/v8.1/style-transfer",
+        AtlasYouchuanV81RemoveBackground: "youchuan/v8.1/remove-background",
+        AtlasYouchuanV81ImageToVideo: "youchuan/v8.1/image-to-video",
+    }
+    for cls, model_id in expected.items():
+        assert model_id in inspect.getsource(cls.run)


### PR DESCRIPTION
## New AtlasCloud visual models (2026-06-24 sync)

Adds ComfyUI nodes for the **Youchuan V8.1** family (mirrors the existing Midjourney V8.1 nodes — identical input schemas):

- \`youchuan/v8.1/text-to-image\`
- \`youchuan/v8.1/image-to-image\`
- \`youchuan/v8.1/blend\`
- \`youchuan/v8.1/style-transfer\`
- \`youchuan/v8.1/remove-background\`
- \`youchuan/v8.1/image-to-video\`

### Changes
- 6 new node files under \`nodes/image/\` (5) and \`nodes/video/\` (1)
- registry imports + \`NODE_CLASS_MAPPINGS\` + \`NODE_DISPLAY_NAME_MAPPINGS\`
- README Available Nodes table rows
- metadata-only tests in \`tests/test_new_nodes_2026_06_24.py\`

### Tests
- \`ruff check .\` ✅ All checks passed
- \`pytest -k "not e2e"\` ✅ 304 passed, 26 deselected

E2E skipped (no local ComfyUI source).