### PR TITLE
sync: add 1 AtlasCloud model (2026-07-24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Nano Banana 2 Edit Developer | google/nano-banana-2/edit-developer |
 | AtlasCloud Nano Banana 2 Lite Edit | google/nano-banana-2-lite/edit |
 | AtlasCloud Nano Banana 2 Lite Edit Developer | google/nano-banana-2-lite/edit-developer |
+| AtlasCloud Nano Banana 2 Lite Reference-to-Image | google/nano-banana-2-lite/reference-to-image |
 | AtlasCloud HiDream O1 1.5 Edit | hidream-o1-1.5/edit |
 | AtlasCloud Reve 2.1 Text-to-Image | reve-ai/reve-2.1/text-to-image |
 | AtlasCloud Reve 2.1 Edit | reve-ai/reve-2.1/edit |

--- a/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_r2i.py
+++ b/src/atlascloud_comfyui/nodes/image/nano_banana2_lite_r2i.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasNanoBanana2LiteReferenceToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt for generation"}),
+                "video_url": ("STRING", {"default": "", "tooltip": "Source video clip URL (HTTP <=15MB or YouTube URL)"}),
+            },
+            "optional": {
+                "randomize_seed": ("BOOLEAN", {"default": True, "tooltip": "开启后每次生成随机结果；关闭后使用下方固定 seed"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 4294967295, "tooltip": "固定 seed（仅在随机开关关闭时生效）"}),
+                "video_start": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 86400.0, "tooltip": "Trim start (seconds)"}),
+                "video_ends": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 86400.0, "tooltip": "Trim end (seconds); 0 = whole video"}),
+                "video_fps": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 24.0, "tooltip": "FPS of the video clip"}),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional 0-10 reference image URLs/base64, one per line"}),
+                "aspect_ratio": (
+                    ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "resolution": (["1k", "2k", "4k"], {"default": "1k", "tooltip": "Resolution preset"}),
+                "output_format": (["default", "png", "jpeg"], {"default": "default", "tooltip": "Output format"}),
+                "enable_web_search": ("BOOLEAN", {"default": False, "tooltip": "Ground generation with web search"}),
+                "enable_image_search": ("BOOLEAN", {"default": False, "tooltip": "Ground generation with image search"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        video_url: str,
+        video_start: float = 0.0,
+        video_ends: float = 0.0,
+        video_fps: float = 1.0,
+        images: str = "",
+        aspect_ratio: str = "1:1",
+        resolution: str = "1k",
+        output_format: str = "default",
+        enable_web_search: bool = False,
+        enable_image_search: bool = False,
+        enable_base64_output: bool = False,
+        randomize_seed: bool = True,
+        seed: int = 0,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        video_url = (video_url or "").strip()
+        if not video_url:
+            raise RuntimeError("video_url is required")
+
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/nano-banana-2-lite/reference-to-image",
+            "prompt": prompt,
+            "video_clips": [
+                {
+                    "url": video_url,
+                    "start": float(video_start),
+                    "ends": float(video_ends),
+                    "fps": float(video_fps),
+                }
+            ],
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "output_format": output_format,
+            "enable_web_search": bool(enable_web_search),
+            "enable_image_search": bool(enable_image_search),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        if image_list:
+            payload["images"] = image_list
+
+        if not randomize_seed:
+            payload["seed"] = seed
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -162,6 +162,7 @@ from atlascloud_comfyui.nodes.image.nano_banana2_lite_t2i import AtlasNanoBanana
 from atlascloud_comfyui.nodes.image.nano_banana2_lite_t2i_dev import AtlasNanoBanana2LiteTextToImageDev
 from atlascloud_comfyui.nodes.image.nano_banana2_lite_edit import AtlasNanoBanana2LiteEdit
 from atlascloud_comfyui.nodes.image.nano_banana2_lite_edit_dev import AtlasNanoBanana2LiteEditDev
+from atlascloud_comfyui.nodes.image.nano_banana2_lite_r2i import AtlasNanoBanana2LiteReferenceToImage
 from atlascloud_comfyui.nodes.image.hidream_o1_15_t2i import AtlasHiDreamO115TextToImage
 from atlascloud_comfyui.nodes.image.hidream_o1_15_edit import AtlasHiDreamO115Edit
 from atlascloud_comfyui.nodes.image.reve_21_t2i import AtlasReve21TextToImage
@@ -525,6 +526,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Nano Banana 2 Lite Text-to-Image Developer": AtlasNanoBanana2LiteTextToImageDev,
     "AtlasCloud Nano Banana 2 Lite Edit": AtlasNanoBanana2LiteEdit,
     "AtlasCloud Nano Banana 2 Lite Edit Developer": AtlasNanoBanana2LiteEditDev,
+    "AtlasCloud Nano Banana 2 Lite Reference-to-Image": AtlasNanoBanana2LiteReferenceToImage,
     "AtlasCloud HiDream O1 1.5 Text-to-Image": AtlasHiDreamO115TextToImage,
     "AtlasCloud HiDream O1 1.5 Edit": AtlasHiDreamO115Edit,
     "AtlasCloud Reve 2.1 Text-to-Image": AtlasReve21TextToImage,
@@ -877,6 +879,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Nano Banana 2 Lite Text-to-Image Developer": "AtlasCloud Nano Banana 2 Lite Text-to-Image Developer",
     "AtlasCloud Nano Banana 2 Lite Edit": "AtlasCloud Nano Banana 2 Lite Edit",
     "AtlasCloud Nano Banana 2 Lite Edit Developer": "AtlasCloud Nano Banana 2 Lite Edit Developer",
+    "AtlasCloud Nano Banana 2 Lite Reference-to-Image": "AtlasCloud Nano Banana 2 Lite Reference-to-Image",
     "AtlasCloud Seedream V5.0 Lite Text-to-Image": "AtlasCloud Seedream V5.0 Lite Text-to-Image",
     "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image": "AtlasCloud Seedream V5.0 Lite Sequential Text-to-Image",
     "AtlasCloud Seedream V5.0 Lite Edit": "AtlasCloud Seedream V5.0 Lite Edit",

--- a/tests/test_new_nodes_2026_07_24.py
+++ b/tests/test_new_nodes_2026_07_24.py
@@ -1,0 +1,42 @@
+"""Metadata-only tests for newly added nodes (2026-07-24).
+
+New model: Nano Banana 2 Lite Reference-to-Image.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+
+def test_nano_banana2_lite_r2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_r2i import (
+        AtlasNanoBanana2LiteReferenceToImage,
+    )
+
+    required = AtlasNanoBanana2LiteReferenceToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "video_url" in required
+    assert AtlasNanoBanana2LiteReferenceToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasNanoBanana2LiteReferenceToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_new_nodes_2026_07_24_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    key = "AtlasCloud Nano Banana 2 Lite Reference-to-Image"
+    assert key in NODE_CLASS_MAPPINGS
+    assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_07_24_model_ids():
+    import inspect
+
+    from src.atlascloud_comfyui.nodes.image.nano_banana2_lite_r2i import (
+        AtlasNanoBanana2LiteReferenceToImage,
+    )
+
+    assert (
+        '"model": "google/nano-banana-2-lite/reference-to-image"'
+        in inspect.getsource(AtlasNanoBanana2LiteReferenceToImage.run)
+    )


### PR DESCRIPTION
## New AtlasCloud model

- \`google/nano-banana-2-lite/reference-to-image\` (Image) — Nano Banana 2 Lite Reference-to-image

Added ComfyUI node \`AtlasNanoBanana2LiteReferenceToImage\` (patterned on the existing \`google/nano-banana-2/reference-to-image\` node), wired into the registry, README table, and metadata tests.

## Tests

- ruff: ✅ All checks passed
- pytest (metadata-only, e2e skipped — no ComfyUI source locally): ✅ 361 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)