### PR TITLE
sync: add 6 AtlasCloud models (2026-07-31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud WAN2.6 Spicy Image-to-Video | atlascloud/wan-2.6-spicy/image-to-video |
 | AtlasCloud WAN2.7 Spicy Image-to-Video | atlascloud/wan-2.7-spicy/image-to-video |
 | AtlasCloud WAN2.7 Spicy Reference-to-Video | atlascloud/wan-2.7-spicy/reference-to-video |
+| AtlasCloud MiniMax H3 Text-to-Video | minimax/h3/text-to-video |
+| AtlasCloud MiniMax H3 Image-to-Video | minimax/h3/image-to-video |
+| AtlasCloud MiniMax H3 Reference-to-Video | minimax/h3/reference-to-video |
+| AtlasCloud Tencent Image Upscaler | tencent/image/upscaler |
+| AtlasCloud Tencent Video Upscaler | tencent/video/upscaler |
+| AtlasCloud BytePlus Video Upscaler | byteplus/video/upscaler |
 | AtlasCloud WAN2.7 Image-to-Video | alibaba/wan-2.7/image-to-video |
 | AtlasCloud HappyHorse 1.0 Image-to-Video | alibaba/happyhorse-1.0/image-to-video |
 | AtlasCloud HappyHorse 1.1 Image-to-Video | alibaba/happyhorse-1.1/image-to-video |

--- a/src/atlascloud_comfyui/nodes/image/tencent_image_upscaler.py
+++ b/src/atlascloud_comfyui/nodes/image/tencent_image_upscaler.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasTencentImageUpscaler:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image_url": ("STRING", {"default": "", "tooltip": "Public HTTP(S) URL of the source image"}),
+            },
+            "optional": {
+                "type": (
+                    ["standard", "super", "ultra", "fidelity"],
+                    {
+                        "default": "ultra",
+                        "tooltip": "Super-resolution type (standard = fastest, ultra = more detail)",
+                    },
+                ),
+                "mode": (
+                    ["percent", "aspect", "fixed"],
+                    {"default": "percent", "tooltip": "percent = scale factor; aspect/fixed = target dimensions"},
+                ),
+                "percent": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 1.0, "max": 10.0, "tooltip": "Scale factor for mode=percent"},
+                ),
+                "width": ("INT", {"default": 0, "min": 0, "max": 16384, "tooltip": "Target width (0 = unset)"}),
+                "height": ("INT", {"default": 0, "min": 0, "max": 16384, "tooltip": "Target height (0 = unset)"}),
+                "long_side": ("INT", {"default": 0, "min": 0, "max": 16384, "tooltip": "Target long edge (0 = unset)"}),
+                "short_side": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 16384, "tooltip": "Target short edge (0 = unset)"},
+                ),
+                "encode_format": (
+                    ["JPEG", "PNG", "WEBP", "BMP"],
+                    {"default": "JPEG", "tooltip": "Output image encode format"},
+                ),
+                "encode_quality": (
+                    "INT",
+                    {"default": 80, "min": 1, "max": 100, "tooltip": "Encode quality for lossy formats"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image_url: str,
+        type: str = "ultra",
+        mode: str = "percent",
+        percent: float = 2.0,
+        width: int = 0,
+        height: int = 0,
+        long_side: int = 0,
+        short_side: int = 0,
+        encode_format: str = "JPEG",
+        encode_quality: int = 80,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        img = (image_url or "").strip()
+        if not img:
+            raise RuntimeError("image_url is required for Tencent Image Upscaler")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "tencent/image/upscaler",
+            "image_url": img,
+            "type": type,
+            "mode": mode,
+            "encode_format": encode_format,
+            "encode_quality": int(encode_quality),
+        }
+
+        if mode == "percent":
+            payload["percent"] = float(percent)
+        else:
+            for key, value in (
+                ("width", width),
+                ("height", height),
+                ("long_side", long_side),
+                ("short_side", short_side),
+            ):
+                if int(value) > 0:
+                    payload[key] = int(value)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/byteplus_video_upscaler.py
+++ b/src/atlascloud_comfyui/nodes/video/byteplus_video_upscaler.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasBytePlusVideoUpscaler:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video_url": ("STRING", {"default": "", "tooltip": "Public HTTP(S) URL of the source video"}),
+            },
+            "optional": {
+                "tool_version": (
+                    ["standard", "professional"],
+                    {"default": "standard", "tooltip": "professional = strongest quality, ~10x the cost"},
+                ),
+                "scene": (
+                    ["common", "ugc", "short_series", "aigc", "old_film"],
+                    {"default": "common", "tooltip": "Scene template (only effective when tool_version=standard)"},
+                ),
+                "resolution": (
+                    ["240p", "360p", "480p", "540p", "720p", "1080p", "2k", "4k", "8k"],
+                    {"default": "1080p", "tooltip": "Target resolution (mutually exclusive with resolution_limit)"},
+                ),
+                "resolution_limit": (
+                    "INT",
+                    {
+                        "default": 0,
+                        "min": 0,
+                        "max": 4320,
+                        "tooltip": "Short-edge pixel cap [128, 4320]; ignored when resolution is set (0 = unset)",
+                    },
+                ),
+                "bitrate_level": (["low", "medium", "high"], {"default": "medium", "tooltip": "Target bitrate tier"}),
+                "fps": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 120, "tooltip": "Frame interpolation target [15, 120] (0 = keep source)"},
+                ),
+                "bit_depth": (
+                    [8, 10, 12],
+                    {"default": 8, "tooltip": "Color bit depth (only effective when tool_version=professional)"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video_url: str,
+        tool_version: str = "standard",
+        scene: str = "common",
+        resolution: str = "1080p",
+        resolution_limit: int = 0,
+        bitrate_level: str = "medium",
+        fps: int = 0,
+        bit_depth: int = 8,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        vid = (video_url or "").strip()
+        if not vid:
+            raise RuntimeError("video_url is required for BytePlus Video Upscaler")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "byteplus/video/upscaler",
+            "video_url": vid,
+            "tool_version": tool_version,
+            "scene": scene,
+            "resolution": resolution,
+            "bitrate_level": bitrate_level,
+            "bit_depth": int(bit_depth),
+        }
+
+        if int(resolution_limit) > 0:
+            payload["resolution_limit"] = int(resolution_limit)
+        if int(fps) > 0:
+            payload["fps"] = int(fps)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/minimax_h3_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/minimax_h3_i2v.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMinimaxH3ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the motion / action"}),
+            },
+            "optional": {
+                "end_image": ("STRING", {"default": "", "tooltip": "Optional last frame image URL or base64"}),
+                "resolution": (["2K"], {"default": "2K", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 8, "min": 5, "max": 15, "tooltip": "Duration (seconds)"}),
+                "ratio": (
+                    ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = let the model choose)"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        end_image: str = "",
+        resolution: str = "2K",
+        duration: int = 8,
+        ratio: str = "adaptive",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required for MiniMax H3 Image-to-Video")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/h3/image-to-video",
+            "image": img,
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+        }
+
+        if (end_image or "").strip():
+            payload["end_image"] = end_image.strip()
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/minimax_h3_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/minimax_h3_r2v.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMinimaxH3ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "refers": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": (
+                            "Reference image/video/audio URLs, one per line "
+                            "(at least one image or video; audio alone is not allowed)"
+                        ),
+                    },
+                ),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the video"}),
+            },
+            "optional": {
+                "resolution": (["2K"], {"default": "2K", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 8, "min": 5, "max": 15, "tooltip": "Duration (seconds)"}),
+                "ratio": (
+                    ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = let the model choose)"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        refers: str,
+        prompt: str,
+        resolution: str = "2K",
+        duration: int = 8,
+        ratio: str = "adaptive",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        urls: List[str] = [v.strip() for v in (refers or "").splitlines() if v.strip()]
+        if not urls:
+            raise RuntimeError("refers is required for MiniMax H3 Reference-to-Video (at least one image or video URL)")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/h3/reference-to-video",
+            "refers": [{"url": u} for u in urls],
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/minimax_h3_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/minimax_h3_t2v.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMinimaxH3TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the video"}),
+            },
+            "optional": {
+                "resolution": (["2K"], {"default": "2K", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 8, "min": 5, "max": 15, "tooltip": "Duration (seconds)"}),
+                "ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str = "2K",
+        duration: int = 8,
+        ratio: str = "1:1",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required for MiniMax H3 Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/h3/text-to-video",
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/tencent_video_upscaler.py
+++ b/src/atlascloud_comfyui/nodes/video/tencent_video_upscaler.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+TEMPLATES: List[str] = [
+    "live-action-enhance-720p",
+    "live-action-enhance-1080p",
+    "live-action-enhance-2k",
+    "live-action-enhance-4k",
+    "anime-enhance-720p",
+    "anime-enhance-1080p",
+    "anime-enhance-2k",
+    "anime-enhance-4k",
+    "restore-720p",
+    "restore-1080p",
+    "restore-2k",
+    "restore-4k",
+    "live-action-smallface-720p",
+    "live-action-smallface-1080p",
+    "live-action-smallface-2k",
+    "live-action-smallface-4k",
+    "anime-smallface-720p",
+    "anime-smallface-1080p",
+    "anime-smallface-2k",
+    "anime-smallface-4k",
+    "seedance2-enhance-720p",
+    "seedance2-enhance-1080p",
+    "seedance2-enhance-2k",
+    "seedance2-enhance-4k",
+]
+
+
+class AtlasTencentVideoUpscaler:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video_url": ("STRING", {"default": "", "tooltip": "Public HTTP(S) URL of the source video"}),
+            },
+            "optional": {
+                "template": (
+                    TEMPLATES,
+                    {"default": "anime-enhance-4k", "tooltip": "Enhancement template (content type + target tier)"},
+                ),
+                "short": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 4320, "tooltip": "Output short edge in pixels (0 = keep source)"},
+                ),
+                "fps": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 120, "tooltip": "Frame-interpolation target FPS (0 = keep source)"},
+                ),
+                "keep_metadata": ("BOOLEAN", {"default": True, "tooltip": "Preserve source media metadata"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video_url: str,
+        template: str = "anime-enhance-4k",
+        short: int = 0,
+        fps: int = 0,
+        keep_metadata: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        vid = (video_url or "").strip()
+        if not vid:
+            raise RuntimeError("video_url is required for Tencent Video Upscaler")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "tencent/video/upscaler",
+            "video_url": vid,
+            "template": template,
+            "short": int(short),
+            "keep_metadata": bool(keep_metadata),
+        }
+
+        if int(fps) > 0:
+            payload["fps"] = int(fps)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -236,6 +236,12 @@ from atlascloud_comfyui.nodes.video.atlascloud_wan_2_2_turbo_spicy_infinite_i2v_
 from atlascloud_comfyui.nodes.video.atlascloud_wan_2_6_spicy_i2v import AtlasWan26SpicyImageToVideo
 from atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_i2v import AtlasWan27SpicyImageToVideo
 from atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_r2v import AtlasWan27SpicyReferenceToVideo
+from atlascloud_comfyui.nodes.video.minimax_h3_t2v import AtlasMinimaxH3TextToVideo
+from atlascloud_comfyui.nodes.video.minimax_h3_i2v import AtlasMinimaxH3ImageToVideo
+from atlascloud_comfyui.nodes.video.minimax_h3_r2v import AtlasMinimaxH3ReferenceToVideo
+from atlascloud_comfyui.nodes.video.byteplus_video_upscaler import AtlasBytePlusVideoUpscaler
+from atlascloud_comfyui.nodes.video.tencent_video_upscaler import AtlasTencentVideoUpscaler
+from atlascloud_comfyui.nodes.image.tencent_image_upscaler import AtlasTencentImageUpscaler
 from atlascloud_comfyui.nodes.video.van25_t2v import AtlasAtlascloudVan25TextToVideo
 from atlascloud_comfyui.nodes.video.van25_i2v import AtlasAtlascloudVan25ImageToVideo
 from atlascloud_comfyui.nodes.video.van26_t2v import AtlasVan26TextToVideo
@@ -641,6 +647,12 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.6 Spicy Image-to-Video": AtlasWan26SpicyImageToVideo,
     "AtlasCloud WAN2.7 Spicy Image-to-Video": AtlasWan27SpicyImageToVideo,
     "AtlasCloud WAN2.7 Spicy Reference-to-Video": AtlasWan27SpicyReferenceToVideo,
+    "AtlasCloud MiniMax H3 Text-to-Video": AtlasMinimaxH3TextToVideo,
+    "AtlasCloud MiniMax H3 Image-to-Video": AtlasMinimaxH3ImageToVideo,
+    "AtlasCloud MiniMax H3 Reference-to-Video": AtlasMinimaxH3ReferenceToVideo,
+    "AtlasCloud Tencent Image Upscaler": AtlasTencentImageUpscaler,
+    "AtlasCloud Tencent Video Upscaler": AtlasTencentVideoUpscaler,
+    "AtlasCloud BytePlus Video Upscaler": AtlasBytePlusVideoUpscaler,
     "AtlasCloud Imagen4 Ultra Text-to-Image": AtlasImagen4UltraTextToImage,
     "AtlasCloud Imagen3 Text-to-Image": AtlasImagen3TextToImage,
     "AtlasCloud Imagen3 Fast Text-to-Image": AtlasImagen3FastTextToImage,
@@ -994,6 +1006,12 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN2.6 Spicy Image-to-Video": "AtlasCloud WAN2.6 Spicy Image-to-Video",
     "AtlasCloud WAN2.7 Spicy Image-to-Video": "AtlasCloud WAN2.7 Spicy Image-to-Video",
     "AtlasCloud WAN2.7 Spicy Reference-to-Video": "AtlasCloud WAN2.7 Spicy Reference-to-Video",
+    "AtlasCloud MiniMax H3 Text-to-Video": "AtlasCloud MiniMax H3 Text-to-Video",
+    "AtlasCloud MiniMax H3 Image-to-Video": "AtlasCloud MiniMax H3 Image-to-Video",
+    "AtlasCloud MiniMax H3 Reference-to-Video": "AtlasCloud MiniMax H3 Reference-to-Video",
+    "AtlasCloud Tencent Image Upscaler": "AtlasCloud Tencent Image Upscaler",
+    "AtlasCloud Tencent Video Upscaler": "AtlasCloud Tencent Video Upscaler",
+    "AtlasCloud BytePlus Video Upscaler": "AtlasCloud BytePlus Video Upscaler",
     "AtlasCloud Imagen4 Ultra Text-to-Image": "AtlasCloud Imagen4 Ultra Text-to-Image",
     "AtlasCloud Imagen3 Text-to-Image": "AtlasCloud Imagen3 Text-to-Image",
     "AtlasCloud Imagen3 Fast Text-to-Image": "AtlasCloud Imagen3 Fast Text-to-Image",

--- a/tests/test_new_nodes_2026_07_31.py
+++ b/tests/test_new_nodes_2026_07_31.py
@@ -1,0 +1,191 @@
+"""Metadata-only tests for newly added nodes (2026-07-31).
+
+New models: MiniMax H3 (T2V / I2V / R2V), Tencent Image Upscaler,
+Tencent Video Upscaler, BytePlus Video Upscaler.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+
+def test_minimax_h3_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_t2v import AtlasMinimaxH3TextToVideo
+
+    inputs = AtlasMinimaxH3TextToVideo.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert optional["resolution"][0] == ["2K"]
+    assert optional["ratio"][0] == ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+    assert optional["ratio"][1]["default"] == "1:1"
+    assert optional["duration"][1]["min"] == 5
+    assert optional["duration"][1]["max"] == 15
+    assert AtlasMinimaxH3TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasMinimaxH3TextToVideo.RETURN_NAMES == ("video_url", "prediction_id")
+    assert AtlasMinimaxH3TextToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_minimax_h3_t2v_requires_prompt():
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_t2v import AtlasMinimaxH3TextToVideo
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasMinimaxH3TextToVideo().run(None, "   ")
+
+
+def test_minimax_h3_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_i2v import AtlasMinimaxH3ImageToVideo
+
+    inputs = AtlasMinimaxH3ImageToVideo.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "image" in required
+    assert "prompt" in required
+    assert "end_image" in optional
+    assert optional["ratio"][0] == ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+    assert optional["ratio"][1]["default"] == "adaptive"
+    assert AtlasMinimaxH3ImageToVideo.RETURN_NAMES == ("video_url", "prediction_id")
+
+
+@pytest.mark.parametrize("bad_image", ["", "   "])
+def test_minimax_h3_i2v_requires_image(bad_image):
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_i2v import AtlasMinimaxH3ImageToVideo
+
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasMinimaxH3ImageToVideo().run(None, bad_image, "a prompt")
+
+
+def test_minimax_h3_i2v_requires_prompt():
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_i2v import AtlasMinimaxH3ImageToVideo
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasMinimaxH3ImageToVideo().run(None, "https://example.com/a.png", "  ")
+
+
+def test_minimax_h3_r2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_r2v import AtlasMinimaxH3ReferenceToVideo
+
+    inputs = AtlasMinimaxH3ReferenceToVideo.INPUT_TYPES()
+    assert "refers" in inputs["required"]
+    assert "prompt" in inputs["required"]
+    assert inputs["optional"]["duration"][1]["default"] == 8
+    assert AtlasMinimaxH3ReferenceToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+@pytest.mark.parametrize("bad_refers", ["", "  \n \n"])
+def test_minimax_h3_r2v_requires_refers(bad_refers):
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_r2v import AtlasMinimaxH3ReferenceToVideo
+
+    with pytest.raises(RuntimeError, match="refers is required"):
+        AtlasMinimaxH3ReferenceToVideo().run(None, bad_refers, "a prompt")
+
+
+def test_minimax_h3_r2v_wraps_refers_as_objects():
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_r2v import AtlasMinimaxH3ReferenceToVideo
+
+    source = inspect.getsource(AtlasMinimaxH3ReferenceToVideo.run)
+    assert '"refers": [{"url": u} for u in urls]' in source
+
+
+def test_tencent_image_upscaler_metadata():
+    from src.atlascloud_comfyui.nodes.image.tencent_image_upscaler import AtlasTencentImageUpscaler
+
+    inputs = AtlasTencentImageUpscaler.INPUT_TYPES()
+    optional = inputs["optional"]
+    assert "image_url" in inputs["required"]
+    assert optional["type"][0] == ["standard", "super", "ultra", "fidelity"]
+    assert optional["mode"][0] == ["percent", "aspect", "fixed"]
+    assert optional["encode_format"][0] == ["JPEG", "PNG", "WEBP", "BMP"]
+    assert AtlasTencentImageUpscaler.CATEGORY == "AtlasCloud/Image"
+    assert AtlasTencentImageUpscaler.RETURN_NAMES == ("image_url", "prediction_id")
+
+
+def test_tencent_image_upscaler_requires_image_url():
+    from src.atlascloud_comfyui.nodes.image.tencent_image_upscaler import AtlasTencentImageUpscaler
+
+    with pytest.raises(RuntimeError, match="image_url is required"):
+        AtlasTencentImageUpscaler().run(None, "  ")
+
+
+def test_tencent_video_upscaler_metadata():
+    from src.atlascloud_comfyui.nodes.video.tencent_video_upscaler import (
+        TEMPLATES,
+        AtlasTencentVideoUpscaler,
+    )
+
+    inputs = AtlasTencentVideoUpscaler.INPUT_TYPES()
+    optional = inputs["optional"]
+    assert "video_url" in inputs["required"]
+    assert optional["template"][0] == TEMPLATES
+    assert optional["template"][1]["default"] == "anime-enhance-4k"
+    assert len(TEMPLATES) == 24
+    assert optional["keep_metadata"][1]["default"] is True
+
+
+def test_tencent_video_upscaler_requires_video_url():
+    from src.atlascloud_comfyui.nodes.video.tencent_video_upscaler import AtlasTencentVideoUpscaler
+
+    with pytest.raises(RuntimeError, match="video_url is required"):
+        AtlasTencentVideoUpscaler().run(None, "")
+
+
+def test_byteplus_video_upscaler_metadata():
+    from src.atlascloud_comfyui.nodes.video.byteplus_video_upscaler import AtlasBytePlusVideoUpscaler
+
+    inputs = AtlasBytePlusVideoUpscaler.INPUT_TYPES()
+    optional = inputs["optional"]
+    assert "video_url" in inputs["required"]
+    assert optional["tool_version"][0] == ["standard", "professional"]
+    assert optional["scene"][0] == ["common", "ugc", "short_series", "aigc", "old_film"]
+    assert optional["resolution"][0] == ["240p", "360p", "480p", "540p", "720p", "1080p", "2k", "4k", "8k"]
+    assert optional["bitrate_level"][0] == ["low", "medium", "high"]
+    assert optional["bit_depth"][0] == [8, 10, 12]
+
+
+def test_byteplus_video_upscaler_requires_video_url():
+    from src.atlascloud_comfyui.nodes.video.byteplus_video_upscaler import AtlasBytePlusVideoUpscaler
+
+    with pytest.raises(RuntimeError, match="video_url is required"):
+        AtlasBytePlusVideoUpscaler().run(None, "   ")
+
+
+def test_new_nodes_2026_07_31_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    keys = [
+        "AtlasCloud MiniMax H3 Text-to-Video",
+        "AtlasCloud MiniMax H3 Image-to-Video",
+        "AtlasCloud MiniMax H3 Reference-to-Video",
+        "AtlasCloud Tencent Image Upscaler",
+        "AtlasCloud Tencent Video Upscaler",
+        "AtlasCloud BytePlus Video Upscaler",
+    ]
+    for key in keys:
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_07_31_model_ids():
+    from src.atlascloud_comfyui.nodes.image.tencent_image_upscaler import AtlasTencentImageUpscaler
+    from src.atlascloud_comfyui.nodes.video.byteplus_video_upscaler import AtlasBytePlusVideoUpscaler
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_i2v import AtlasMinimaxH3ImageToVideo
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_r2v import AtlasMinimaxH3ReferenceToVideo
+    from src.atlascloud_comfyui.nodes.video.minimax_h3_t2v import AtlasMinimaxH3TextToVideo
+    from src.atlascloud_comfyui.nodes.video.tencent_video_upscaler import AtlasTencentVideoUpscaler
+
+    expected = [
+        (AtlasMinimaxH3TextToVideo, "minimax/h3/text-to-video"),
+        (AtlasMinimaxH3ImageToVideo, "minimax/h3/image-to-video"),
+        (AtlasMinimaxH3ReferenceToVideo, "minimax/h3/reference-to-video"),
+        (AtlasTencentImageUpscaler, "tencent/image/upscaler"),
+        (AtlasTencentVideoUpscaler, "tencent/video/upscaler"),
+        (AtlasBytePlusVideoUpscaler, "byteplus/video/upscaler"),
+    ]
+    for cls, model_id in expected:
+        source = inspect.getsource(cls.run)
+        assert f'"model": "{model_id}"' in source


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync.

## New models

| Node | Model ID |
| --- | --- |
| AtlasCloud MiniMax H3 Text-to-Video | `minimax/h3/text-to-video` |
| AtlasCloud MiniMax H3 Image-to-Video | `minimax/h3/image-to-video` |
| AtlasCloud MiniMax H3 Reference-to-Video | `minimax/h3/reference-to-video` |
| AtlasCloud Tencent Image Upscaler | `tencent/image/upscaler` |
| AtlasCloud Tencent Video Upscaler | `tencent/video/upscaler` |
| AtlasCloud BytePlus Video Upscaler | `byteplus/video/upscaler` |

Params follow each model's published schema (H3: 2K only, duration 5-15s, ratio enums incl. `adaptive` for I2V/R2V; R2V wraps each reference URL as `{"url": ...}` and lets the backend infer media type). Upscalers send only the fields the schema marks as active (e.g. `resolution_limit`/`fps` omitted when unset, `percent` only for `mode=percent`).

Registry + README table updated.

## Out of scope

7 further missing visual models are `*-to-3d` (`bytedance/seed3d-v2.0`, `tencent/hunyuan3d-*`, `tripo-h3.1/*`). They are typed `Image` but output mesh archives, so no image-node contract fits — skipped, consistent with prior syncs.

## Tests

- `ruff check .` — clean
- `pytest tests/ -k "not e2e"` — 399 passed, 26 deselected
- New metadata-only tests in `tests/test_new_nodes_2026_07_31.py` (no live API calls)
- E2E not run locally (no ComfyUI source on the sync machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)