### PR TITLE
sync: add 2 AtlasCloud models (2026-08-05)

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud ZImage Turbo Lora Text-to-Image | z-image/turbo-lora |
 | AtlasCloud Qwen Image Text-to-Image Plus | alibaba/qwen-image/text-to-image-plus |
 | AtlasCloud Qwen Image Text-to-Image Max | alibaba/qwen-image/text-to-image-max |
+| AtlasCloud Qwen Image 3.0 Text-to-Image | qwen-image-3.0/text-to-image |
 | AtlasCloud Grok Imagine IQ Text-to-Image | xai/grok-imagine-image-quality/text-to-image |
 | AtlasCloud Grok Imagine Text-to-Image | xai/grok-imagine-image/text-to-image |
 | AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
@@ -476,6 +477,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Flux Kontext Dev Edit | black-forest-labs/flux-kontext-dev |
 | AtlasCloud Flux Kontext Dev LoRA Edit | black-forest-labs/flux-kontext-dev-lora |
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
+| AtlasCloud Qwen Image 3.0 Edit | qwen-image-3.0/edit |
 | AtlasCloud Grok Imagine IQ Edit | xai/grok-imagine-image-quality/edit |
 | AtlasCloud Grok Imagine Edit | xai/grok-imagine-image/edit |
 | AtlasCloud GPT Image-2 Edit | openai/gpt-image-2/edit |

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_30_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_30_edit.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_PROMPT_EXTEND_MODES = ["direct", "agent"]
+
+
+class AtlasQwenImage30Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Editing instruction for the reference image(s)"}),
+                "reference_image_urls": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "1-3 reference image URLs/base64, ONE PER LINE"},
+                ),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Output resolution as width*height (512*512-1440*1440). Leave empty to let the model pick",
+                    },
+                ),
+                "n": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images to generate"}),
+                "negative_prompt": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "Content that should NOT appear in the image"},
+                ),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2**31 - 1,
+                        "tooltip": "Random seed (-1 for random)",
+                    },
+                ),
+                "prompt_extend": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Enable intelligent prompt rewriting"},
+                ),
+                "prompt_extend_mode": (
+                    _PROMPT_EXTEND_MODES,
+                    {"default": "direct", "tooltip": "Prompt rewriting strategy: direct (DPE) or agent (APE)"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        reference_image_urls: str,
+        size: str = "",
+        n: int = 1,
+        negative_prompt: str = "",
+        seed: int = -1,
+        prompt_extend: bool = True,
+        prompt_extend_mode: str = "direct",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        # Split on newlines, NOT commas: base64 data URLs contain a comma.
+        refs: List[str] = [u.strip() for u in (reference_image_urls or "").splitlines() if u.strip()]
+        if not refs:
+            raise RuntimeError("reference_image_urls is required (1-3 lines)")
+        if len(refs) > 3:
+            raise RuntimeError("reference_image_urls maxItems is 3")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "qwen-image-3.0/edit",
+            "prompt": p,
+            "reference_image_urls": refs,
+            "n": int(n),
+            "prompt_extend": bool(prompt_extend),
+            "prompt_extend_mode": prompt_extend_mode,
+        }
+
+        sz = (size or "").strip()
+        if sz:
+            payload["size"] = sz
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+        if seed >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/qwen_image_30_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/qwen_image_30_t2i.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_PROMPT_EXTEND_MODES = ["direct", "agent"]
+
+
+class AtlasQwenImage30TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the image to generate"}),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Output resolution as width*height (512*512-2048*2048). Leave empty to let the model pick",
+                    },
+                ),
+                "n": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images to generate"}),
+                "negative_prompt": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "Content that should NOT appear in the image"},
+                ),
+                "seed": (
+                    "INT",
+                    {
+                        "default": -1,
+                        "min": -1,
+                        "max": 2**31 - 1,
+                        "tooltip": "Random seed (-1 for random)",
+                    },
+                ),
+                "prompt_extend": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Enable intelligent prompt rewriting"},
+                ),
+                "prompt_extend_mode": (
+                    _PROMPT_EXTEND_MODES,
+                    {"default": "direct", "tooltip": "Prompt rewriting strategy: direct (DPE) or agent (APE)"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "",
+        n: int = 1,
+        negative_prompt: str = "",
+        seed: int = -1,
+        prompt_extend: bool = True,
+        prompt_extend_mode: str = "direct",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "qwen-image-3.0/text-to-image",
+            "prompt": p,
+            "n": int(n),
+            "prompt_extend": bool(prompt_extend),
+            "prompt_extend_mode": prompt_extend_mode,
+        }
+
+        sz = (size or "").strip()
+        if sz:
+            payload["size"] = sz
+        neg = (negative_prompt or "").strip()
+        if neg:
+            payload["negative_prompt"] = neg
+        if seed >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -216,6 +216,8 @@ from atlascloud_comfyui.nodes.image.qwen_image_20_t2i import AtlasQwenImage20Tex
 from atlascloud_comfyui.nodes.image.qwen_image_20_edit import AtlasQwenImage20Edit
 from atlascloud_comfyui.nodes.image.qwen_image_20_pro_t2i import AtlasQwenImage20ProTextToImage
 from atlascloud_comfyui.nodes.image.qwen_image_20_pro_edit import AtlasQwenImage20ProEdit
+from atlascloud_comfyui.nodes.image.qwen_image_30_t2i import AtlasQwenImage30TextToImage
+from atlascloud_comfyui.nodes.image.qwen_image_30_edit import AtlasQwenImage30Edit
 
 from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_t2v import AtlasSeedanceV1ProFastTextToVideo
 from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_i2v import AtlasSeedanceV1ProFastImageToVideo
@@ -693,6 +695,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Qwen Image 2.0 Edit": AtlasQwenImage20Edit,
     "AtlasCloud Qwen Image 2.0 Pro Text-to-Image": AtlasQwenImage20ProTextToImage,
     "AtlasCloud Qwen Image 2.0 Pro Edit": AtlasQwenImage20ProEdit,
+    "AtlasCloud Qwen Image 3.0 Text-to-Image": AtlasQwenImage30TextToImage,
+    "AtlasCloud Qwen Image 3.0 Edit": AtlasQwenImage30Edit,
     "AtlasCloud Seedance V1 Pro Fast Text-to-Video": AtlasSeedanceV1ProFastTextToVideo,
     "AtlasCloud Seedance V1 Pro Fast Image-to-Video": AtlasSeedanceV1ProFastImageToVideo,
     "AtlasCloud Seedance V1 Pro Image-to-Video 1080p": AtlasBytedanceSeedanceV1ProI2V1080p,
@@ -1052,6 +1056,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Qwen Image 2.0 Edit": "AtlasCloud Qwen Image 2.0 Edit",
     "AtlasCloud Qwen Image 2.0 Pro Text-to-Image": "AtlasCloud Qwen Image 2.0 Pro Text-to-Image",
     "AtlasCloud Qwen Image 2.0 Pro Edit": "AtlasCloud Qwen Image 2.0 Pro Edit",
+    "AtlasCloud Qwen Image 3.0 Text-to-Image": "AtlasCloud Qwen Image 3.0 Text-to-Image",
+    "AtlasCloud Qwen Image 3.0 Edit": "AtlasCloud Qwen Image 3.0 Edit",
     "AtlasCloud Seedance V1 Pro Fast Text-to-Video": "AtlasCloud Seedance V1 Pro Fast Text-to-Video",
     "AtlasCloud Seedance V1 Pro Fast Image-to-Video": "AtlasCloud Seedance V1 Pro Fast Image-to-Video",
     "AtlasCloud Seedance V1 Pro Image-to-Video 1080p": "AtlasCloud Seedance V1 Pro Image-to-Video 1080p",

--- a/tests/test_new_nodes_2026_08_05.py
+++ b/tests/test_new_nodes_2026_08_05.py
@@ -1,0 +1,132 @@
+"""Metadata-only tests for newly added nodes (2026-08-05).
+
+New models: Qwen Image 3.0 (Text-to-Image / Edit).
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+
+def test_qwen_image_30_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_t2i import (
+        AtlasQwenImage30TextToImage,
+    )
+
+    inputs = AtlasQwenImage30TextToImage.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert optional["n"][1]["min"] == 1
+    assert optional["n"][1]["max"] == 4
+    assert optional["n"][1]["default"] == 1
+    assert optional["prompt_extend"][0] == "BOOLEAN"
+    assert optional["prompt_extend"][1]["default"] is True
+    assert optional["prompt_extend_mode"][0] == ["direct", "agent"]
+    assert optional["prompt_extend_mode"][1]["default"] == "direct"
+    assert optional["seed"][1]["min"] == -1
+    assert AtlasQwenImage30TextToImage.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasQwenImage30TextToImage.RETURN_NAMES == ("image_url", "prediction_id")
+    assert AtlasQwenImage30TextToImage.CATEGORY == "AtlasCloud/Image"
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "   "])
+def test_qwen_image_30_t2i_requires_prompt(bad_prompt):
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_t2i import (
+        AtlasQwenImage30TextToImage,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasQwenImage30TextToImage().run(None, bad_prompt)
+
+
+def test_qwen_image_30_t2i_omits_optional_fields():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_t2i import (
+        AtlasQwenImage30TextToImage,
+    )
+
+    source = inspect.getsource(AtlasQwenImage30TextToImage.run)
+    assert 'payload["size"] = sz' in source
+    assert 'payload["negative_prompt"] = neg' in source
+    assert "if seed >= 0:" in source
+
+
+def test_qwen_image_30_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_edit import (
+        AtlasQwenImage30Edit,
+    )
+
+    inputs = AtlasQwenImage30Edit.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert "reference_image_urls" in required
+    assert optional["n"][1]["max"] == 4
+    assert optional["prompt_extend_mode"][0] == ["direct", "agent"]
+    assert AtlasQwenImage30Edit.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasQwenImage30Edit.RETURN_NAMES == ("image_url", "prediction_id")
+    assert AtlasQwenImage30Edit.CATEGORY == "AtlasCloud/Image"
+
+
+def test_qwen_image_30_edit_requires_prompt():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_edit import (
+        AtlasQwenImage30Edit,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasQwenImage30Edit().run(None, "  ", "https://example.com/a.png")
+
+
+@pytest.mark.parametrize("bad_refs", ["", "  \n \n"])
+def test_qwen_image_30_edit_requires_reference_images(bad_refs):
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_edit import (
+        AtlasQwenImage30Edit,
+    )
+
+    with pytest.raises(RuntimeError, match="reference_image_urls is required"):
+        AtlasQwenImage30Edit().run(None, "a prompt", bad_refs)
+
+
+def test_qwen_image_30_edit_rejects_too_many_reference_images():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_edit import (
+        AtlasQwenImage30Edit,
+    )
+
+    urls = "\n".join(f"https://example.com/{i}.png" for i in range(4))
+    with pytest.raises(RuntimeError, match="reference_image_urls maxItems is 3"):
+        AtlasQwenImage30Edit().run(None, "a prompt", urls)
+
+
+def test_new_nodes_2026_08_05_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    keys = [
+        "AtlasCloud Qwen Image 3.0 Text-to-Image",
+        "AtlasCloud Qwen Image 3.0 Edit",
+    ]
+    for key in keys:
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_08_05_model_ids():
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_edit import (
+        AtlasQwenImage30Edit,
+    )
+    from src.atlascloud_comfyui.nodes.image.qwen_image_30_t2i import (
+        AtlasQwenImage30TextToImage,
+    )
+
+    expected = [
+        (AtlasQwenImage30TextToImage, "qwen-image-3.0/text-to-image"),
+        (AtlasQwenImage30Edit, "qwen-image-3.0/edit"),
+    ]
+    for cls, model_id in expected:
+        source = inspect.getsource(cls.run)
+        assert f'"model": "{model_id}"' in source


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync.

## New models

| Node | Model ID |
| --- | --- |
| AtlasCloud Qwen Image 3.0 Text-to-Image | `qwen-image-3.0/text-to-image` |
| AtlasCloud Qwen Image 3.0 Edit | `qwen-image-3.0/edit` |

Both nodes follow the published schemas: `n` (1-4), `negative_prompt`, `seed` (omitted when -1), `prompt_extend` / `prompt_extend_mode` (`direct` | `agent`), and an optional `size` (omitted when blank so the model picks a resolution). The Edit node takes 1-3 `reference_image_urls` (one per line, newline-split so base64 data URIs survive) and validates both the empty and >3 cases.

## Testing

- `python3 -m ruff check .` → All checks passed
- `python3 -m pytest tests/ -k "not e2e"` → 423 passed, 26 deselected

E2E was skipped: no ComfyUI source on the sync machine, so only metadata-level tests were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)