### PR TITLE
sync: add 1 AtlasCloud model (2026-07-30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud WAN2.6 Image-to-Video | alibaba/wan-2.6/image-to-video |
 | AtlasCloud WAN2.6 Spicy Image-to-Video | atlascloud/wan-2.6-spicy/image-to-video |
 | AtlasCloud WAN2.7 Spicy Image-to-Video | atlascloud/wan-2.7-spicy/image-to-video |
+| AtlasCloud WAN2.7 Spicy Reference-to-Video | atlascloud/wan-2.7-spicy/reference-to-video |
 | AtlasCloud WAN2.7 Image-to-Video | alibaba/wan-2.7/image-to-video |
 | AtlasCloud HappyHorse 1.0 Image-to-Video | alibaba/happyhorse-1.0/image-to-video |
 | AtlasCloud HappyHorse 1.1 Image-to-Video | alibaba/happyhorse-1.1/image-to-video |

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_7_spicy_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_wan_2_7_spicy_r2v.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasWan27SpicyReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "reference_images": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": "1-4 image URLs/base64, one per line (images only; video/audio refs unsupported)",
+                    },
+                ),
+                "prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Text prompt; bind subjects with @image1, @image2, ..."},
+                ),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 5, "min": 2, "max": 15, "tooltip": "Duration (seconds)"}),
+                "resolution": (
+                    ["720P", "1080P", "1080P-SR", "1440P-SR"],
+                    {"default": "720P", "tooltip": "Output resolution (SR variants use super-resolution)"},
+                ),
+                "aspect_ratio": (
+                    ["auto", "16:9", "9:16", "4:3", "3:4", "1:1"],
+                    {"default": "auto", "tooltip": "Aspect ratio (auto = follow reference images)"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        reference_images: str,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720P",
+        aspect_ratio: str = "auto",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        if not ref_imgs:
+            raise RuntimeError(
+                "reference_images is required for AtlasCloud WAN2.7 Spicy Reference-to-Video (1-4 images)"
+            )
+        if len(ref_imgs) > 4:
+            raise RuntimeError(f"At most 4 reference images are supported, got {len(ref_imgs)}")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/wan-2.7-spicy/reference-to-video",
+            "reference_images": ref_imgs,
+            "prompt": p,
+            "duration": int(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -235,6 +235,7 @@ from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_spicy_infinite_i2v_
 )
 from atlascloud_comfyui.nodes.video.atlascloud_wan_2_6_spicy_i2v import AtlasWan26SpicyImageToVideo
 from atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_i2v import AtlasWan27SpicyImageToVideo
+from atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_r2v import AtlasWan27SpicyReferenceToVideo
 from atlascloud_comfyui.nodes.video.van25_t2v import AtlasAtlascloudVan25TextToVideo
 from atlascloud_comfyui.nodes.video.van25_i2v import AtlasAtlascloudVan25ImageToVideo
 from atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
@@ -639,6 +640,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA": AtlasWan22TurboSpicyInfiniteImageToVideoLoRA,
     "AtlasCloud WAN2.6 Spicy Image-to-Video": AtlasWan26SpicyImageToVideo,
     "AtlasCloud WAN2.7 Spicy Image-to-Video": AtlasWan27SpicyImageToVideo,
+    "AtlasCloud WAN2.7 Spicy Reference-to-Video": AtlasWan27SpicyReferenceToVideo,
     "AtlasCloud Imagen4 Ultra Text-to-Image": AtlasImagen4UltraTextToImage,
     "AtlasCloud Imagen3 Text-to-Image": AtlasImagen3TextToImage,
     "AtlasCloud Imagen3 Fast Text-to-Image": AtlasImagen3FastTextToImage,
@@ -991,6 +993,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA": "AtlasCloud Wan 2.2 Turbo Spicy Infinite Image-to-Video LoRA",
     "AtlasCloud WAN2.6 Spicy Image-to-Video": "AtlasCloud WAN2.6 Spicy Image-to-Video",
     "AtlasCloud WAN2.7 Spicy Image-to-Video": "AtlasCloud WAN2.7 Spicy Image-to-Video",
+    "AtlasCloud WAN2.7 Spicy Reference-to-Video": "AtlasCloud WAN2.7 Spicy Reference-to-Video",
     "AtlasCloud Imagen4 Ultra Text-to-Image": "AtlasCloud Imagen4 Ultra Text-to-Image",
     "AtlasCloud Imagen3 Text-to-Image": "AtlasCloud Imagen3 Text-to-Image",
     "AtlasCloud Imagen3 Fast Text-to-Image": "AtlasCloud Imagen3 Fast Text-to-Image",

--- a/tests/test_new_nodes_2026_07_30.py
+++ b/tests/test_new_nodes_2026_07_30.py
@@ -1,0 +1,78 @@
+"""Metadata-only tests for newly added nodes (2026-07-30).
+
+New model: Wan 2.7 Spicy Reference-to-Video.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+
+def test_wan27_spicy_r2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_r2v import (
+        AtlasWan27SpicyReferenceToVideo,
+    )
+
+    inputs = AtlasWan27SpicyReferenceToVideo.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "atlas_client" in required
+    assert "reference_images" in required
+    assert "prompt" in required
+    assert optional["resolution"][0] == ["720P", "1080P", "1080P-SR", "1440P-SR"]
+    assert optional["aspect_ratio"][0] == ["auto", "16:9", "9:16", "4:3", "3:4", "1:1"]
+    assert optional["duration"][1]["min"] == 2
+    assert optional["duration"][1]["max"] == 15
+    assert AtlasWan27SpicyReferenceToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasWan27SpicyReferenceToVideo.RETURN_NAMES == ("video_url", "prediction_id")
+    assert AtlasWan27SpicyReferenceToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+@pytest.mark.parametrize("bad_images", ["", "   \n  \n"])
+def test_wan27_spicy_r2v_requires_reference_images(bad_images):
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_r2v import (
+        AtlasWan27SpicyReferenceToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="reference_images is required"):
+        AtlasWan27SpicyReferenceToVideo().run(None, bad_images, "a prompt")
+
+
+def test_wan27_spicy_r2v_rejects_more_than_four_images():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_r2v import (
+        AtlasWan27SpicyReferenceToVideo,
+    )
+
+    images = "\n".join(f"https://example.com/{i}.png" for i in range(5))
+    with pytest.raises(RuntimeError, match="At most 4 reference images"):
+        AtlasWan27SpicyReferenceToVideo().run(None, images, "a prompt")
+
+
+def test_wan27_spicy_r2v_requires_prompt():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_r2v import (
+        AtlasWan27SpicyReferenceToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasWan27SpicyReferenceToVideo().run(None, "https://example.com/1.png", "   ")
+
+
+def test_new_nodes_2026_07_30_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    key = "AtlasCloud WAN2.7 Spicy Reference-to-Video"
+    assert key in NODE_CLASS_MAPPINGS
+    assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_07_30_model_ids():
+    from src.atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_r2v import (
+        AtlasWan27SpicyReferenceToVideo,
+    )
+
+    source = inspect.getsource(AtlasWan27SpicyReferenceToVideo.run)
+    assert '"model": "atlascloud/wan-2.7-spicy/reference-to-video"' in source


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync.

## New model
- `atlascloud/wan-2.7-spicy/reference-to-video` — Wan 2.7 Spicy Reference-to-Video (node: `AtlasCloud WAN2.7 Spicy Reference-to-Video`)

Params follow the published model schema: `reference_images` (1–4, images only — reference video/audio unsupported), `prompt` (with `@imageN` subject binding), `duration` (2–15s), `resolution` (720P/1080P/1080P-SR/1440P-SR), `aspect_ratio` (auto/16:9/9:16/4:3/3:4/1:1).

Also skipped (out of scope, mesh outputs — no image-node infra fits): the 7 `*-to-3d` models newly present in the API.

## Tests
- `python3 -m ruff check .` → All checks passed
- `python3 -m pytest tests/ -k "not e2e"` → 381 passed, 26 deselected
- E2E skipped locally (no ComfyUI source on the sync machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)