### PR TITLE
sync: fix Ideogram V4 Quality model id casing (2026-07-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud ZImage Turbo Text-to-Image | z-image/turbo |
 | AtlasCloud Ideogram V3 Quality Text-to-Image | ideogram-ai/ideogram-v3-quality |
 | AtlasCloud Ideogram V3 Turbo Text-to-Image | ideogram-ai/ideogram-v3-turbo |
-| AtlasCloud Ideogram V4 Quality Text-to-Image | ideogram/v4/Quality/text-to-image |
+| AtlasCloud Ideogram V4 Quality Text-to-Image | ideogram/v4/quality/text-to-image |
 | AtlasCloud Ideogram V4 Turbo Text-to-Image | ideogram/v4/turbo/text-to-image |
 | AtlasCloud Luma Photon Text-to-Image | luma/photon |
 | AtlasCloud Luma Photon Flash Text-to-Image | luma/photon-flash |

--- a/src/atlascloud_comfyui/nodes/image/ideogram_v4_quality_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/ideogram_v4_quality_t2i.py
@@ -45,7 +45,7 @@ class AtlasIdeogramV4QualityTextToImage:
         client = atlas_client.client
 
         payload: Dict[str, Any] = {
-            "model": "ideogram/v4/Quality/text-to-image",
+            "model": "ideogram/v4/quality/text-to-image",
             "prompt": prompt,
             "image_size": image_size,
             "output_format": output_format,

--- a/tests/test_new_nodes_2026_07_09.py
+++ b/tests/test_new_nodes_2026_07_09.py
@@ -114,7 +114,7 @@ def test_new_nodes_2026_07_09_model_ids():
         AtlasCosmos3SuperTextToImage: "nvidia/cosmos-3-super/text-to-image",
         AtlasCosmos3SuperImageToVideo: "nvidia/cosmos-3-super/image-to-video",
         AtlasIdeogramV4TurboTextToImage: "ideogram/v4/turbo/text-to-image",
-        AtlasIdeogramV4QualityTextToImage: "ideogram/v4/Quality/text-to-image",
+        AtlasIdeogramV4QualityTextToImage: "ideogram/v4/quality/text-to-image",
     }
     for cls, model_id in expected.items():
         src = inspect.getsource(cls.run)


### PR DESCRIPTION
## Summary

Daily AtlasCloud → ComfyUI sync for 2026-07-10.

The only diff against the live API is a **casing rename**: the API now serves `ideogram/v4/quality/text-to-image` (lowercase `quality`), while the node added in the 2026-07-09 sync used capital-Q `ideogram/v4/Quality/text-to-image`, which no longer resolves. This is a fix, not a new node — creating a duplicate node would be wrong.

### Changes
- `ideogram_v4_quality_t2i.py`: payload model id → lowercase
- `test_new_nodes_2026_07_09.py`: expected model id → lowercase
- `README.md`: Available Nodes table → lowercase

No genuinely new visual models this cycle.

### Tests
- ruff: ✅ All checks passed
- pytest (metadata only, e2e deselected): ✅ 340 passed, 26 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)