### PR TITLE
chore: set Comfy Registry PublisherId to atlascloud

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,17 +32,17 @@ dev = [
 ]
 
 [project.urls]
-Repository = "https://github.com/AtlascloudAI/atlascloud_comfyui"
-BugTracker = "https://github.com/AtlascloudAI/atlascloud_comfyui/issues"
-Documentation = "https://github.com/AtlascloudAI/atlascloud_comfyui/wiki"
+Repository = "https://github.com/AtlasCloudAI/atlascloud_comfyui"
+BugTracker = "https://github.com/AtlasCloudAI/atlascloud_comfyui/issues"
+Documentation = "https://github.com/AtlasCloudAI/atlascloud_comfyui/wiki"
 
 
 [tool.comfy]
-PublisherId = "YC0101"
+PublisherId = "atlascloud"
 DisplayName = "AtlasCloud_ComfyUI"
 Icon = ""
 Tags = []
-Repository = "https://github.com/AtlascloudAI/atlascloud_comfyui"
+Repository = "https://github.com/AtlasCloudAI/atlascloud_comfyui"
 
 includes = ["src/atlascloud_comfyui"]
 


### PR DESCRIPTION
发布到 Comfy Registry 的前置改动。

**为什么**：`publish_node.yml` 已配好（`Comfy-Org/publish-node-action` + secret `REGISTRY_ACCESS_TOKEN`），但 registry 侧从未注册过 publisher —— `api.comfy.org/publishers/YC0101` 返回 Publisher not found，名下节点数 0，workflow 因为仓库从未打过 tag 也一次没跑过。所以官方节点目前不在 registry，也不在 ComfyUI-Manager 列表里（那边只有第三方 `clownvary/ComfyUI-AtlasCloud` 0★ 占位，已另提 PR: Comfy-Org/ComfyUI-Manager#3122）。

**改了什么**
- `PublisherId`: `YC0101` → `atlascloud`。publisher handle 会公开显示在节点页（形如 `@kijai`、`@rgthree`），且注册后永久不可改，所以用品牌名。
- 顺带修正 `Repository` 等 4 处 URL 里 `AtlascloudAI` 的大小写 → `AtlasCloudAI`。

**合并后的发布顺序**（需要先做完 1、2 再合，否则 workflow 会红）
1. 在 https://registry.comfy.org 用 GitHub 登录，创建 publisher，handle 填 `atlascloud`
2. 该 publisher 下创建 API key，加到本仓库 secret，名字必须是 `REGISTRY_ACCESS_TOKEN`
3. 合并本 PR
4. 打 tag `v0.0.1` 并 push（workflow 由 push tag 触发），或直接 workflow_dispatch