### PR TITLE
sync: add 4 AtlasCloud Nano Banana 2 Lite models (2026-07-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Imagen3 Fast Text-to-Image | google/imagen3-fast |
 | AtlasCloud Nano Banana 2 Text-to-Image | google/nano-banana-2/text-to-image |
 | AtlasCloud Nano Banana 2 Text-to-Image Developer | google/nano-banana-2/text-to-image-developer |
+| AtlasCloud Nano Banana 2 Lite Text-to-Image | google/nano-banana-2-lite/text-to-image |
+| AtlasCloud Nano Banana 2 Lite Text-to-Image Developer | google/nano-banana-2-lite/text-to-image-developer |
 | AtlasCloud Nano Banana Pro Text-to-Image Ultra | google/nano-banana-pro/text-to-image-ultra |
 | AtlasCloud Nano Banana Pro Text-to-Image | google/nano-banana-pro/text-to-image |
 | AtlasCloud Nano Banana Pro Text-to-Image Developer | google/nano-banana-pro/text-to-image-developer |
@@ -410,6 +412,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 |------|-------|
 | AtlasCloud Nano Banana 2 Edit | google/nano-banana-2/edit |
 | AtlasCloud Nano Banana 2 Edit Developer | google/nano-banana-2/edit-developer |
+| AtlasCloud Nano Banana 2 Lite Edit | google/nano-banana-2-lite/edit |
+| AtlasCloud Nano Banana 2 Lite Edit Developer | google/nano-banana-2-lite/edit-developer |
 | AtlasCloud Nano Banana 2 Reference-to-Image | google/nano-banana-2/reference-to-image |
 | AtlasCloud Nano Banana 2 Reference-to-Image Developer | google/nano-banana-2/reference-to-image-developer |
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |

--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_edit.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBanana2LiteEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64 (up to 14 reference images, ONE PER LINE)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt for editing"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+                "output_format": (["png", "jpeg"], {"default": "png", "tooltip": "Output format"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 4294967295, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        aspect_ratio: str,
+        resolution: str,
+        output_format: str,
+        enable_base64_output: bool,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        # Split on newlines, NOT commas: base64 data URLs ("data:image/png;base64,...")
+        # contain a comma, so comma-splitting corrupts them into invalid fragments.
+        images = [img.strip() for img in image.splitlines() if img.strip()]
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-2-lite/edit",
+            "images": images,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": output_format,
+            "enable_base64_output": enable_base64_output,
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_edit_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_edit_dev.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBanana2LiteEditDev:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64 (up to 14 reference images, ONE PER LINE)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt for editing"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+                "output_format": (["png", "jpeg"], {"default": "png", "tooltip": "Output format"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 4294967295, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        aspect_ratio: str,
+        resolution: str,
+        output_format: str,
+        enable_base64_output: bool,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        # Split on newlines, NOT commas: base64 data URLs ("data:image/png;base64,...")
+        # contain a comma, so comma-splitting corrupts them into invalid fragments.
+        images = [img.strip() for img in image.splitlines() if img.strip()]
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-2-lite/edit-developer",
+            "images": images,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": output_format,
+            "enable_base64_output": enable_base64_output,
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_t2i.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBanana2LiteTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+                "output_format": (["png", "jpeg"], {"default": "png", "tooltip": "Output format"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 4294967295, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        resolution: str,
+        output_format: str,
+        enable_base64_output: bool,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-2-lite/text-to-image",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": output_format,
+            "enable_base64_output": enable_base64_output,
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_t2i_dev.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_t2i_dev.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBanana2LiteTextToImageDev:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "16:9", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+                "output_format": (["png", "jpeg"], {"default": "png", "tooltip": "Output format"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 4294967295, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str,
+        resolution: str,
+        output_format: str,
+        enable_base64_output: bool,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-2-lite/text-to-image-developer",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": output_format,
+            "enable_base64_output": enable_base64_output,
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -153,6 +153,10 @@ from atlascloud_comfyui.nodes.image.nano_banana2_edit import AtlasNanoBanana2Edi
 from atlascloud_comfyui.nodes.image.nano_banana2_r2i import AtlasNanoBanana2ReferenceToImage
 from atlascloud_comfyui.nodes.image.nano_banana2_r2i_dev import AtlasNanoBanana2ReferenceToImageDev
 from atlascloud_comfyui.nodes.deprecated.image.nano_banana2_edit_dev import AtlasNanoBanana2EditDev
+from atlascloud_comfyui.nodes.image.nano_banana2_lite_t2i import AtlasNanoBanana2LiteTextToImage
+from atlascloud_comfyui.nodes.image.nano_banana2_lite_t2i_dev import AtlasNanoBanana2LiteTextToImageDev
+from atlascloud_comfyui.nodes.image.nano_banana2_lite_edit import AtlasNanoBanana2LiteEdit
+from atlascloud_comfyui.nodes.image.nano_banana2_lite_edit_dev import AtlasNanoBanana2LiteEditDev
 from atlascloud_comfyui.nodes.image.seedream_v50_lite_t2i import AtlasSeedreamV50LiteTextToImage
 from atlascloud_comfyui.nodes.image.seedream_v50_lite_edit import AtlasSeedreamV50LiteEdit
 from atlascloud_comfyui.nodes.image.seedream_v50_lite_sequential_t2i import AtlasSeedreamV50LiteSequentialTextToImage
@@ -487,6 +491,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Nano Banana 2 Edit Developer": AtlasNanoBanana2EditDev,
     "AtlasCloud Nano Banana 2 Reference-to-Image": AtlasNanoBanana2ReferenceToImage,
     "AtlasCloud Nano Banana 2 Reference-to-Image Developer": AtlasNanoBanana2ReferenceToImageDev,
+    "AtlasCloud Nano Banana 2 Lite Text-to-Image": AtlasNanoBanana2LiteTextToImage,
+    "AtlasCloud Nano Banana 2 Lite Text-to-Image Developer": AtlasNanoBanana2LiteTextToImageDev,
+    "AtlasCloud Nano Banana 2 Lite Edit": AtlasNanoBanana2LiteEdit,
+    "AtlasCloud Nano Banana 2 Lite Edit Developer": AtlasNanoBanana2LiteEditDev,
     "AtlasCloud Seedream V5.0 Lite Text-to-Image": AtlasSeedreamV50LiteTextToImage,
     "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image": AtlasSeedreamV50LiteSequentialTextToImage,
     "AtlasCloud Seedream V5.0 Lite Edit": AtlasSeedreamV50LiteEdit,
@@ -811,6 +819,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Nano Banana 2 Edit Developer": "AtlasCloud Nano Banana 2 Edit Developer",
     "AtlasCloud Nano Banana 2 Reference-to-Image": "AtlasCloud Nano Banana 2 Reference-to-Image",
     "AtlasCloud Nano Banana 2 Reference-to-Image Developer": "AtlasCloud Nano Banana 2 Reference-to-Image Developer",
+    "AtlasCloud Nano Banana 2 Lite Text-to-Image": "AtlasCloud Nano Banana 2 Lite Text-to-Image",
+    "AtlasCloud Nano Banana 2 Lite Text-to-Image Developer": "AtlasCloud Nano Banana 2 Lite Text-to-Image Developer",
+    "AtlasCloud Nano Banana 2 Lite Edit": "AtlasCloud Nano Banana 2 Lite Edit",
+    "AtlasCloud Nano Banana 2 Lite Edit Developer": "AtlasCloud Nano Banana 2 Lite Edit Developer",
     "AtlasCloud Seedream V5.0 Lite Text-to-Image": "AtlasCloud Seedream V5.0 Lite Text-to-Image",
     "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image": "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image",
     "AtlasCloud Seedream V5.0 Lite Edit": "AtlasCloud Seedream V5.0 Lite Edit",

--- a/tests/test_local_history_mvp_2026_06_26.py
+++ b/tests/test_local_history_mvp_2026_06_26.py
@@ -1,7 +1,5 @@
 import json
-import os
 import sys
-import types
 
 import pytest
 

--- a/tests/test_new_nodes_2026_07_01.py
+++ b/tests/test_new_nodes_2026_07_01.py
@@ -1,0 +1,89 @@
+"""Metadata-only tests for newly added nodes (2026-07-01).
+
+Nano Banana 2 Lite family: text-to-image (+ developer) and edit (+ developer).
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_nano_banana2_lite_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_t2i import (
+        AtlasNanoBanana2LiteTextToImage,
+    )
+
+    required = AtlasNanoBanana2LiteTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasNanoBanana2LiteTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasNanoBanana2LiteTextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_nano_banana2_lite_t2i_dev_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_t2i_dev import (
+        AtlasNanoBanana2LiteTextToImageDev,
+    )
+
+    required = AtlasNanoBanana2LiteTextToImageDev.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasNanoBanana2LiteTextToImageDev.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasNanoBanana2LiteTextToImageDev.CATEGORY == "AtlasCloud/Image"
+
+
+def test_nano_banana2_lite_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_edit import (
+        AtlasNanoBanana2LiteEdit,
+    )
+
+    required = AtlasNanoBanana2LiteEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasNanoBanana2LiteEdit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasNanoBanana2LiteEdit.CATEGORY == "AtlasCloud/Image"
+
+
+def test_nano_banana2_lite_edit_dev_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_edit_dev import (
+        AtlasNanoBanana2LiteEditDev,
+    )
+
+    required = AtlasNanoBanana2LiteEditDev.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasNanoBanana2LiteEditDev.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasNanoBanana2LiteEditDev.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_2026_07_01_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Nano Banana 2 Lite Text-to-Image",
+        "AtlasCloud Nano Banana 2 Lite Text-to-Image Developer",
+        "AtlasCloud Nano Banana 2 Lite Edit",
+        "AtlasCloud Nano Banana 2 Lite Edit Developer",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_07_01_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_edit import AtlasNanoBanana2LiteEdit
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_edit_dev import AtlasNanoBanana2LiteEditDev
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_t2i import AtlasNanoBanana2LiteTextToImage
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_t2i_dev import AtlasNanoBanana2LiteTextToImageDev
+
+    expected = {
+        AtlasNanoBanana2LiteTextToImage: "google/nano-banana-2-lite/text-to-image",
+        AtlasNanoBanana2LiteTextToImageDev: "google/nano-banana-2-lite/text-to-image-developer",
+        AtlasNanoBanana2LiteEdit: "google/nano-banana-2-lite/edit",
+        AtlasNanoBanana2LiteEditDev: "google/nano-banana-2-lite/edit-developer",
+    }
+    for cls, model_id in expected.items():
+        assert model_id in inspect.getsource(cls.run)


### PR DESCRIPTION
## Summary
Daily AtlasCloud → ComfyUI sync for 2026-07-01.

API diff surfaced 9 missing visual models. 5 were `*-to-3d` (Hunyuan3D / Seed3D) which are out of scope (type=Image but output mesh zips — no image-node infra fits). The remaining 4 are the **Nano Banana 2 Lite** family, all currently returned by `/api/v1/models`:

- `google/nano-banana-2-lite/text-to-image`
- `google/nano-banana-2-lite/text-to-image-developer`
- `google/nano-banana-2-lite/edit`
- `google/nano-banana-2-lite/edit-developer`

Nodes mirror the existing non-lite `nano-banana-2` nodes (t2i + edit, with randomize_seed/seed, poll_prediction, outputs[0]). Registry, README table, and metadata-only tests updated.

Also removed 2 pre-existing unused imports (`os`, `types`) in `tests/test_local_history_mvp_2026_06_26.py` so `ruff check .` stays green.

## Tests
- `ruff check .` → ✅ All checks passed
- `pytest tests/ -k "not e2e"` → ✅ 320 passed, 26 deselected
- E2E skipped (no ComfyUI source on sync host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)