### PR TITLE
sync: add 6 AtlasCloud models (2026-07-09)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Gemini Omni Flash Text-to-Video Developer | google/gemini-omni-flash/text-to-video-developer |
 | AtlasCloud Gemini Omni Flash Text-to-Video | google/gemini-omni-flash/text-to-video |
 | AtlasCloud Gemini Omni Flash Image-to-Video | google/gemini-omni-flash/image-to-video |
+| AtlasCloud Cosmos 3 Super Image-to-Video | nvidia/cosmos-3-super/image-to-video |
 | AtlasCloud Gemini Omni Flash Reference-to-Video | google/gemini-omni-flash/reference-to-video |
 | AtlasCloud Gemini Omni Flash Video Edit | google/gemini-omni-flash/video-edit |
 | AtlasCloud Grok Imagine Video Text-to-Video | xai/grok-imagine-video/text-to-video |
@@ -368,6 +369,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Nano Banana Text-to-Image Developer | google/nano-banana/text-to-image-developer |
 | AtlasCloud Seedream V5.0 Lite Text-to-Image | bytedance/seedream-v5.0-lite |
 | AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image | bytedance/seedream-v5.0-lite/sequential |
+| AtlasCloud Seedream V5.0 Pro Text-to-Image | bytedance/seedream-v5.0-pro/text-to-image |
+| AtlasCloud Cosmos 3 Super Text-to-Image | nvidia/cosmos-3-super/text-to-image |
 | AtlasCloud Seedream V4 Text-to-Image | bytedance/seedream-v4 |
 | AtlasCloud Seedream V4 Sequential Text-to-Image | bytedance/seedream-v4/sequential |
 | AtlasCloud Seedream V4.5 Text-to-Image | bytedance/seedream-v4.5 |
@@ -375,6 +378,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud ZImage Turbo Text-to-Image | z-image/turbo |
 | AtlasCloud Ideogram V3 Quality Text-to-Image | ideogram-ai/ideogram-v3-quality |
 | AtlasCloud Ideogram V3 Turbo Text-to-Image | ideogram-ai/ideogram-v3-turbo |
+| AtlasCloud Ideogram V4 Quality Text-to-Image | ideogram/v4/Quality/text-to-image |
+| AtlasCloud Ideogram V4 Turbo Text-to-Image | ideogram/v4/turbo/text-to-image |
 | AtlasCloud Luma Photon Text-to-Image | luma/photon |
 | AtlasCloud Luma Photon Flash Text-to-Image | luma/photon-flash |
 | AtlasCloud Recraft V3 Text-to-Image | recraft-ai/recraft-v3 |
@@ -426,6 +431,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Nano Banana 2 Reference-to-Image Developer | google/nano-banana-2/reference-to-image-developer |
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |
 | AtlasCloud Seedream V5.0 Lite Edit Sequential | bytedance/seedream-v5.0-lite/edit-sequential |
+| AtlasCloud Seedream V5.0 Pro Edit | bytedance/seedream-v5.0-pro/edit |
 | AtlasCloud WAN2.6 Image-Edit | alibaba/wan-2.6/image-edit |
 | AtlasCloud WAN2.7 Image-Edit | alibaba/wan-2.7/image-edit |
 | AtlasCloud WAN2.7 Pro Image-Edit | alibaba/wan-2.7-pro/image-edit |

--- a/src/atlascloud_comfyui/nodes/image/ideogram_v4_quality_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/ideogram_v4_quality_t2i.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasIdeogramV4QualityTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image_size": (
+                    ["square_hd", "square", "portrait_3_4", "portrait_9_16", "landscape_4_3", "landscape_16_9"],
+                    {"default": "landscape_16_9", "tooltip": "Output image resolution preset"},
+                ),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output image file format"}),
+            },
+            "optional": {
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_size: str,
+        output_format: str,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "ideogram/v4/Quality/text-to-image",
+            "prompt": prompt,
+            "image_size": image_size,
+            "output_format": output_format,
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/ideogram_v4_turbo_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/ideogram_v4_turbo_t2i.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasIdeogramV4TurboTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image_size": (
+                    ["square_hd", "square", "portrait_3_4", "portrait_9_16", "landscape_4_3", "landscape_16_9"],
+                    {"default": "landscape_16_9", "tooltip": "Output image resolution preset"},
+                ),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output image file format"}),
+            },
+            "optional": {
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_size: str,
+        output_format: str,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "ideogram/v4/turbo/text-to-image",
+            "prompt": prompt,
+            "image_size": image_size,
+            "output_format": output_format,
+        }
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/nvidia_cosmos_3_super_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/nvidia_cosmos_3_super_t2i.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasCosmos3SuperTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image_size": (
+                    ["square_hd", "square", "portrait_4_3", "portrait_16_9", "landscape_4_3", "landscape_16_9"],
+                    {"default": "landscape_16_9", "tooltip": "Output image resolution preset"},
+                ),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output image file format"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "num_inference_steps": ("INT", {"default": 28, "min": 1, "max": 50, "tooltip": "Inference steps"}),
+                "guidance_scale": ("FLOAT", {"default": 4.0, "min": 1.0, "max": 20.0, "tooltip": "Guidance scale"}),
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "enable_safety_checker": ("BOOLEAN", {"default": False, "tooltip": "Enable safety checker"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_size: str,
+        output_format: str,
+        negative_prompt: str = "",
+        num_inference_steps: int = 28,
+        guidance_scale: float = 4.0,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        enable_safety_checker: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "nvidia/cosmos-3-super/text-to-image",
+            "prompt": prompt,
+            "image_size": image_size,
+            "num_inference_steps": int(num_inference_steps),
+            "guidance_scale": float(guidance_scale),
+            "output_format": output_format,
+            "enable_safety_checker": bool(enable_safety_checker),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v50_pro_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v50_pro_edit.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV50ProEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "Input image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "size": (
+                    [
+                        "2048*2048", "2304*1728", "1728*2304", "2720*1530", "1530*2720",
+                        "2496*1664", "1664*2496", "1024*1024", "1536*1536",
+                        "1776*1328", "1328*1776", "2048*1152", "1152*2048",
+                    ],
+                    {"default": "2048*2048", "tooltip": "Output image size WIDTH*HEIGHT"},
+                ),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output image file format"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        size: str,
+        output_format: str,
+        enable_base64_output: bool,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1+ lines) for Seedream V5.0 Pro Edit")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v5.0-pro/edit",
+            "images": image_list,
+            "prompt": p,
+            "size": size,
+            "output_format": output_format,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v50_pro_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v50_pro_t2i.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV50ProTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (recommended under 600 English words)"}),
+                "size": (
+                    [
+                        "2048*2048", "2304*1728", "1728*2304", "2720*1530", "1530*2720",
+                        "2496*1664", "1664*2496", "1024*1024", "1536*1536",
+                        "1776*1328", "1328*1776", "2048*1152", "1152*2048",
+                    ],
+                    {"default": "2048*2048", "tooltip": "Output image size WIDTH*HEIGHT"},
+                ),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "Output image file format"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str,
+        output_format: str,
+        enable_base64_output: bool,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v5.0-pro/text-to-image",
+            "prompt": prompt,
+            "size": size,
+            "output_format": output_format,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/nvidia_cosmos_3_super_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/nvidia_cosmos_3_super_i2v.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasCosmos3SuperImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image_url": ("STRING", {"default": "", "tooltip": "First frame image (URL or data:image/...;base64,...)"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Negative prompt"}),
+                "image_size": (
+                    ["square_hd", "square", "portrait_4_3", "portrait_16_9", "landscape_4_3", "landscape_16_9"],
+                    {"default": "landscape_16_9", "tooltip": "Output resolution preset"},
+                ),
+                "duration": ([1, 2, 3, 4, 5, 6, 7], {"default": 5, "tooltip": "Duration (seconds)"}),
+                "num_inference_steps": ("INT", {"default": 28, "min": 1, "max": 50, "tooltip": "Inference steps"}),
+                "guidance_scale": ("FLOAT", {"default": 6.0, "min": 1.0, "max": 20.0, "tooltip": "Guidance scale"}),
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2**31 - 1, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "enable_safety_checker": ("BOOLEAN", {"default": False, "tooltip": "Enable safety checker"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_url: str,
+        negative_prompt: str = "",
+        image_size: str = "landscape_16_9",
+        duration: int = 5,
+        num_inference_steps: int = 28,
+        guidance_scale: float = 6.0,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        enable_safety_checker: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image_url = (image_url or "").strip()
+        if not image_url:
+            raise RuntimeError("image_url is required for Cosmos 3 Super Image-to-Video")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "nvidia/cosmos-3-super/image-to-video",
+            "prompt": p,
+            "image_url": image_url,
+            "image_size": image_size,
+            "duration": int(duration),
+            "num_inference_steps": int(num_inference_steps),
+            "guidance_scale": float(guidance_scale),
+            "enable_safety_checker": bool(enable_safety_checker),
+        }
+
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -258,6 +258,13 @@ from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_edit import A
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_t2i import AtlasGrokImagineImageTextToImage
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_edit import AtlasGrokImagineImageEdit
 
+from atlascloud_comfyui.nodes.image.seedream_v50_pro_t2i import AtlasSeedreamV50ProTextToImage
+from atlascloud_comfyui.nodes.image.seedream_v50_pro_edit import AtlasSeedreamV50ProEdit
+from atlascloud_comfyui.nodes.image.nvidia_cosmos_3_super_t2i import AtlasCosmos3SuperTextToImage
+from atlascloud_comfyui.nodes.video.nvidia_cosmos_3_super_i2v import AtlasCosmos3SuperImageToVideo
+from atlascloud_comfyui.nodes.image.ideogram_v4_turbo_t2i import AtlasIdeogramV4TurboTextToImage
+from atlascloud_comfyui.nodes.image.ideogram_v4_quality_t2i import AtlasIdeogramV4QualityTextToImage
+
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_pro import AtlasKlingV16MultiI2VPro
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_standard import AtlasKlingV16MultiI2VStandard
 from atlascloud_comfyui.nodes.video.kling_v16_i2v_standard import AtlasKlingV16I2VStandard
@@ -710,6 +717,12 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud FLUX.2 Pro Edit": AtlasFlux2ProEdit,
     "AtlasCloud Grok Imagine Video Edit": AtlasGrokImagineVideoEdit,
     "AtlasCloud Grok Imagine Video Extend": AtlasGrokImagineVideoExtend,
+    "AtlasCloud Seedream V5.0 Pro Text-to-Image": AtlasSeedreamV50ProTextToImage,
+    "AtlasCloud Seedream V5.0 Pro Edit": AtlasSeedreamV50ProEdit,
+    "AtlasCloud Cosmos 3 Super Text-to-Image": AtlasCosmos3SuperTextToImage,
+    "AtlasCloud Cosmos 3 Super Image-to-Video": AtlasCosmos3SuperImageToVideo,
+    "AtlasCloud Ideogram V4 Turbo Text-to-Image": AtlasIdeogramV4TurboTextToImage,
+    "AtlasCloud Ideogram V4 Quality Text-to-Image": AtlasIdeogramV4QualityTextToImage,
 }
 
 
@@ -1044,6 +1057,12 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud HiDream O1 1.5 Edit": "AtlasCloud HiDream O1 1.5 Edit",
     "AtlasCloud Sync Lipsync v3": "AtlasCloud Sync Lipsync v3",
     "AtlasCloud VEED Lipsync": "AtlasCloud VEED Lipsync",
+    "AtlasCloud Seedream V5.0 Pro Text-to-Image": "AtlasCloud Seedream V5.0 Pro Text-to-Image",
+    "AtlasCloud Seedream V5.0 Pro Edit": "AtlasCloud Seedream V5.0 Pro Edit",
+    "AtlasCloud Cosmos 3 Super Text-to-Image": "AtlasCloud Cosmos 3 Super Text-to-Image",
+    "AtlasCloud Cosmos 3 Super Image-to-Video": "AtlasCloud Cosmos 3 Super Image-to-Video",
+    "AtlasCloud Ideogram V4 Turbo Text-to-Image": "AtlasCloud Ideogram V4 Turbo Text-to-Image",
+    "AtlasCloud Ideogram V4 Quality Text-to-Image": "AtlasCloud Ideogram V4 Quality Text-to-Image",
 }
 
 

--- a/tests/test_new_nodes_2026_07_09.py
+++ b/tests/test_new_nodes_2026_07_09.py
@@ -1,0 +1,121 @@
+"""Metadata-only tests for newly added nodes (2026-07-09).
+
+Seedream v5.0 Pro (text-to-image, edit), Nvidia Cosmos 3 Super
+(text-to-image, image-to-video), and Ideogram v4 (turbo, quality) text-to-image.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_seedream_v50_pro_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_pro_t2i import (
+        AtlasSeedreamV50ProTextToImage,
+    )
+
+    required = AtlasSeedreamV50ProTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasSeedreamV50ProTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasSeedreamV50ProTextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_seedream_v50_pro_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_pro_edit import (
+        AtlasSeedreamV50ProEdit,
+    )
+
+    required = AtlasSeedreamV50ProEdit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "images" in required
+    assert AtlasSeedreamV50ProEdit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasSeedreamV50ProEdit.CATEGORY == "AtlasCloud/Image"
+
+
+def test_cosmos_3_super_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.nvidia_cosmos_3_super_t2i import (
+        AtlasCosmos3SuperTextToImage,
+    )
+
+    required = AtlasCosmos3SuperTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasCosmos3SuperTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasCosmos3SuperTextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_cosmos_3_super_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.nvidia_cosmos_3_super_i2v import (
+        AtlasCosmos3SuperImageToVideo,
+    )
+
+    required = AtlasCosmos3SuperImageToVideo.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image_url" in required
+    assert AtlasCosmos3SuperImageToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasCosmos3SuperImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_ideogram_v4_turbo_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.ideogram_v4_turbo_t2i import (
+        AtlasIdeogramV4TurboTextToImage,
+    )
+
+    required = AtlasIdeogramV4TurboTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasIdeogramV4TurboTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasIdeogramV4TurboTextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_ideogram_v4_quality_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.ideogram_v4_quality_t2i import (
+        AtlasIdeogramV4QualityTextToImage,
+    )
+
+    required = AtlasIdeogramV4QualityTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasIdeogramV4QualityTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasIdeogramV4QualityTextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_2026_07_09_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Seedream V5.0 Pro Text-to-Image",
+        "AtlasCloud Seedream V5.0 Pro Edit",
+        "AtlasCloud Cosmos 3 Super Text-to-Image",
+        "AtlasCloud Cosmos 3 Super Image-to-Video",
+        "AtlasCloud Ideogram V4 Turbo Text-to-Image",
+        "AtlasCloud Ideogram V4 Quality Text-to-Image",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_07_09_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_pro_t2i import AtlasSeedreamV50ProTextToImage
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_pro_edit import AtlasSeedreamV50ProEdit
+    from src.atlascloud_comfyui.nodes.image.nvidia_cosmos_3_super_t2i import AtlasCosmos3SuperTextToImage
+    from src.atlascloud_comfyui.nodes.video.nvidia_cosmos_3_super_i2v import AtlasCosmos3SuperImageToVideo
+    from src.atlascloud_comfyui.nodes.image.ideogram_v4_turbo_t2i import AtlasIdeogramV4TurboTextToImage
+    from src.atlascloud_comfyui.nodes.image.ideogram_v4_quality_t2i import AtlasIdeogramV4QualityTextToImage
+
+    expected = {
+        AtlasSeedreamV50ProTextToImage: "bytedance/seedream-v5.0-pro/text-to-image",
+        AtlasSeedreamV50ProEdit: "bytedance/seedream-v5.0-pro/edit",
+        AtlasCosmos3SuperTextToImage: "nvidia/cosmos-3-super/text-to-image",
+        AtlasCosmos3SuperImageToVideo: "nvidia/cosmos-3-super/image-to-video",
+        AtlasIdeogramV4TurboTextToImage: "ideogram/v4/turbo/text-to-image",
+        AtlasIdeogramV4QualityTextToImage: "ideogram/v4/Quality/text-to-image",
+    }
+    for cls, model_id in expected.items():
+        src = inspect.getsource(cls.run)
+        assert f'"model": "{model_id}"' in src


### PR DESCRIPTION
Automated daily AtlasCloud → ComfyUI node sync.

## New models (6)
- \`bytedance/seedream-v5.0-pro/text-to-image\` — Seedream V5.0 Pro Text-to-Image
- \`bytedance/seedream-v5.0-pro/edit\` — Seedream V5.0 Pro Edit
- \`nvidia/cosmos-3-super/text-to-image\` — Cosmos 3 Super Text-to-Image
- \`nvidia/cosmos-3-super/image-to-video\` — Cosmos 3 Super Image-to-Video
- \`ideogram/v4/turbo/text-to-image\` — Ideogram V4 Turbo Text-to-Image
- \`ideogram/v4/Quality/text-to-image\` — Ideogram V4 Quality Text-to-Image

Excluded from this batch: 5 \`*-to-3d\` models (seed3d-v2.0, hunyuan3d-rapid/pro) — they output mesh zips, no image-node infra fits.

## Tests
- ruff: ✅ All checks passed
- pytest (metadata, non-e2e): ✅ 340 passed, 26 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)