### PR TITLE
sync: add 7 AtlasCloud models (2026-08-06)

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,13 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud LTX 2.3 Quality Text-to-Video | ltx-2.3-quality/text-to-video |
 | AtlasCloud LTX 2.3 Quality Image-to-Video | ltx-2.3-quality/image-to-video |
 | AtlasCloud LTX 2.3 Quality Extend Video | ltx-2.3-quality/extend-video |
+| AtlasCloud FLUX 3 Text-to-Video | black-forest-labs/flux-3/text-to-video |
+| AtlasCloud FLUX 3 Image-to-Video | black-forest-labs/flux-3/image-to-video |
+| AtlasCloud FLUX 3 First & Last Frame to Video | black-forest-labs/flux-3/first-last-frame-to-video |
+| AtlasCloud FLUX 3 Keyframes to Video | black-forest-labs/flux-3/keyframes-to-video |
+| AtlasCloud FLUX 3 Extend Video | black-forest-labs/flux-3/extend-video |
+| AtlasCloud Kling V3.0 Pro Motion Control | kwaivgi/kling-v3.0-pro/motion-control |
+| AtlasCloud Kling V3.0 Std Motion Control | kwaivgi/kling-v3.0-std/motion-control |
 
 > Nodes are continuously expanded as new models are added to AtlasCloud.
 

--- a/src/atlascloud_comfyui/nodes/video/flux3_extend_video.py
+++ b/src/atlascloud_comfyui/nodes/video/flux3_extend_video.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_ASPECT_RATIOS = ["auto", "21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"]
+_RESOLUTIONS = ["720p", "1080p"]
+
+
+class AtlasFlux3ExtendVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video_url": (
+                    "STRING",
+                    {"default": "", "tooltip": "URL of the input video to extend (mp4, under 50MB and under 15s)"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": "How the video continues from the source clip's final frames",
+                    },
+                ),
+                "aspect_ratio": (
+                    _ASPECT_RATIOS,
+                    {"default": "auto", "tooltip": "Aspect ratio of the generated video ('auto' lets the model choose)"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 5, "min": 5, "max": 20, "tooltip": "Duration (seconds, 5-20)"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio for the video"}),
+                "safety_tolerance": (
+                    "INT",
+                    {"default": 2, "min": 0, "max": 4, "tooltip": "Safety tolerance (0 strictest, 4 most permissive)"},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random seed (-1 for random)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video_url: str,
+        prompt: str = "",
+        aspect_ratio: str = "auto",
+        resolution: str = "720p",
+        duration: int = 5,
+        generate_audio: bool = True,
+        safety_tolerance: int = 2,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        video_url = (video_url or "").strip()
+        if not video_url:
+            raise RuntimeError("video_url is required (public mp4 URL)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-3/extend-video",
+            "video_url": video_url,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "duration": int(duration),
+            "generate_audio": bool(generate_audio),
+            "safety_tolerance": int(safety_tolerance),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+        if seed >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/flux3_first_last_frame_to_video.py
+++ b/src/atlascloud_comfyui/nodes/video/flux3_first_last_frame_to_video.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_ASPECT_RATIOS = ["auto", "21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"]
+_RESOLUTIONS = ["720p", "1080p"]
+
+
+class AtlasFlux3FirstLastFrameToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "start_image_url": (
+                    "STRING",
+                    {"default": "", "tooltip": "URL of the image used as the first frame (PNG, JPEG, or WebP)"},
+                ),
+                "end_image_url": (
+                    "STRING",
+                    {"default": "", "tooltip": "URL of the image used as the last frame (PNG, JPEG, or WebP)"},
+                ),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Text description of the video to generate"}),
+                "aspect_ratio": (
+                    _ASPECT_RATIOS,
+                    {"default": "auto", "tooltip": "Aspect ratio of the generated video ('auto' lets the model choose)"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 5, "min": 5, "max": 20, "tooltip": "Duration (seconds, 5-20)"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio for the video"}),
+                "safety_tolerance": (
+                    "INT",
+                    {"default": 2, "min": 0, "max": 4, "tooltip": "Safety tolerance (0 strictest, 4 most permissive)"},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random seed (-1 for random)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        start_image_url: str,
+        end_image_url: str,
+        prompt: str = "",
+        aspect_ratio: str = "auto",
+        resolution: str = "720p",
+        duration: int = 5,
+        generate_audio: bool = True,
+        safety_tolerance: int = 2,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        start_image_url = (start_image_url or "").strip()
+        if not start_image_url:
+            raise RuntimeError("start_image_url is required")
+
+        end_image_url = (end_image_url or "").strip()
+        if not end_image_url:
+            raise RuntimeError("end_image_url is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-3/first-last-frame-to-video",
+            "start_image_url": start_image_url,
+            "end_image_url": end_image_url,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "duration": int(duration),
+            "generate_audio": bool(generate_audio),
+            "safety_tolerance": int(safety_tolerance),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+        if seed >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/flux3_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/flux3_i2v.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_ASPECT_RATIOS = ["auto", "21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"]
+_RESOLUTIONS = ["720p", "1080p"]
+
+
+class AtlasFlux3ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image_url": (
+                    "STRING",
+                    {"default": "", "tooltip": "URL of the image the video starts from (PNG, JPEG, or WebP)"},
+                ),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Text description of the video to generate"}),
+                "aspect_ratio": (
+                    _ASPECT_RATIOS,
+                    {"default": "auto", "tooltip": "Aspect ratio of the generated video ('auto' lets the model choose)"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 5, "min": 5, "max": 20, "tooltip": "Duration (seconds, 5-20)"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio for the video"}),
+                "safety_tolerance": (
+                    "INT",
+                    {"default": 2, "min": 0, "max": 4, "tooltip": "Safety tolerance (0 strictest, 4 most permissive)"},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random seed (-1 for random)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image_url: str,
+        prompt: str = "",
+        aspect_ratio: str = "auto",
+        resolution: str = "720p",
+        duration: int = 5,
+        generate_audio: bool = True,
+        safety_tolerance: int = 2,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image_url = (image_url or "").strip()
+        if not image_url:
+            raise RuntimeError("image_url is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-3/image-to-video",
+            "image_url": image_url,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "duration": int(duration),
+            "generate_audio": bool(generate_audio),
+            "safety_tolerance": int(safety_tolerance),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+        if seed >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/flux3_keyframes_to_video.py
+++ b/src/atlascloud_comfyui/nodes/video/flux3_keyframes_to_video.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_ASPECT_RATIOS = ["auto", "21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"]
+_RESOLUTIONS = ["720p", "1080p"]
+_MAX_KEYFRAMES = 10
+_FPS = 24
+
+_KEYFRAMES_TOOLTIP = (
+    'JSON array of keyframes, e.g. [{"image_url": "https://...", "frame_index": 0}]. '
+    "Up to 10 entries with unique frame_index values; video is 24 fps so frame_index must be <= duration * 24"
+)
+
+
+class AtlasFlux3KeyframesToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "keyframes": ("STRING", {"multiline": True, "default": "", "tooltip": _KEYFRAMES_TOOLTIP}),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Text description of the video to generate"}),
+                "aspect_ratio": (
+                    _ASPECT_RATIOS,
+                    {"default": "auto", "tooltip": "Aspect ratio of the generated video ('auto' lets the model choose)"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 5, "min": 5, "max": 20, "tooltip": "Duration (seconds, 5-20)"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio for the video"}),
+                "safety_tolerance": (
+                    "INT",
+                    {"default": 2, "min": 0, "max": 4, "tooltip": "Safety tolerance (0 strictest, 4 most permissive)"},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random seed (-1 for random)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    @staticmethod
+    def _parse_keyframes(keyframes: str, duration: int) -> List[Dict[str, Any]]:
+        raw = (keyframes or "").strip()
+        if not raw:
+            raise RuntimeError("keyframes is required (JSON array of {image_url, frame_index})")
+
+        try:
+            parsed = json.loads(raw)
+        except ValueError as exc:
+            raise RuntimeError(f"keyframes must be valid JSON: {exc}") from exc
+
+        if not isinstance(parsed, list) or not parsed:
+            raise RuntimeError("keyframes must be a non-empty JSON array")
+        if len(parsed) > _MAX_KEYFRAMES:
+            raise RuntimeError(f"keyframes maxItems is {_MAX_KEYFRAMES}")
+
+        max_frame_index = int(duration) * _FPS
+        cleaned: List[Dict[str, Any]] = []
+        seen_indices = set()
+        for item in parsed:
+            if not isinstance(item, dict):
+                raise RuntimeError("each keyframe must be an object with image_url and frame_index")
+
+            image_url = str(item.get("image_url") or "").strip()
+            if not image_url:
+                raise RuntimeError("each keyframe requires image_url")
+
+            if "frame_index" not in item:
+                raise RuntimeError("each keyframe requires frame_index")
+            try:
+                frame_index = int(item["frame_index"])
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError("keyframe frame_index must be an integer") from exc
+
+            if frame_index < 0 or frame_index > max_frame_index:
+                raise RuntimeError(f"keyframe frame_index must be between 0 and duration * 24 ({max_frame_index})")
+            if frame_index in seen_indices:
+                raise RuntimeError(f"keyframe frame_index values must be unique (duplicate {frame_index})")
+            seen_indices.add(frame_index)
+
+            cleaned.append({"image_url": image_url, "frame_index": frame_index})
+
+        return cleaned
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        keyframes: str,
+        prompt: str = "",
+        aspect_ratio: str = "auto",
+        resolution: str = "720p",
+        duration: int = 5,
+        generate_audio: bool = True,
+        safety_tolerance: int = 2,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        parsed_keyframes = self._parse_keyframes(keyframes, duration)
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-3/keyframes-to-video",
+            "keyframes": parsed_keyframes,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "duration": int(duration),
+            "generate_audio": bool(generate_audio),
+            "safety_tolerance": int(safety_tolerance),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+        if seed >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/flux3_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/flux3_t2v.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_ASPECT_RATIOS = ["auto", "21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"]
+_RESOLUTIONS = ["720p", "1080p"]
+
+
+class AtlasFlux3TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text description of the video to generate"}),
+            },
+            "optional": {
+                "aspect_ratio": (
+                    _ASPECT_RATIOS,
+                    {"default": "auto", "tooltip": "Aspect ratio of the generated video ('auto' lets the model choose)"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 5, "min": 5, "max": 20, "tooltip": "Duration (seconds, 5-20)"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Whether to generate audio for the video"}),
+                "safety_tolerance": (
+                    "INT",
+                    {"default": 2, "min": 0, "max": 4, "tooltip": "Safety tolerance (0 strictest, 4 most permissive)"},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random seed (-1 for random)"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        aspect_ratio: str = "auto",
+        resolution: str = "720p",
+        duration: int = 5,
+        generate_audio: bool = True,
+        safety_tolerance: int = 2,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "black-forest-labs/flux-3/text-to-video",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "duration": int(duration),
+            "generate_audio": bool(generate_audio),
+            "safety_tolerance": int(safety_tolerance),
+        }
+
+        if seed >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v30_pro_motion_control.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v30_pro_motion_control.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_CHARACTER_ORIENTATIONS = ["image", "video"]
+
+
+class AtlasKlingV30ProMotionControl:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Character image URL/base64 (jpg/jpeg/png, <=10MB, >=300px, aspect ratio 1:2.5-2.5:1)",
+                    },
+                ),
+                "video": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Motion reference video URL (mp4/mov, <=10MB, >=300px, aspect ratio 1:2.5-2.5:1)",
+                    },
+                ),
+                "character_orientation": (
+                    _CHARACTER_ORIENTATIONS,
+                    {"default": "image", "tooltip": "Match the character orientation to the image or to the video"},
+                ),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Positive prompt for the generation"}),
+                "keep_original_sound": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Whether to retain the original video sound"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        video: str,
+        character_orientation: str = "image",
+        prompt: str = "",
+        keep_original_sound: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required (URL)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v3.0-pro/motion-control",
+            "image": image,
+            "video": video,
+            "character_orientation": character_orientation,
+            "keep_original_sound": bool(keep_original_sound),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/kling_v30_std_motion_control.py
+++ b/src/atlascloud_comfyui/nodes/video/kling_v30_std_motion_control.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_CHARACTER_ORIENTATIONS = ["image", "video"]
+
+
+class AtlasKlingV30StdMotionControl:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Character image URL/base64 (jpg/jpeg/png, <=10MB, >=300px, aspect ratio 1:2.5-2.5:1)",
+                    },
+                ),
+                "video": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "Motion reference video URL (mp4/mov, <=10MB, >=300px, aspect ratio 1:2.5-2.5:1)",
+                    },
+                ),
+                "character_orientation": (
+                    _CHARACTER_ORIENTATIONS,
+                    {"default": "image", "tooltip": "Match the character orientation to the image or to the video"},
+                ),
+            },
+            "optional": {
+                "prompt": ("STRING", {"multiline": True, "default": "", "tooltip": "Positive prompt for the generation"}),
+                "keep_original_sound": (
+                    "BOOLEAN",
+                    {"default": True, "tooltip": "Whether to retain the original video sound"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        video: str,
+        character_orientation: str = "image",
+        prompt: str = "",
+        keep_original_sound: bool = True,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required (URL or base64)")
+
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required (URL)")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "kwaivgi/kling-v3.0-std/motion-control",
+            "image": image,
+            "video": video,
+            "character_orientation": character_orientation,
+            "keep_original_sound": bool(keep_original_sound),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -285,6 +285,14 @@ from atlascloud_comfyui.nodes.video.ltx_2_3_quality_t2v import AtlasLtx23Quality
 from atlascloud_comfyui.nodes.video.ltx_2_3_quality_i2v import AtlasLtx23QualityImageToVideo
 from atlascloud_comfyui.nodes.video.ltx_2_3_quality_extend_video import AtlasLtx23QualityExtendVideo
 
+from atlascloud_comfyui.nodes.video.flux3_t2v import AtlasFlux3TextToVideo
+from atlascloud_comfyui.nodes.video.flux3_i2v import AtlasFlux3ImageToVideo
+from atlascloud_comfyui.nodes.video.flux3_first_last_frame_to_video import AtlasFlux3FirstLastFrameToVideo
+from atlascloud_comfyui.nodes.video.flux3_keyframes_to_video import AtlasFlux3KeyframesToVideo
+from atlascloud_comfyui.nodes.video.flux3_extend_video import AtlasFlux3ExtendVideo
+from atlascloud_comfyui.nodes.video.kling_v30_pro_motion_control import AtlasKlingV30ProMotionControl
+from atlascloud_comfyui.nodes.video.kling_v30_std_motion_control import AtlasKlingV30StdMotionControl
+
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_pro import AtlasKlingV16MultiI2VPro
 from atlascloud_comfyui.nodes.video.kling_v16_multi_i2v_standard import AtlasKlingV16MultiI2VStandard
 from atlascloud_comfyui.nodes.video.kling_v16_i2v_standard import AtlasKlingV16I2VStandard
@@ -780,6 +788,13 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud LTX 2.3 Quality Text-to-Video": AtlasLtx23QualityTextToVideo,
     "AtlasCloud LTX 2.3 Quality Image-to-Video": AtlasLtx23QualityImageToVideo,
     "AtlasCloud LTX 2.3 Quality Extend Video": AtlasLtx23QualityExtendVideo,
+    "AtlasCloud FLUX 3 Text-to-Video": AtlasFlux3TextToVideo,
+    "AtlasCloud FLUX 3 Image-to-Video": AtlasFlux3ImageToVideo,
+    "AtlasCloud FLUX 3 First & Last Frame to Video": AtlasFlux3FirstLastFrameToVideo,
+    "AtlasCloud FLUX 3 Keyframes to Video": AtlasFlux3KeyframesToVideo,
+    "AtlasCloud FLUX 3 Extend Video": AtlasFlux3ExtendVideo,
+    "AtlasCloud Kling V3.0 Pro Motion Control": AtlasKlingV30ProMotionControl,
+    "AtlasCloud Kling V3.0 Std Motion Control": AtlasKlingV30StdMotionControl,
 }
 
 
@@ -1148,6 +1163,13 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud LTX 2.3 Quality Text-to-Video": "AtlasCloud LTX 2.3 Quality Text-to-Video",
     "AtlasCloud LTX 2.3 Quality Image-to-Video": "AtlasCloud LTX 2.3 Quality Image-to-Video",
     "AtlasCloud LTX 2.3 Quality Extend Video": "AtlasCloud LTX 2.3 Quality Extend Video",
+    "AtlasCloud FLUX 3 Text-to-Video": "AtlasCloud FLUX 3 Text-to-Video",
+    "AtlasCloud FLUX 3 Image-to-Video": "AtlasCloud FLUX 3 Image-to-Video",
+    "AtlasCloud FLUX 3 First & Last Frame to Video": "AtlasCloud FLUX 3 First & Last Frame to Video",
+    "AtlasCloud FLUX 3 Keyframes to Video": "AtlasCloud FLUX 3 Keyframes to Video",
+    "AtlasCloud FLUX 3 Extend Video": "AtlasCloud FLUX 3 Extend Video",
+    "AtlasCloud Kling V3.0 Pro Motion Control": "AtlasCloud Kling V3.0 Pro Motion Control",
+    "AtlasCloud Kling V3.0 Std Motion Control": "AtlasCloud Kling V3.0 Std Motion Control",
 }
 
 

--- a/tests/test_new_nodes_2026_08_06.py
+++ b/tests/test_new_nodes_2026_08_06.py
@@ -1,0 +1,269 @@
+"""Metadata-only tests for newly added nodes (2026-08-06).
+
+New models: BLACK FOREST LABS FLUX 3 video family (text-to-video, image-to-video,
+first-last-frame-to-video, keyframes-to-video, extend-video) and Kling v3.0
+Pro/Std Motion Control.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+import json
+
+import pytest
+
+_ASPECT_RATIOS = ["auto", "21:9", "2:1", "16:9", "4:3", "1:1", "3:4", "9:16"]
+
+
+def _flux3_common_assertions(cls):
+    inputs = cls.INPUT_TYPES()
+    optional = inputs["optional"]
+    assert "atlas_client" in inputs["required"]
+    assert optional["aspect_ratio"][0] == _ASPECT_RATIOS
+    assert optional["aspect_ratio"][1]["default"] == "auto"
+    assert optional["resolution"][0] == ["720p", "1080p"]
+    assert optional["resolution"][1]["default"] == "720p"
+    assert optional["duration"][1]["default"] == 5
+    assert optional["duration"][1]["min"] == 5
+    assert optional["duration"][1]["max"] == 20
+    assert optional["generate_audio"][0] == "BOOLEAN"
+    assert optional["generate_audio"][1]["default"] is True
+    assert optional["safety_tolerance"][1]["min"] == 0
+    assert optional["safety_tolerance"][1]["max"] == 4
+    assert optional["safety_tolerance"][1]["default"] == 2
+    assert optional["seed"][1]["min"] == -1
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("video_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Video"
+    assert "if seed >= 0:" in inspect.getsource(cls.run)
+
+
+def test_flux3_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.flux3_t2v import AtlasFlux3TextToVideo
+
+    _flux3_common_assertions(AtlasFlux3TextToVideo)
+    assert "prompt" in AtlasFlux3TextToVideo.INPUT_TYPES()["required"]
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "   "])
+def test_flux3_t2v_requires_prompt(bad_prompt):
+    from src.atlascloud_comfyui.nodes.video.flux3_t2v import AtlasFlux3TextToVideo
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasFlux3TextToVideo().run(None, bad_prompt)
+
+
+def test_flux3_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.flux3_i2v import AtlasFlux3ImageToVideo
+
+    _flux3_common_assertions(AtlasFlux3ImageToVideo)
+    assert "image_url" in AtlasFlux3ImageToVideo.INPUT_TYPES()["required"]
+    assert "prompt" in AtlasFlux3ImageToVideo.INPUT_TYPES()["optional"]
+
+
+@pytest.mark.parametrize("bad_url", ["", "  "])
+def test_flux3_i2v_requires_image_url(bad_url):
+    from src.atlascloud_comfyui.nodes.video.flux3_i2v import AtlasFlux3ImageToVideo
+
+    with pytest.raises(RuntimeError, match="image_url is required"):
+        AtlasFlux3ImageToVideo().run(None, bad_url)
+
+
+def test_flux3_first_last_frame_metadata():
+    from src.atlascloud_comfyui.nodes.video.flux3_first_last_frame_to_video import (
+        AtlasFlux3FirstLastFrameToVideo,
+    )
+
+    _flux3_common_assertions(AtlasFlux3FirstLastFrameToVideo)
+    required = AtlasFlux3FirstLastFrameToVideo.INPUT_TYPES()["required"]
+    assert "start_image_url" in required
+    assert "end_image_url" in required
+
+
+def test_flux3_first_last_frame_requires_both_frames():
+    from src.atlascloud_comfyui.nodes.video.flux3_first_last_frame_to_video import (
+        AtlasFlux3FirstLastFrameToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="start_image_url is required"):
+        AtlasFlux3FirstLastFrameToVideo().run(None, "  ", "https://example.com/b.png")
+    with pytest.raises(RuntimeError, match="end_image_url is required"):
+        AtlasFlux3FirstLastFrameToVideo().run(None, "https://example.com/a.png", "")
+
+
+def test_flux3_extend_video_metadata():
+    from src.atlascloud_comfyui.nodes.video.flux3_extend_video import AtlasFlux3ExtendVideo
+
+    _flux3_common_assertions(AtlasFlux3ExtendVideo)
+    assert "video_url" in AtlasFlux3ExtendVideo.INPUT_TYPES()["required"]
+
+
+@pytest.mark.parametrize("bad_url", ["", "   "])
+def test_flux3_extend_video_requires_video_url(bad_url):
+    from src.atlascloud_comfyui.nodes.video.flux3_extend_video import AtlasFlux3ExtendVideo
+
+    with pytest.raises(RuntimeError, match="video_url is required"):
+        AtlasFlux3ExtendVideo().run(None, bad_url)
+
+
+def test_flux3_keyframes_metadata():
+    from src.atlascloud_comfyui.nodes.video.flux3_keyframes_to_video import (
+        AtlasFlux3KeyframesToVideo,
+    )
+
+    _flux3_common_assertions(AtlasFlux3KeyframesToVideo)
+    assert "keyframes" in AtlasFlux3KeyframesToVideo.INPUT_TYPES()["required"]
+
+
+def test_flux3_keyframes_parses_valid_json():
+    from src.atlascloud_comfyui.nodes.video.flux3_keyframes_to_video import (
+        AtlasFlux3KeyframesToVideo,
+    )
+
+    raw = json.dumps(
+        [
+            {"image_url": " https://example.com/a.png ", "frame_index": 0},
+            {"image_url": "https://example.com/b.png", "frame_index": 119},
+        ]
+    )
+    parsed = AtlasFlux3KeyframesToVideo._parse_keyframes(raw, 5)
+    assert parsed == [
+        {"image_url": "https://example.com/a.png", "frame_index": 0},
+        {"image_url": "https://example.com/b.png", "frame_index": 119},
+    ]
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("", "keyframes is required"),
+        ("not json", "keyframes must be valid JSON"),
+        ("[]", "keyframes must be a non-empty JSON array"),
+        ('{"image_url": "x", "frame_index": 0}', "keyframes must be a non-empty JSON array"),
+        ('[{"frame_index": 0}]', "each keyframe requires image_url"),
+        ('[{"image_url": "https://example.com/a.png"}]', "each keyframe requires frame_index"),
+        (
+            '[{"image_url": "https://example.com/a.png", "frame_index": 121}]',
+            r"frame_index must be between 0 and duration \* 24",
+        ),
+        (
+            '[{"image_url": "https://example.com/a.png", "frame_index": 1},'
+            ' {"image_url": "https://example.com/b.png", "frame_index": 1}]',
+            "frame_index values must be unique",
+        ),
+    ],
+)
+def test_flux3_keyframes_rejects_bad_input(raw, expected):
+    from src.atlascloud_comfyui.nodes.video.flux3_keyframes_to_video import (
+        AtlasFlux3KeyframesToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match=expected):
+        AtlasFlux3KeyframesToVideo._parse_keyframes(raw, 5)
+
+
+def test_flux3_keyframes_rejects_too_many():
+    from src.atlascloud_comfyui.nodes.video.flux3_keyframes_to_video import (
+        AtlasFlux3KeyframesToVideo,
+    )
+
+    raw = json.dumps([{"image_url": f"https://example.com/{i}.png", "frame_index": i} for i in range(11)])
+    with pytest.raises(RuntimeError, match="keyframes maxItems is 10"):
+        AtlasFlux3KeyframesToVideo._parse_keyframes(raw, 5)
+
+
+@pytest.mark.parametrize(
+    "module_name,class_name",
+    [
+        ("kling_v30_pro_motion_control", "AtlasKlingV30ProMotionControl"),
+        ("kling_v30_std_motion_control", "AtlasKlingV30StdMotionControl"),
+    ],
+)
+def test_kling_v30_motion_control_metadata(module_name, class_name):
+    module = __import__(
+        f"src.atlascloud_comfyui.nodes.video.{module_name}", fromlist=[class_name]
+    )
+    cls = getattr(module, class_name)
+
+    inputs = cls.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert "video" in required
+    assert required["character_orientation"][0] == ["image", "video"]
+    assert required["character_orientation"][1]["default"] == "image"
+    assert optional["keep_original_sound"][0] == "BOOLEAN"
+    assert optional["keep_original_sound"][1]["default"] is True
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("video_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Video"
+
+
+@pytest.mark.parametrize(
+    "module_name,class_name",
+    [
+        ("kling_v30_pro_motion_control", "AtlasKlingV30ProMotionControl"),
+        ("kling_v30_std_motion_control", "AtlasKlingV30StdMotionControl"),
+    ],
+)
+def test_kling_v30_motion_control_requires_image_and_video(module_name, class_name):
+    module = __import__(
+        f"src.atlascloud_comfyui.nodes.video.{module_name}", fromlist=[class_name]
+    )
+    cls = getattr(module, class_name)
+
+    with pytest.raises(RuntimeError, match="image is required"):
+        cls().run(None, "  ", "https://example.com/a.mp4")
+    with pytest.raises(RuntimeError, match="video is required"):
+        cls().run(None, "https://example.com/a.png", "")
+
+
+def test_new_nodes_2026_08_06_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    keys = [
+        "AtlasCloud FLUX 3 Text-to-Video",
+        "AtlasCloud FLUX 3 Image-to-Video",
+        "AtlasCloud FLUX 3 First & Last Frame to Video",
+        "AtlasCloud FLUX 3 Keyframes to Video",
+        "AtlasCloud FLUX 3 Extend Video",
+        "AtlasCloud Kling V3.0 Pro Motion Control",
+        "AtlasCloud Kling V3.0 Std Motion Control",
+    ]
+    for key in keys:
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_08_06_model_ids():
+    from src.atlascloud_comfyui.nodes.video.flux3_extend_video import AtlasFlux3ExtendVideo
+    from src.atlascloud_comfyui.nodes.video.flux3_first_last_frame_to_video import (
+        AtlasFlux3FirstLastFrameToVideo,
+    )
+    from src.atlascloud_comfyui.nodes.video.flux3_i2v import AtlasFlux3ImageToVideo
+    from src.atlascloud_comfyui.nodes.video.flux3_keyframes_to_video import (
+        AtlasFlux3KeyframesToVideo,
+    )
+    from src.atlascloud_comfyui.nodes.video.flux3_t2v import AtlasFlux3TextToVideo
+    from src.atlascloud_comfyui.nodes.video.kling_v30_pro_motion_control import (
+        AtlasKlingV30ProMotionControl,
+    )
+    from src.atlascloud_comfyui.nodes.video.kling_v30_std_motion_control import (
+        AtlasKlingV30StdMotionControl,
+    )
+
+    expected = [
+        (AtlasFlux3TextToVideo, "black-forest-labs/flux-3/text-to-video"),
+        (AtlasFlux3ImageToVideo, "black-forest-labs/flux-3/image-to-video"),
+        (AtlasFlux3FirstLastFrameToVideo, "black-forest-labs/flux-3/first-last-frame-to-video"),
+        (AtlasFlux3KeyframesToVideo, "black-forest-labs/flux-3/keyframes-to-video"),
+        (AtlasFlux3ExtendVideo, "black-forest-labs/flux-3/extend-video"),
+        (AtlasKlingV30ProMotionControl, "kwaivgi/kling-v3.0-pro/motion-control"),
+        (AtlasKlingV30StdMotionControl, "kwaivgi/kling-v3.0-std/motion-control"),
+    ]
+    for cls, model_id in expected:
+        source = inspect.getsource(cls.run)
+        assert f'"model": "{model_id}"' in source


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync.

## New models (7)
| Node | Model ID |
| --- | --- |
| AtlasCloud FLUX 3 Text-to-Video | `black-forest-labs/flux-3/text-to-video` |
| AtlasCloud FLUX 3 Image-to-Video | `black-forest-labs/flux-3/image-to-video` |
| AtlasCloud FLUX 3 First & Last Frame to Video | `black-forest-labs/flux-3/first-last-frame-to-video` |
| AtlasCloud FLUX 3 Keyframes to Video | `black-forest-labs/flux-3/keyframes-to-video` |
| AtlasCloud FLUX 3 Extend Video | `black-forest-labs/flux-3/extend-video` |
| AtlasCloud Kling V3.0 Pro Motion Control | `kwaivgi/kling-v3.0-pro/motion-control` |
| AtlasCloud Kling V3.0 Std Motion Control | `kwaivgi/kling-v3.0-std/motion-control` |

Params follow each model's published schema (aspect_ratio / resolution / duration 5-20s / generate_audio / safety_tolerance 0-4 / seed for FLUX 3; image + video + character_orientation + keep_original_sound for Kling Motion Control). Keyframes-to-video takes a JSON array of `{image_url, frame_index}` and validates maxItems=10, unique indices, and `frame_index <= duration * 24`.

Also updated: `registry.py` (imports + class/display mappings), README Available Nodes table.

Skipped this round: the 7 `*-to-3d` models in the API (Seed3D 2.0, Hunyuan 3D Rapid/Pro, Tripo H3.1) — they are typed `Image` but output mesh archives, so no existing image-node shape fits.

## Tests
- `ruff check .` — clean
- `pytest tests/ -k "not e2e"` — 451 passed, 26 deselected
- New metadata-only tests in `tests/test_new_nodes_2026_08_06.py` (no live API calls). E2E not run locally (no ComfyUI source on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)