### PR TITLE
sync: add 3 AtlasCloud models (2026-07-21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,9 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Nano Banana 2 Lite Edit | google/nano-banana-2-lite/edit |
 | AtlasCloud Nano Banana 2 Lite Edit Developer | google/nano-banana-2-lite/edit-developer |
 | AtlasCloud HiDream O1 1.5 Edit | hidream-o1-1.5/edit |
+| AtlasCloud Reve 2.1 Text-to-Image | reve-ai/reve-2.1/text-to-image |
+| AtlasCloud Reve 2.1 Edit | reve-ai/reve-2.1/edit |
+| AtlasCloud Reve 2.1 Remix | reve-ai/reve-2.1/remix |
 | AtlasCloud Nano Banana 2 Reference-to-Image | google/nano-banana-2/reference-to-image |
 | AtlasCloud Nano Banana 2 Reference-to-Image Developer | google/nano-banana-2/reference-to-image-developer |
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |

--- a/src/atlascloud_comfyui/nodes/image/reve_21_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/reve_21_edit.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_ASPECT_RATIOS = [
+    "auto",
+    "4:1",
+    "3:1",
+    "21:9",
+    "2:1",
+    "17:9",
+    "16:9",
+    "3:2",
+    "4:3",
+    "5:4",
+    "1:1",
+    "4:5",
+    "3:4",
+    "2:3",
+    "9:16",
+    "1:2",
+    "1:3",
+    "1:4",
+]
+
+
+class AtlasReve21Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image URL or base64 to edit"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Instruction describing the desired edit (max 2560 chars)"}),
+                "aspect_ratio": (_ASPECT_RATIOS, {"default": "auto", "tooltip": "Aspect ratio ('auto' keeps the input ratio)"}),
+                "output_format": (["png", "jpeg", "webp"], {"default": "png", "tooltip": "Output format"}),
+            },
+            "optional": {
+                "remove_background": ("BOOLEAN", {"default": False, "tooltip": "Keep only the central subject, transparent background"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        aspect_ratio: str = "auto",
+        output_format: str = "png",
+        remove_background: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required (URL or base64)")
+
+        payload: Dict[str, Any] = {
+            "model": "reve-ai/reve-2.1/edit",
+            "prompt": p,
+            "image": img,
+            "aspect_ratio": aspect_ratio,
+            "resolution": "4k",
+            "remove_background": bool(remove_background),
+            "output_format": output_format,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/reve_21_remix.py
+++ b/src/atlascloud_comfyui/nodes/image/reve_21_remix.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_ASPECT_RATIOS = [
+    "auto",
+    "4:1",
+    "3:1",
+    "21:9",
+    "2:1",
+    "17:9",
+    "16:9",
+    "3:2",
+    "4:3",
+    "5:4",
+    "1:1",
+    "4:5",
+    "3:4",
+    "2:3",
+    "9:16",
+    "1:2",
+    "1:3",
+    "1:4",
+]
+
+
+class AtlasReve21Remix:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-6 reference image URLs/base64, ONE PER LINE. Refer to them in the prompt with <frame>0</frame> etc."}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (max 2560 chars)"}),
+                "aspect_ratio": (_ASPECT_RATIOS, {"default": "auto", "tooltip": "Aspect ratio ('auto' lets the model decide)"}),
+                "output_format": (["png", "jpeg", "webp"], {"default": "png", "tooltip": "Output format"}),
+            },
+            "optional": {
+                "remove_background": ("BOOLEAN", {"default": False, "tooltip": "Keep only the central subject, transparent background"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        aspect_ratio: str = "auto",
+        output_format: str = "png",
+        remove_background: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        # Split on newlines, NOT commas: base64 data URLs contain a comma.
+        image_list: List[str] = [u.strip() for u in (images or "").splitlines() if u.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (provide between 1 and 6 reference images, one per line)")
+        if len(image_list) > 6:
+            raise RuntimeError("images maxItems is 6")
+
+        payload: Dict[str, Any] = {
+            "model": "reve-ai/reve-2.1/remix",
+            "prompt": p,
+            "images": image_list,
+            "aspect_ratio": aspect_ratio,
+            "resolution": "4k",
+            "remove_background": bool(remove_background),
+            "output_format": output_format,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/reve_21_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/reve_21_t2i.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_ASPECT_RATIOS = [
+    "auto",
+    "4:1",
+    "3:1",
+    "21:9",
+    "2:1",
+    "17:9",
+    "16:9",
+    "3:2",
+    "4:3",
+    "5:4",
+    "1:1",
+    "4:5",
+    "3:4",
+    "2:3",
+    "9:16",
+    "1:2",
+    "1:3",
+    "1:4",
+]
+
+
+class AtlasReve21TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (max 2560 chars)"}),
+                "aspect_ratio": (_ASPECT_RATIOS, {"default": "auto", "tooltip": "Aspect ratio ('auto' lets the model decide)"}),
+                "output_format": (["png", "jpeg", "webp"], {"default": "png", "tooltip": "Output format"}),
+            },
+            "optional": {
+                "remove_background": ("BOOLEAN", {"default": False, "tooltip": "Keep only the central subject, transparent background"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str = "auto",
+        output_format: str = "png",
+        remove_background: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        payload: Dict[str, Any] = {
+            "model": "reve-ai/reve-2.1/text-to-image",
+            "prompt": p,
+            "aspect_ratio": aspect_ratio,
+            "resolution": "4k",
+            "remove_background": bool(remove_background),
+            "output_format": output_format,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -164,6 +164,9 @@ from atlascloud_comfyui.nodes.image.nano_banana2_lite_edit import AtlasNanoBanan
 from atlascloud_comfyui.nodes.image.nano_banana2_lite_edit_dev import AtlasNanoBanana2LiteEditDev
 from atlascloud_comfyui.nodes.image.hidream_o1_15_t2i import AtlasHiDreamO115TextToImage
 from atlascloud_comfyui.nodes.image.hidream_o1_15_edit import AtlasHiDreamO115Edit
+from atlascloud_comfyui.nodes.image.reve_21_t2i import AtlasReve21TextToImage
+from atlascloud_comfyui.nodes.image.reve_21_edit import AtlasReve21Edit
+from atlascloud_comfyui.nodes.image.reve_21_remix import AtlasReve21Remix
 from atlascloud_comfyui.nodes.video.sync_lipsync_v3 import AtlasSyncLipsyncV3
 from atlascloud_comfyui.nodes.video.veed_lipsync import AtlasVeedLipsync
 from atlascloud_comfyui.nodes.image.seedream_v50_lite_t2i import AtlasSeedreamV50LiteTextToImage
@@ -524,6 +527,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Nano Banana 2 Lite Edit Developer": AtlasNanoBanana2LiteEditDev,
     "AtlasCloud HiDream O1 1.5 Text-to-Image": AtlasHiDreamO115TextToImage,
     "AtlasCloud HiDream O1 1.5 Edit": AtlasHiDreamO115Edit,
+    "AtlasCloud Reve 2.1 Text-to-Image": AtlasReve21TextToImage,
+    "AtlasCloud Reve 2.1 Edit": AtlasReve21Edit,
+    "AtlasCloud Reve 2.1 Remix": AtlasReve21Remix,
     "AtlasCloud Sync Lipsync v3": AtlasSyncLipsyncV3,
     "AtlasCloud VEED Lipsync": AtlasVeedLipsync,
     "AtlasCloud Seedream V5.0 Lite Text-to-Image": AtlasSeedreamV50LiteTextToImage,
@@ -1074,6 +1080,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Grok Imagine Video Extend": "AtlasCloud Grok Imagine Video Extend",
     "AtlasCloud HiDream O1 1.5 Text-to-Image": "AtlasCloud HiDream O1 1.5 Text-to-Image",
     "AtlasCloud HiDream O1 1.5 Edit": "AtlasCloud HiDream O1 1.5 Edit",
+    "AtlasCloud Reve 2.1 Text-to-Image": "AtlasCloud Reve 2.1 Text-to-Image",
+    "AtlasCloud Reve 2.1 Edit": "AtlasCloud Reve 2.1 Edit",
+    "AtlasCloud Reve 2.1 Remix": "AtlasCloud Reve 2.1 Remix",
     "AtlasCloud Sync Lipsync v3": "AtlasCloud Sync Lipsync v3",
     "AtlasCloud VEED Lipsync": "AtlasCloud VEED Lipsync",
     "AtlasCloud Seedream V5.0 Pro Text-to-Image": "AtlasCloud Seedream V5.0 Pro Text-to-Image",

--- a/tests/test_new_nodes_2026_07_21.py
+++ b/tests/test_new_nodes_2026_07_21.py
@@ -1,0 +1,67 @@
+"""Metadata-only tests for newly added nodes (2026-07-21).
+
+New models: Reve 2.1 Text-to-Image, Reve 2.1 Edit, Reve 2.1 Remix.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_reve_21_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.reve_21_t2i import (
+        AtlasReve21TextToImage,
+    )
+
+    required = AtlasReve21TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "aspect_ratio" in required
+    assert AtlasReve21TextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasReve21TextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_reve_21_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.reve_21_edit import AtlasReve21Edit
+
+    required = AtlasReve21Edit.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasReve21Edit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasReve21Edit.CATEGORY == "AtlasCloud/Image"
+
+
+def test_reve_21_remix_metadata():
+    from src.atlascloud_comfyui.nodes.image.reve_21_remix import AtlasReve21Remix
+
+    required = AtlasReve21Remix.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert "prompt" in required
+    assert AtlasReve21Remix.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasReve21Remix.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_2026_07_21_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Reve 2.1 Text-to-Image",
+        "AtlasCloud Reve 2.1 Edit",
+        "AtlasCloud Reve 2.1 Remix",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_07_21_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.reve_21_t2i import AtlasReve21TextToImage
+    from src.atlascloud_comfyui.nodes.image.reve_21_edit import AtlasReve21Edit
+    from src.atlascloud_comfyui.nodes.image.reve_21_remix import AtlasReve21Remix
+
+    assert '"model": "reve-ai/reve-2.1/text-to-image"' in inspect.getsource(AtlasReve21TextToImage.run)
+    assert '"model": "reve-ai/reve-2.1/edit"' in inspect.getsource(AtlasReve21Edit.run)
+    assert '"model": "reve-ai/reve-2.1/remix"' in inspect.getsource(AtlasReve21Remix.run)


### PR DESCRIPTION
## New AtlasCloud visual models

Adds ComfyUI nodes for 3 newly-surfaced Reve 2.1 image models (type=Image):

- \`reve-ai/reve-2.1/text-to-image\` — AtlasCloud Reve 2.1 Text-to-Image
- \`reve-ai/reve-2.1/edit\` — AtlasCloud Reve 2.1 Edit (requires \`image\`)
- \`reve-ai/reve-2.1/remix\` — AtlasCloud Reve 2.1 Remix (requires 1-6 reference \`images\`)

All use native 4K resolution, the full Reve aspect-ratio enum, and the standard `generate_image` + `poll_prediction` + `outputs[0]` flow. Edit/Remix validate required image input(s).

## Changes
- New node files under \`src/atlascloud_comfyui/nodes/image/\`
- Registered in \`registry.py\` (imports + NODE_CLASS_MAPPINGS + NODE_DISPLAY_NAME_MAPPINGS)
- README Available Nodes table updated
- Metadata-only tests in \`tests/test_new_nodes_2026_07_21.py\`

## Testing
- \`ruff check .\` ✅ All checks passed
- \`pytest -k "not e2e"\` ✅ 358 passed, 26 deselected

E2E skipped (no local ComfyUI source on the sync host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)