### PR TITLE
sync: add 5 AtlasCloud models (2026-06-25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |
 | AtlasCloud Seedance 2.0 Reference-to-Video | bytedance/seedance-2.0/reference-to-video |
 | AtlasCloud Seedance 2.0 Fast Reference-to-Video | bytedance/seedance-2.0-fast/reference-to-video |
+| AtlasCloud Seedance 2.0 Mini Text-to-Video | bytedance/seedance-2.0-mini/text-to-video |
+| AtlasCloud Seedance 2.0 Mini Image-to-Video | bytedance/seedance-2.0-mini/image-to-video |
+| AtlasCloud Seedance 2.0 Mini Reference-to-Video | bytedance/seedance-2.0-mini/reference-to-video |
+| AtlasCloud Avatar Omni Human 1.5 | bytedance/avatar-omni-human-v1.5 |
+| AtlasCloud Image Upscaler | atlascloud/image-upscaler |
 | AtlasCloud Seedance 2.0 Reference-to-Video Upscaled | bytedance/seedance-2.0/reference-to-video-upscaled |
 | AtlasCloud Seedance 2.0 Fast Reference-to-Video Upscaled | bytedance/seedance-2.0-fast/reference-to-video-upscaled |
 | AtlasCloud Vidu Q3 Reference-to-Video | vidu/q3/reference-to-video |

--- a/src/atlascloud_comfyui/nodes/image/atlascloud_image_upscaler.py
+++ b/src/atlascloud_comfyui/nodes/image/atlascloud_image_upscaler.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasImageUpscaler:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL to upscale"}),
+            },
+            "optional": {
+                "outscale": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 1.0, "max": 4.0, "tooltip": "Output scale multiplier (2.0 standard, 4.0 max)"},
+                ),
+                "output_format": (["jpeg", "png", "webp", "jpg"], {"default": "jpeg", "tooltip": "Output image format"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        outscale: float = 2.0,
+        output_format: str = "jpeg",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required for AtlasCloud Image Upscaler")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/image-upscaler",
+            "image": img,
+            "outscale": float(outscale),
+            "output_format": output_format,
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_avatar_omni_human_v15.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_avatar_omni_human_v15.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasAvatarOmniHumanV15:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image_url": ("STRING", {"default": "", "tooltip": "Reference portrait image URL (clear, front-facing face)"}),
+                "audio_url": ("STRING", {"default": "", "tooltip": "Driving audio URL (MP3/WAV, max 60s)"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional action/scene/expression hint"}),
+                "output_resolution": ([720, 1080], {"default": 1080, "tooltip": "Output resolution (720 or 1080)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image_url: str,
+        audio_url: str,
+        prompt: str = "",
+        output_resolution: int = 1080,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image_url = (image_url or "").strip()
+        if not image_url:
+            raise RuntimeError("image_url is required for AtlasCloud Avatar Omni Human 1.5")
+
+        audio_url = (audio_url or "").strip()
+        if not audio_url:
+            raise RuntimeError("audio_url is required for AtlasCloud Avatar Omni Human 1.5")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/avatar-omni-human-v1.5",
+            "image_url": image_url,
+            "audio_url": audio_url,
+            "output_resolution": int(output_resolution),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_mini_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_mini_i2v.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20MiniImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {"default": "", "tooltip": "First frame image (URL or base64)"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "last_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional last frame image (URL/base64)"},
+                ),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (
+                    ["480p", "720p", "720p-SR", "1080p-SR", "1440p-SR"],
+                    {"default": "720p", "tooltip": "Resolution"},
+                ),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "bitrate_mode": (["standard", "high"], {"default": "standard", "tooltip": "Output bitrate mode"}),
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 4294967295, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "The scene comes alive with gentle motion and cinematic lighting",
+        last_image: str = "",
+        randomize_seed: bool = True,
+        seed: int = 0,
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        bitrate_mode: str = "standard",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Seedance 2.0 Mini Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-mini/image-to-video",
+            "image": image,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "bitrate_mode": bitrate_mode,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_mini_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_mini_r2v.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20MiniReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "reference_images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ image URLs/base64, one per line"},
+                ),
+                "reference_videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ video URLs, one per line"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The character in image 1 dances gracefully to the music",
+                        "tooltip": "Prompt (optional)",
+                    },
+                ),
+                "reference_audios": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "Reference audio URLs, one per line (at least 1 for audio)"},
+                ),
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (
+                    ["480p", "720p", "720p-SR", "1080p-SR", "1440p-SR"],
+                    {"default": "720p", "tooltip": "Resolution"},
+                ),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "bitrate_mode": (["standard", "high"], {"default": "standard", "tooltip": "Output bitrate mode"}),
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 4294967295, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        reference_images: str,
+        reference_videos: str,
+        prompt: str = "The character in image 1 dances gracefully to the music",
+        reference_audios: str = "",
+        randomize_seed: bool = True,
+        seed: int = 0,
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        bitrate_mode: str = "standard",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        ref_vids: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
+        if not ref_imgs and not ref_vids:
+            raise RuntimeError("Provide at least one reference image or reference video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-mini/reference-to-video",
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "bitrate_mode": bitrate_mode,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        ref_auds = [v.strip() for v in (reference_audios or "").splitlines() if v.strip()]
+        if ref_auds:
+            payload["reference_audios"] = ref_auds
+
+        if ref_imgs:
+            payload["reference_images"] = ref_imgs
+        if ref_vids:
+            payload["reference_videos"] = ref_vids
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_mini_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_0_mini_t2v.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedance20MiniTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "A golden retriever running on a sunny beach, waves crashing in the background, cinematic lighting",
+                        "tooltip": "Text prompt",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (
+                    ["480p", "720p", "720p-SR", "1080p-SR", "1440p-SR"],
+                    {"default": "720p", "tooltip": "Resolution"},
+                ),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "bitrate_mode": (["standard", "high"], {"default": "standard", "tooltip": "Output bitrate mode"}),
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 4294967295, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        bitrate_mode: str = "standard",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Seedance 2.0 Mini Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.0-mini/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "bitrate_mode": bitrate_mode,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -270,6 +270,11 @@ from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_r2v import AtlasSeeda
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_t2v import AtlasSeedance20FastTextToVideo
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_i2v import AtlasSeedance20FastImageToVideo
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_r2v import AtlasSeedance20FastReferenceToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_t2v import AtlasSeedance20MiniTextToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_i2v import AtlasSeedance20MiniImageToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_r2v import AtlasSeedance20MiniReferenceToVideo
+from atlascloud_comfyui.nodes.video.bytedance_avatar_omni_human_v15 import AtlasAvatarOmniHumanV15
+from atlascloud_comfyui.nodes.image.atlascloud_image_upscaler import AtlasImageUpscaler
 from atlascloud_comfyui.nodes.deprecated.video.bytedance_seedance_2_0_t2v_upscaled import AtlasSeedance20TextToVideoUpscaled
 from atlascloud_comfyui.nodes.deprecated.video.bytedance_seedance_2_0_i2v_upscaled import AtlasSeedance20ImageToVideoUpscaled
 from atlascloud_comfyui.nodes.deprecated.video.bytedance_seedance_2_0_r2v_upscaled import AtlasSeedance20ReferenceToVideoUpscaled
@@ -417,6 +422,11 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Seedance 2.0 Fast Text-to-Video": AtlasSeedance20FastTextToVideo,
     "AtlasCloud Seedance 2.0 Fast Image-to-Video": AtlasSeedance20FastImageToVideo,
     "AtlasCloud Seedance 2.0 Fast Reference-to-Video": AtlasSeedance20FastReferenceToVideo,
+    "AtlasCloud Seedance 2.0 Mini Text-to-Video": AtlasSeedance20MiniTextToVideo,
+    "AtlasCloud Seedance 2.0 Mini Image-to-Video": AtlasSeedance20MiniImageToVideo,
+    "AtlasCloud Seedance 2.0 Mini Reference-to-Video": AtlasSeedance20MiniReferenceToVideo,
+    "AtlasCloud Avatar Omni Human 1.5": AtlasAvatarOmniHumanV15,
+    "AtlasCloud Image Upscaler": AtlasImageUpscaler,
     "AtlasCloud Seedance 2.0 Text-to-Video Upscaled": AtlasSeedance20TextToVideoUpscaled,
     "AtlasCloud Seedance 2.0 Image-to-Video Upscaled": AtlasSeedance20ImageToVideoUpscaled,
     "AtlasCloud Seedance 2.0 Reference-to-Video Upscaled": AtlasSeedance20ReferenceToVideoUpscaled,
@@ -736,6 +746,11 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedance 2.0 Fast Text-to-Video": "AtlasCloud Seedance 2.0 Fast Text-to-Video",
     "AtlasCloud Seedance 2.0 Fast Image-to-Video": "AtlasCloud Seedance 2.0 Fast Image-to-Video",
     "AtlasCloud Seedance 2.0 Fast Reference-to-Video": "AtlasCloud Seedance 2.0 Fast Reference-to-Video",
+    "AtlasCloud Seedance 2.0 Mini Text-to-Video": "AtlasCloud Seedance 2.0 Mini Text-to-Video",
+    "AtlasCloud Seedance 2.0 Mini Image-to-Video": "AtlasCloud Seedance 2.0 Mini Image-to-Video",
+    "AtlasCloud Seedance 2.0 Mini Reference-to-Video": "AtlasCloud Seedance 2.0 Mini Reference-to-Video",
+    "AtlasCloud Avatar Omni Human 1.5": "AtlasCloud Avatar Omni Human 1.5",
+    "AtlasCloud Image Upscaler": "AtlasCloud Image Upscaler",
     "AtlasCloud Seedance 2.0 Text-to-Video Upscaled": "AtlasCloud Seedance 2.0 Text-to-Video Upscaled",
     "AtlasCloud Seedance 2.0 Image-to-Video Upscaled": "AtlasCloud Seedance 2.0 Image-to-Video Upscaled",
     "AtlasCloud Seedance 2.0 Reference-to-Video Upscaled": "AtlasCloud Seedance 2.0 Reference-to-Video Upscaled",

--- a/tests/test_new_nodes_2026_06_25.py
+++ b/tests/test_new_nodes_2026_06_25.py
@@ -1,0 +1,105 @@
+"""Metadata-only tests for newly added nodes (2026-06-25).
+
+Seedance 2.0 Mini family (text/image/reference-to-video), Avatar Omni Human 1.5,
+and the AtlasCloud Image Upscaler.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_seedance_20_mini_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_t2v import (
+        AtlasSeedance20MiniTextToVideo,
+    )
+
+    required = AtlasSeedance20MiniTextToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasSeedance20MiniTextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasSeedance20MiniTextToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_seedance_20_mini_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_i2v import (
+        AtlasSeedance20MiniImageToVideo,
+    )
+
+    required = AtlasSeedance20MiniImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasSeedance20MiniImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasSeedance20MiniImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_seedance_20_mini_r2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_r2v import (
+        AtlasSeedance20MiniReferenceToVideo,
+    )
+
+    required = AtlasSeedance20MiniReferenceToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "reference_images" in required
+    assert "reference_videos" in required
+    assert AtlasSeedance20MiniReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasSeedance20MiniReferenceToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_avatar_omni_human_v15_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_avatar_omni_human_v15 import (
+        AtlasAvatarOmniHumanV15,
+    )
+
+    required = AtlasAvatarOmniHumanV15.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image_url" in required
+    assert "audio_url" in required
+    assert AtlasAvatarOmniHumanV15.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasAvatarOmniHumanV15.CATEGORY == "AtlasCloud/Video"
+
+
+def test_image_upscaler_metadata():
+    from src.atlascloud_comfyui.nodes.image.atlascloud_image_upscaler import (
+        AtlasImageUpscaler,
+    )
+
+    required = AtlasImageUpscaler.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasImageUpscaler.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasImageUpscaler.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_2026_06_25_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Seedance 2.0 Mini Text-to-Video",
+        "AtlasCloud Seedance 2.0 Mini Image-to-Video",
+        "AtlasCloud Seedance 2.0 Mini Reference-to-Video",
+        "AtlasCloud Avatar Omni Human 1.5",
+        "AtlasCloud Image Upscaler",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_06_25_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.atlascloud_image_upscaler import AtlasImageUpscaler
+    from src.atlascloud_comfyui.nodes.video.bytedance_avatar_omni_human_v15 import AtlasAvatarOmniHumanV15
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_i2v import AtlasSeedance20MiniImageToVideo
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_r2v import AtlasSeedance20MiniReferenceToVideo
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_t2v import AtlasSeedance20MiniTextToVideo
+
+    expected = {
+        AtlasSeedance20MiniTextToVideo: "bytedance/seedance-2.0-mini/text-to-video",
+        AtlasSeedance20MiniImageToVideo: "bytedance/seedance-2.0-mini/image-to-video",
+        AtlasSeedance20MiniReferenceToVideo: "bytedance/seedance-2.0-mini/reference-to-video",
+        AtlasAvatarOmniHumanV15: "bytedance/avatar-omni-human-v1.5",
+        AtlasImageUpscaler: "atlascloud/image-upscaler",
+    }
+    for cls, model_id in expected.items():
+        assert model_id in inspect.getsource(cls.run)


### PR DESCRIPTION
## New AtlasCloud visual models

- \`bytedance/seedance-2.0-mini/text-to-video\` — Seedance 2.0 Mini Text-to-Video
- \`bytedance/seedance-2.0-mini/image-to-video\` — Seedance 2.0 Mini Image-to-Video
- \`bytedance/seedance-2.0-mini/reference-to-video\` — Seedance 2.0 Mini Reference-to-Video
- \`bytedance/avatar-omni-human-v1.5\` — Avatar Omni Human 1.5 (portrait + audio → talking video)
- \`atlascloud/image-upscaler\` — Image Upscaler (up to 4x)

## Changes
- 5 new node files (4 video, 1 image), import-safe (no top-level comfy/folder_paths/requests)
- registry.py: imports + NODE_CLASS_MAPPINGS + NODE_DISPLAY_NAME_MAPPINGS
- README Available Nodes table
- metadata-only tests in tests/test_new_nodes_2026_06_25.py

## Test summary
- ruff check . → All checks passed
- pytest (metadata, e2e deselected) → 311 passed, 26 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)