### PR TITLE
sync: add 1 AtlasCloud model (2026-07-20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Flux2 Flex Text-to-Image | flux2/flex |
 | AtlasCloud Flux Dev Text-to-Image | black-forest-labs/flux-dev |
 | AtlasCloud Flux Dev LoRA Text-to-Image | black-forest-labs/flux-dev-lora |
+| AtlasCloud Krea-2 Turbo Text-to-Image | krea-2-turbo/text-to-image |
 | AtlasCloud Flux Schnell Text-to-Image | black-forest-labs/flux-schnell |
 | AtlasCloud FLUX.2 Pro Text-to-Image | black-forest-labs/flux-2-pro/text-to-image |
 | AtlasCloud FLUX.2 Flex Edit | black-forest-labs/flux-2-flex/edit |

--- a/src/atlascloud_comfyui/nodes/image/krea_2_turbo_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/krea_2_turbo_t2i.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasKrea2TurboTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt"}),
+                "image_size": (
+                    ["square_hd", "square", "portrait_3_4", "portrait_9_16", "landscape_4_3", "landscape_16_9"],
+                    {"default": "square_hd", "tooltip": "Output image size preset"},
+                ),
+            },
+            "optional": {
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images"}),
+                "output_format": (["png", "jpeg"], {"default": "png", "tooltip": "Output image format"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2147483647, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_size: str = "square_hd",
+        num_images: int = 1,
+        output_format: str = "png",
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "krea-2-turbo/text-to-image",
+            "prompt": p,
+            "image_size": image_size,
+            "num_images": int(num_images),
+            "output_format": output_format,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -151,6 +151,7 @@ from atlascloud_comfyui.nodes.image.nano_banana_pro_edit_ultra import AtlasNanoB
 from atlascloud_comfyui.nodes.deprecated.image.flux2_flex_t2i import AtlasFlux2FlexTextToImage
 from atlascloud_comfyui.nodes.image.flux_dev_t2i import AtlasFluxDevTextToImage
 from atlascloud_comfyui.nodes.image.flux_dev_lora_t2i import AtlasFluxDevLoraTextToImage
+from atlascloud_comfyui.nodes.image.krea_2_turbo_t2i import AtlasKrea2TurboTextToImage
 from atlascloud_comfyui.nodes.image.nano_banana2_t2i import AtlasNanoBanana2TextToImage
 from atlascloud_comfyui.nodes.deprecated.image.nano_banana2_t2i_dev import AtlasNanoBanana2TextToImageDev
 from atlascloud_comfyui.nodes.image.nano_banana2_edit import AtlasNanoBanana2Edit
@@ -495,6 +496,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Flux2 Flex Text-to-Image": AtlasFlux2FlexTextToImage,
     "AtlasCloud Flux Dev Text-to-Image": AtlasFluxDevTextToImage,
     "AtlasCloud Flux Dev LoRA Text-to-Image": AtlasFluxDevLoraTextToImage,
+    "AtlasCloud Krea-2 Turbo Text-to-Image": AtlasKrea2TurboTextToImage,
     "AtlasCloud Flux Schnell Text-to-Image": AtlasFluxSchnellTextToImage,
     "AtlasCloud Flux Kontext Dev Edit": AtlasFluxKontextDevEdit,
     "AtlasCloud Flux Kontext Dev LoRA Edit": AtlasFluxKontextDevLoraEdit,
@@ -845,6 +847,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Flux2 Flex Text-to-Image": "AtlasCloud Flux2 Flex Text-to-Image",
     "AtlasCloud Flux Dev Text-to-Image": "AtlasCloud Flux Dev Text-to-Image",
     "AtlasCloud Flux Dev LoRA Text-to-Image": "AtlasCloud Flux Dev LoRA Text-to-Image",
+    "AtlasCloud Krea-2 Turbo Text-to-Image": "AtlasCloud Krea-2 Turbo Text-to-Image",
     "AtlasCloud Flux Schnell Text-to-Image": "AtlasCloud Flux Schnell Text-to-Image",
     "AtlasCloud Flux Kontext Dev Edit": "AtlasCloud Flux Kontext Dev Edit",
     "AtlasCloud Flux Kontext Dev LoRA Edit": "AtlasCloud Flux Kontext Dev LoRA Edit",

--- a/tests/test_new_nodes_2026_07_20.py
+++ b/tests/test_new_nodes_2026_07_20.py
@@ -1,0 +1,38 @@
+"""Metadata-only tests for newly added nodes (2026-07-20).
+
+New model: Krea-2 Turbo Text-to-Image.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_krea_2_turbo_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.krea_2_turbo_t2i import (
+        AtlasKrea2TurboTextToImage,
+    )
+
+    required = AtlasKrea2TurboTextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "image_size" in required
+    assert AtlasKrea2TurboTextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasKrea2TurboTextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_2026_07_20_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    key = "AtlasCloud Krea-2 Turbo Text-to-Image"
+    assert key in NODE_CLASS_MAPPINGS
+    assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_07_20_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.krea_2_turbo_t2i import AtlasKrea2TurboTextToImage
+
+    src = inspect.getsource(AtlasKrea2TurboTextToImage.run)
+    assert '"model": "krea-2-turbo/text-to-image"' in src


### PR DESCRIPTION
## New model

- `krea-2-turbo/text-to-image` — Krea-2 Turbo Text-to-Image (type: Image, text-to-image)

Added ComfyUI node `AtlasCloud Krea-2 Turbo Text-to-Image`, wired into registry (imports + NODE_CLASS_MAPPINGS + NODE_DISPLAY_NAME_MAPPINGS), README table, and metadata-only tests.

## Notes on diff
Corrected the supported-model grep to match both `'model':` and `"model":` quote styles. The naive double-quote-only grep over-reported 16 missing; after fixing, only this 1 model is genuinely new.

## Tests
- ruff: ✅ All checks passed
- pytest (metadata, non-e2e): ✅ 353 passed, 26 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)