### PR TITLE
sync: add 6 AtlasCloud models (2026-07-29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud VEO3 Fast Image-to-Video | google/veo3-fast/image-to-video |
 | AtlasCloud Midjourney V8.1 Image-to-Video | midjourney/v8.1/image-to-video |
 | AtlasCloud Youchuan V8.1 Image-to-Video | youchuan/v8.1/image-to-video |
+| AtlasCloud Youchuan V8.2 Image-to-Video | youchuan/v8.2/image-to-video |
 | AtlasCloud VEO3.1 Fast Image-to-Video | google/veo3.1-fast/image-to-video |
 | AtlasCloud Gemini Omni Flash Image-to-Video Developer | google/gemini-omni-flash/image-to-video-developer |
 | AtlasCloud Gemini Omni Flash Reference-to-Video Developer | google/gemini-omni-flash/reference-to-video-developer |
@@ -351,6 +352,11 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Youchuan V8.1 Blend | youchuan/v8.1/blend |
 | AtlasCloud Youchuan V8.1 Remove Background | youchuan/v8.1/remove-background |
 | AtlasCloud Youchuan V8.1 Style Transfer | youchuan/v8.1/style-transfer |
+| AtlasCloud Youchuan V8.2 Text-to-Image | youchuan/v8.2/text-to-image |
+| AtlasCloud Youchuan V8.2 Image-to-Image | youchuan/v8.2/image-to-image |
+| AtlasCloud Youchuan V8.2 Blend | youchuan/v8.2/blend |
+| AtlasCloud Youchuan V8.2 Remove Background | youchuan/v8.2/remove-background |
+| AtlasCloud Youchuan V8.2 Style Transfer | youchuan/v8.2/style-transfer |
 | AtlasCloud WAN2.6 Text-to-Image | alibaba/wan-2.6/text-to-image |
 | AtlasCloud WAN2.7 Text-to-Image | alibaba/wan-2.7/text-to-image |
 | AtlasCloud WAN2.7 Pro Text-to-Image | alibaba/wan-2.7-pro/text-to-image |

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v82_blend.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v82_blend.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV82Blend:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "2-5 input image URLs to blend, one per line"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional text prompt guiding the blend (max 1024 chars)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if len(image_list) < 2:
+            raise RuntimeError("images requires at least 2 URLs (one per line) for Youchuan V8.2 Blend")
+        if len(image_list) > 5:
+            raise RuntimeError("images maxItems is 5 for Youchuan V8.2 Blend")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.2/blend",
+            "images": image_list,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v82_i2i.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v82_i2i.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV82ImageToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image to re-imagine (public https URL)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt guiding the generation (max 1024 chars)"}),
+            },
+            "optional": {
+                "sref": ("STRING", {"default": "", "tooltip": "Optional style-reference image URL (public https)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        sref: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Youchuan V8.2 Image-to-Image")
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Youchuan V8.2 Image-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.2/image-to-image",
+            "image": image,
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        ref = (sref or "").strip()
+        if ref:
+            payload["sref"] = ref
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v82_remove_bg.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v82_remove_bg.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV82RemoveBackground:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image whose background will be removed (public https URL)"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Youchuan V8.2 Remove Background")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.2/remove-background",
+            "image": image,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v82_style_transfer.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v82_style_transfer.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV82StyleTransfer:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "Input image to restyle (public https URL)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Description of the target artistic style"}),
+            },
+            "optional": {
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Youchuan V8.2 Style Transfer")
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Youchuan V8.2 Style Transfer")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.2/style-transfer",
+            "image": image,
+            "prompt": prompt,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/youchuan_v82_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/youchuan_v82_t2i.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV82TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "default": "A serene mountain lake at sunrise, photorealistic", "tooltip": "Natural-language description of the image to generate (max 1024 chars)"}),
+            },
+            "optional": {
+                "sref": ("STRING", {"default": "", "tooltip": "Optional style-reference image URL (public https)"}),
+                "aspect_ratio": (
+                    ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "9:21", "21:9"],
+                    {"default": "1:1", "tooltip": "Aspect ratio of the generated image"},
+                ),
+                "hd": ("BOOLEAN", {"default": False, "tooltip": "Enable native 2K HD generation (costs 1.5x)"}),
+                "stylize": ("INT", {"default": 0, "min": 0, "max": 1000, "tooltip": "How strongly the default aesthetic is applied (0-1000)"}),
+                "chaos": ("INT", {"default": 0, "min": 0, "max": 100, "tooltip": "Higher values produce more varied results (0-100)"}),
+                "weird": ("INT", {"default": 0, "min": 0, "max": 3000, "tooltip": "Makes results quirky and unconventional (0-3000)"}),
+                "quality": ([1, 4], {"default": 1, "tooltip": "Image detail. 4 = higher detail at same price (slower)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        sref: str = "",
+        aspect_ratio: str = "1:1",
+        hd: bool = False,
+        stylize: int = 0,
+        chaos: int = 0,
+        weird: int = 0,
+        quality: int = 1,
+        seed: int = -1,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Youchuan V8.2 Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.2/text-to-image",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "hd": bool(hd),
+            "stylize": int(stylize),
+            "chaos": int(chaos),
+            "weird": int(weird),
+            "quality": int(quality),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        ref = (sref or "").strip()
+        if ref:
+            payload["sref"] = ref
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/youchuan_v82_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/youchuan_v82_i2v.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasYouchuanV82ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First-frame image to animate (public https URL or base64)"}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "gentle camera push in, cinematic", "tooltip": "Optional motion / scene description"}),
+                "resolution": (["480p", "720p"], {"default": "480p", "tooltip": "Output resolution. 720p costs 3x of 480p"}),
+                "motion": (["low", "high"], {"default": "low", "tooltip": "Amount of motion in the generated video"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "gentle camera push in, cinematic",
+        resolution: str = "480p",
+        motion: str = "low",
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Youchuan V8.2 Image-to-Video (URL or base64)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "youchuan/v8.2/image-to-video",
+            "image": image,
+            "resolution": resolution,
+            "motion": motion,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -350,6 +350,12 @@ from atlascloud_comfyui.nodes.image.youchuan_v81_i2i import AtlasYouchuanV81Imag
 from atlascloud_comfyui.nodes.image.youchuan_v81_blend import AtlasYouchuanV81Blend
 from atlascloud_comfyui.nodes.image.youchuan_v81_remove_bg import AtlasYouchuanV81RemoveBackground
 from atlascloud_comfyui.nodes.image.youchuan_v81_style_transfer import AtlasYouchuanV81StyleTransfer
+from atlascloud_comfyui.nodes.video.youchuan_v82_i2v import AtlasYouchuanV82ImageToVideo
+from atlascloud_comfyui.nodes.image.youchuan_v82_t2i import AtlasYouchuanV82TextToImage
+from atlascloud_comfyui.nodes.image.youchuan_v82_i2i import AtlasYouchuanV82ImageToImage
+from atlascloud_comfyui.nodes.image.youchuan_v82_blend import AtlasYouchuanV82Blend
+from atlascloud_comfyui.nodes.image.youchuan_v82_remove_bg import AtlasYouchuanV82RemoveBackground
+from atlascloud_comfyui.nodes.image.youchuan_v82_style_transfer import AtlasYouchuanV82StyleTransfer
 from atlascloud_comfyui.nodes.video.kling_v30_4k_i2v import AtlasKlingV304KImageToVideo
 from atlascloud_comfyui.nodes.video.kling_v30_4k_t2v import AtlasKlingV304KTextToVideo
 from atlascloud_comfyui.nodes.video.kling_video_o3_4k_i2v import AtlasKlingVideoO34KImageToVideo
@@ -580,6 +586,12 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Youchuan V8.1 Blend": AtlasYouchuanV81Blend,
     "AtlasCloud Youchuan V8.1 Remove Background": AtlasYouchuanV81RemoveBackground,
     "AtlasCloud Youchuan V8.1 Style Transfer": AtlasYouchuanV81StyleTransfer,
+    "AtlasCloud Youchuan V8.2 Image-to-Video": AtlasYouchuanV82ImageToVideo,
+    "AtlasCloud Youchuan V8.2 Text-to-Image": AtlasYouchuanV82TextToImage,
+    "AtlasCloud Youchuan V8.2 Image-to-Image": AtlasYouchuanV82ImageToImage,
+    "AtlasCloud Youchuan V8.2 Blend": AtlasYouchuanV82Blend,
+    "AtlasCloud Youchuan V8.2 Remove Background": AtlasYouchuanV82RemoveBackground,
+    "AtlasCloud Youchuan V8.2 Style Transfer": AtlasYouchuanV82StyleTransfer,
     "AtlasCloud Kling V3.0 4K Image-to-Video": AtlasKlingV304KImageToVideo,
     "AtlasCloud Kling V3.0 4K Text-to-Video": AtlasKlingV304KTextToVideo,
     "AtlasCloud Kling V3.0 Turbo Image-to-Video": AtlasKlingV30TurboImageToVideo,
@@ -926,6 +938,12 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Youchuan V8.1 Blend": "AtlasCloud Youchuan V8.1 Blend",
     "AtlasCloud Youchuan V8.1 Remove Background": "AtlasCloud Youchuan V8.1 Remove Background",
     "AtlasCloud Youchuan V8.1 Style Transfer": "AtlasCloud Youchuan V8.1 Style Transfer",
+    "AtlasCloud Youchuan V8.2 Image-to-Video": "AtlasCloud Youchuan V8.2 Image-to-Video",
+    "AtlasCloud Youchuan V8.2 Text-to-Image": "AtlasCloud Youchuan V8.2 Text-to-Image",
+    "AtlasCloud Youchuan V8.2 Image-to-Image": "AtlasCloud Youchuan V8.2 Image-to-Image",
+    "AtlasCloud Youchuan V8.2 Blend": "AtlasCloud Youchuan V8.2 Blend",
+    "AtlasCloud Youchuan V8.2 Remove Background": "AtlasCloud Youchuan V8.2 Remove Background",
+    "AtlasCloud Youchuan V8.2 Style Transfer": "AtlasCloud Youchuan V8.2 Style Transfer",
     "AtlasCloud Kling V3.0 4K Image-to-Video": "AtlasCloud Kling V3.0 4K Image-to-Video",
     "AtlasCloud Kling V3.0 4K Text-to-Video": "AtlasCloud Kling V3.0 4K Text-to-Video",
     "AtlasCloud Kling V3.0 Turbo Image-to-Video": "AtlasCloud Kling V3.0 Turbo Image-to-Video",

--- a/tests/test_new_nodes_2026_07_29.py
+++ b/tests/test_new_nodes_2026_07_29.py
@@ -1,0 +1,120 @@
+"""Metadata-only tests for newly added nodes (2026-07-29).
+
+New models: Youchuan V8.2 (text-to-image, image-to-image, blend,
+remove-background, style-transfer, image-to-video).
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+
+def test_youchuan_v82_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v82_t2i import (
+        AtlasYouchuanV82TextToImage,
+    )
+
+    required = AtlasYouchuanV82TextToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert AtlasYouchuanV82TextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasYouchuanV82TextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v82_i2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v82_i2i import (
+        AtlasYouchuanV82ImageToImage,
+    )
+
+    required = AtlasYouchuanV82ImageToImage.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasYouchuanV82ImageToImage.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v82_blend_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v82_blend import (
+        AtlasYouchuanV82Blend,
+    )
+
+    required = AtlasYouchuanV82Blend.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "images" in required
+    assert AtlasYouchuanV82Blend.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v82_remove_bg_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v82_remove_bg import (
+        AtlasYouchuanV82RemoveBackground,
+    )
+
+    required = AtlasYouchuanV82RemoveBackground.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert AtlasYouchuanV82RemoveBackground.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v82_style_transfer_metadata():
+    from src.atlascloud_comfyui.nodes.image.youchuan_v82_style_transfer import (
+        AtlasYouchuanV82StyleTransfer,
+    )
+
+    required = AtlasYouchuanV82StyleTransfer.INPUT_TYPES()["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "prompt" in required
+    assert AtlasYouchuanV82StyleTransfer.CATEGORY == "AtlasCloud/Image"
+
+
+def test_youchuan_v82_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.youchuan_v82_i2v import (
+        AtlasYouchuanV82ImageToVideo,
+    )
+
+    required = AtlasYouchuanV82ImageToVideo.INPUT_TYPES()["required"]
+    optional = AtlasYouchuanV82ImageToVideo.INPUT_TYPES()["optional"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert optional["resolution"][0] == ["480p", "720p"]
+    assert optional["motion"][0] == ["low", "high"]
+    assert AtlasYouchuanV82ImageToVideo.RETURN_NAMES == ("video_url", "prediction_id")
+    assert AtlasYouchuanV82ImageToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_new_nodes_2026_07_29_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key in (
+        "AtlasCloud Youchuan V8.2 Text-to-Image",
+        "AtlasCloud Youchuan V8.2 Image-to-Image",
+        "AtlasCloud Youchuan V8.2 Blend",
+        "AtlasCloud Youchuan V8.2 Remove Background",
+        "AtlasCloud Youchuan V8.2 Style Transfer",
+        "AtlasCloud Youchuan V8.2 Image-to-Video",
+    ):
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+@pytest.mark.parametrize(
+    "module_path, class_name, model_id",
+    [
+        ("image.youchuan_v82_t2i", "AtlasYouchuanV82TextToImage", "youchuan/v8.2/text-to-image"),
+        ("image.youchuan_v82_i2i", "AtlasYouchuanV82ImageToImage", "youchuan/v8.2/image-to-image"),
+        ("image.youchuan_v82_blend", "AtlasYouchuanV82Blend", "youchuan/v8.2/blend"),
+        ("image.youchuan_v82_remove_bg", "AtlasYouchuanV82RemoveBackground", "youchuan/v8.2/remove-background"),
+        ("image.youchuan_v82_style_transfer", "AtlasYouchuanV82StyleTransfer", "youchuan/v8.2/style-transfer"),
+        ("video.youchuan_v82_i2v", "AtlasYouchuanV82ImageToVideo", "youchuan/v8.2/image-to-video"),
+    ],
+)
+def test_new_nodes_2026_07_29_model_ids(module_path, class_name, model_id):
+    import importlib
+
+    module = importlib.import_module(f"src.atlascloud_comfyui.nodes.{module_path}")
+    node_cls = getattr(module, class_name)
+    assert f'"model": "{model_id}"' in inspect.getsource(node_cls.run)


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI sync. Adds the Youchuan V8.2 family (schemas are identical in shape to the existing Youchuan V8.1 / Midjourney V8.1 nodes).

## New models
- \`youchuan/v8.2/text-to-image\` — AtlasCloud Youchuan V8.2 Text-to-Image
- \`youchuan/v8.2/image-to-image\` — AtlasCloud Youchuan V8.2 Image-to-Image
- \`youchuan/v8.2/blend\` — AtlasCloud Youchuan V8.2 Blend
- \`youchuan/v8.2/remove-background\` — AtlasCloud Youchuan V8.2 Remove Background
- \`youchuan/v8.2/style-transfer\` — AtlasCloud Youchuan V8.2 Style Transfer
- \`youchuan/v8.2/image-to-video\` — AtlasCloud Youchuan V8.2 Image-to-Video

## Not included
8 remaining missing visual models are 3D (\`*-to-3d\`: Seed3D 2.0, Hunyuan 3D Rapid/Pro, Tripo H3.1). They carry type=Image but emit mesh archives, so no existing image-node output contract fits them.

## Tests
- \`ruff check .\` — all checks passed
- \`pytest tests/ -k "not e2e"\` — 374 passed, 26 deselected
- New metadata-only tests in \`tests/test_new_nodes_2026_07_29.py\` (INPUT_TYPES, registry mappings, exact model ids). No live API calls.

E2E not run locally (no ComfyUI source on the sync machine); relying on CI.