### PR TITLE
sync: add 2 AtlasCloud models (2026-08-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Grok Imagine Video Image-to-Video | xai/grok-imagine-video/image-to-video |
 | AtlasCloud Grok Imagine Video v1.5 Image-to-Video | xai/grok-imagine-video-v1.5/image-to-video |
 | AtlasCloud Grok Imagine Video Reference-to-Video | xai/grok-imagine-video/reference-to-video |
+| AtlasCloud Grok Imagine Video v1.5 Text-to-Video | xai/grok-imagine-video-v1.5/text-to-video |
+| AtlasCloud Grok Imagine Video v1.5 Reference-to-Video | xai/grok-imagine-video-v1.5/reference-to-video |
 | AtlasCloud Grok Imagine Video Edit | xai/grok-imagine-video/edit-video |
 | AtlasCloud Grok Imagine Video Extend | xai/grok-imagine-video/extend-video |
 | AtlasCloud VEO3.1 Reference-to-Video | google/veo3.1/reference-to-video |

--- a/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_v15_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_v15_r2v.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+VOICE_IDS = [
+    "altair",
+    "ara",
+    "atlas",
+    "carina",
+    "castor",
+    "celeste",
+    "cosmo",
+    "eve",
+    "helios",
+    "helix",
+    "iris",
+    "kepler",
+    "leo",
+    "lumen",
+    "luna",
+    "lux",
+    "naksh",
+    "orion",
+    "perseus",
+    "rex",
+    "rigel",
+    "sal",
+    "sirius",
+    "ursa",
+    "zagan",
+    "zenith",
+]
+
+
+class AtlasGrokImagineVideoV15ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Video prompt; use <IMAGE_N> tags to reference inputs"}),
+                "image_urls": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "1-7 reference images, one per line (URL or base64)"},
+                ),
+            },
+            "optional": {
+                "voice_ids": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": f"Optional xAI preset voices, one per line (max 3). Allowed: {', '.join(VOICE_IDS)}",
+                    },
+                ),
+                "duration": ("INT", {"default": 8, "min": 1, "max": 15, "tooltip": "Duration (seconds, 1-15)"}),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Output resolution (capped at 720p)"}),
+                "aspect_ratio": (
+                    ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"],
+                    {"default": "16:9", "tooltip": "Output aspect ratio"},
+                ),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_urls: str,
+        voice_ids: str = "",
+        duration: int = 8,
+        resolution: str = "720p",
+        aspect_ratio: str = "16:9",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        urls: List[str] = [v.strip() for v in (image_urls or "").splitlines() if v.strip()]
+        if not urls:
+            raise RuntimeError("image_urls is required (1-7 lines)")
+        if len(urls) > 7:
+            raise RuntimeError("image_urls maxItems is 7")
+
+        voices: List[str] = [v.strip() for v in (voice_ids or "").splitlines() if v.strip()]
+        if len(voices) > 3:
+            raise RuntimeError("voice_ids maxItems is 3")
+        unknown = [v for v in voices if v not in VOICE_IDS]
+        if unknown:
+            raise RuntimeError(f"Unknown voice_ids {unknown}; allowed: {', '.join(VOICE_IDS)}")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-video-v1.5/reference-to-video",
+            "prompt": prompt,
+            "image_urls": urls,
+            "duration": int(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+        }
+        if voices:
+            payload["voice_ids"] = voices
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_v15_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_v15_t2v.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineVideoV15TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Text prompt; native synchronized audio is generated in the same pass"},
+                ),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 8, "min": 1, "max": 15, "tooltip": "Duration (seconds, 1-15)"}),
+                "resolution": (["480p", "720p", "1080p"], {"default": "720p", "tooltip": "Output resolution"}),
+                "aspect_ratio": (
+                    ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"],
+                    {"default": "16:9", "tooltip": "Output aspect ratio"},
+                ),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 8,
+        resolution: str = "720p",
+        aspect_ratio: str = "16:9",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-video-v1.5/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -98,6 +98,8 @@ from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_t2v import AtlasGrokI
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_i2v import AtlasGrokImagineVideoImageToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_i2v import AtlasGrokImagineVideoV15ImageToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_r2v import AtlasGrokImagineVideoReferenceToVideo
+from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_t2v import AtlasGrokImagineVideoV15TextToVideo
+from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import AtlasGrokImagineVideoV15ReferenceToVideo
 from atlascloud_comfyui.nodes.image.flux2_pro_t2i import AtlasFlux2ProTextToImage
 from atlascloud_comfyui.nodes.image.flux2_flex_edit import AtlasFlux2FlexEdit
 from atlascloud_comfyui.nodes.image.flux2_pro_edit import AtlasFlux2ProEdit
@@ -758,6 +760,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Grok Imagine Video Image-to-Video": AtlasGrokImagineVideoImageToVideo,
     "AtlasCloud Grok Imagine Video v1.5 Image-to-Video": AtlasGrokImagineVideoV15ImageToVideo,
     "AtlasCloud Grok Imagine Video Reference-to-Video": AtlasGrokImagineVideoReferenceToVideo,
+    "AtlasCloud Grok Imagine Video v1.5 Text-to-Video": AtlasGrokImagineVideoV15TextToVideo,
+    "AtlasCloud Grok Imagine Video v1.5 Reference-to-Video": AtlasGrokImagineVideoV15ReferenceToVideo,
     "AtlasCloud FLUX.2 Pro Text-to-Image": AtlasFlux2ProTextToImage,
     "AtlasCloud FLUX.2 Flex Edit": AtlasFlux2FlexEdit,
     "AtlasCloud FLUX.2 Pro Edit": AtlasFlux2ProEdit,
@@ -1115,6 +1119,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Grok Imagine Video Image-to-Video": "AtlasCloud Grok Imagine Video Image-to-Video",
     "AtlasCloud Grok Imagine Video v1.5 Image-to-Video": "AtlasCloud Grok Imagine Video v1.5 Image-to-Video",
     "AtlasCloud Grok Imagine Video Reference-to-Video": "AtlasCloud Grok Imagine Video Reference-to-Video",
+    "AtlasCloud Grok Imagine Video v1.5 Text-to-Video": "AtlasCloud Grok Imagine Video v1.5 Text-to-Video",
+    "AtlasCloud Grok Imagine Video v1.5 Reference-to-Video": "AtlasCloud Grok Imagine Video v1.5 Reference-to-Video",
     "AtlasCloud FLUX.2 Pro Text-to-Image": "AtlasCloud FLUX.2 Pro Text-to-Image",
     "AtlasCloud FLUX.2 Flex Edit": "AtlasCloud FLUX.2 Flex Edit",
     "AtlasCloud FLUX.2 Pro Edit": "AtlasCloud FLUX.2 Pro Edit",

--- a/tests/test_new_nodes_2026_08_01.py
+++ b/tests/test_new_nodes_2026_08_01.py
@@ -1,0 +1,159 @@
+"""Metadata-only tests for newly added nodes (2026-08-01).
+
+New models: Grok Imagine Video v1.5 (T2V / R2V).
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+
+def test_grok_imagine_video_v15_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_t2v import (
+        AtlasGrokImagineVideoV15TextToVideo,
+    )
+
+    inputs = AtlasGrokImagineVideoV15TextToVideo.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert optional["resolution"][0] == ["480p", "720p", "1080p"]
+    assert optional["resolution"][1]["default"] == "720p"
+    assert optional["aspect_ratio"][0] == ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]
+    assert optional["duration"][1]["min"] == 1
+    assert optional["duration"][1]["max"] == 15
+    assert optional["duration"][1]["default"] == 8
+    assert AtlasGrokImagineVideoV15TextToVideo.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasGrokImagineVideoV15TextToVideo.RETURN_NAMES == ("video_url", "prediction_id")
+    assert AtlasGrokImagineVideoV15TextToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "   "])
+def test_grok_imagine_video_v15_t2v_requires_prompt(bad_prompt):
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_t2v import (
+        AtlasGrokImagineVideoV15TextToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasGrokImagineVideoV15TextToVideo().run(None, bad_prompt)
+
+
+def test_grok_imagine_video_v15_r2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import (
+        VOICE_IDS,
+        AtlasGrokImagineVideoV15ReferenceToVideo,
+    )
+
+    inputs = AtlasGrokImagineVideoV15ReferenceToVideo.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "prompt" in required
+    assert "image_urls" in required
+    assert "voice_ids" in optional
+    assert optional["resolution"][0] == ["480p", "720p"]
+    assert optional["duration"][1]["max"] == 15
+    assert len(VOICE_IDS) == 26
+    assert "altair" in VOICE_IDS and "zenith" in VOICE_IDS
+    assert AtlasGrokImagineVideoV15ReferenceToVideo.RETURN_NAMES == ("video_url", "prediction_id")
+    assert AtlasGrokImagineVideoV15ReferenceToVideo.CATEGORY == "AtlasCloud/Video"
+
+
+def test_grok_imagine_video_v15_r2v_requires_prompt():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import (
+        AtlasGrokImagineVideoV15ReferenceToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasGrokImagineVideoV15ReferenceToVideo().run(None, "  ", "https://example.com/a.png")
+
+
+@pytest.mark.parametrize("bad_urls", ["", "  \n \n"])
+def test_grok_imagine_video_v15_r2v_requires_image_urls(bad_urls):
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import (
+        AtlasGrokImagineVideoV15ReferenceToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="image_urls is required"):
+        AtlasGrokImagineVideoV15ReferenceToVideo().run(None, "a prompt", bad_urls)
+
+
+def test_grok_imagine_video_v15_r2v_rejects_too_many_images():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import (
+        AtlasGrokImagineVideoV15ReferenceToVideo,
+    )
+
+    urls = "\n".join(f"https://example.com/{i}.png" for i in range(8))
+    with pytest.raises(RuntimeError, match="image_urls maxItems is 7"):
+        AtlasGrokImagineVideoV15ReferenceToVideo().run(None, "a prompt", urls)
+
+
+def test_grok_imagine_video_v15_r2v_rejects_too_many_voices():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import (
+        AtlasGrokImagineVideoV15ReferenceToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="voice_ids maxItems is 3"):
+        AtlasGrokImagineVideoV15ReferenceToVideo().run(
+            None,
+            "a prompt",
+            "https://example.com/a.png",
+            "altair\nara\natlas\ncarina",
+        )
+
+
+def test_grok_imagine_video_v15_r2v_rejects_unknown_voice():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import (
+        AtlasGrokImagineVideoV15ReferenceToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="Unknown voice_ids"):
+        AtlasGrokImagineVideoV15ReferenceToVideo().run(
+            None,
+            "a prompt",
+            "https://example.com/a.png",
+            "not-a-voice",
+        )
+
+
+def test_grok_imagine_video_v15_r2v_voice_ids_optional_in_payload():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import (
+        AtlasGrokImagineVideoV15ReferenceToVideo,
+    )
+
+    source = inspect.getsource(AtlasGrokImagineVideoV15ReferenceToVideo.run)
+    assert 'payload["voice_ids"] = voices' in source
+    assert "if voices:" in source
+
+
+def test_new_nodes_2026_08_01_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    keys = [
+        "AtlasCloud Grok Imagine Video v1.5 Text-to-Video",
+        "AtlasCloud Grok Imagine Video v1.5 Reference-to-Video",
+    ]
+    for key in keys:
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_08_01_model_ids():
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_r2v import (
+        AtlasGrokImagineVideoV15ReferenceToVideo,
+    )
+    from src.atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_t2v import (
+        AtlasGrokImagineVideoV15TextToVideo,
+    )
+
+    expected = [
+        (AtlasGrokImagineVideoV15TextToVideo, "xai/grok-imagine-video-v1.5/text-to-video"),
+        (AtlasGrokImagineVideoV15ReferenceToVideo, "xai/grok-imagine-video-v1.5/reference-to-video"),
+    ]
+    for cls, model_id in expected:
+        source = inspect.getsource(cls.run)
+        assert f'"model": "{model_id}"' in source


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync.

## New models
- \`xai/grok-imagine-video-v1.5/text-to-video\` → `AtlasCloud Grok Imagine Video v1.5 Text-to-Video` (480p/720p/1080p, 1-15s)
- \`xai/grok-imagine-video-v1.5/reference-to-video\` → `AtlasCloud Grok Imagine Video v1.5 Reference-to-Video` (1-7 reference images, optional `voice_ids` preset voices max 3, capped at 720p)

Both follow the existing `xai_grok_imagine_video_*` node style: no comfy/folder_paths/requests imports at module level, exact model id in payload, `poll_prediction` + `outputs[0]`, required-input validation.

## Changes
- `src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_v15_t2v.py` (new)
- `src/atlascloud_comfyui/nodes/video/xai_grok_imagine_video_v15_r2v.py` (new)
- `src/atlascloud_comfyui/registry.py`: imports + `NODE_CLASS_MAPPINGS` + `NODE_DISPLAY_NAME_MAPPINGS`
- `README.md`: Available Nodes table
- `tests/test_new_nodes_2026_08_01.py` (new, metadata-only — no API key required)

## Testing
- `ruff check .` → All checks passed
- `pytest tests/ -k "not e2e"` → 412 passed, 26 deselected

E2E not run locally (no ComfyUI source on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)