### PR TITLE
sync: add 4 AtlasCloud models (2026-08-07)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Seedance 2.0 Mini Text-to-Video | bytedance/seedance-2.0-mini/text-to-video |
 | AtlasCloud Seedance 2.0 Mini Image-to-Video | bytedance/seedance-2.0-mini/image-to-video |
 | AtlasCloud Seedance 2.0 Mini Reference-to-Video | bytedance/seedance-2.0-mini/reference-to-video |
+| AtlasCloud Seedance 2.5 Text-to-Video | bytedance/seedance-2.5/text-to-video |
+| AtlasCloud Seedance 2.5 Image-to-Video | bytedance/seedance-2.5/image-to-video |
+| AtlasCloud Seedance 2.5 Reference-to-Video | bytedance/seedance-2.5/reference-to-video |
 | AtlasCloud Avatar Omni Human 1.5 | bytedance/avatar-omni-human-v1.5 |
 | AtlasCloud Image Upscaler | atlascloud/image-upscaler |
 | AtlasCloud Face Swap (Image) | atlascloud/face-swap-image |
@@ -456,6 +459,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Seedream V5.0 Lite Edit | bytedance/seedream-v5.0-lite/edit |
 | AtlasCloud Seedream V5.0 Lite Edit Sequential | bytedance/seedream-v5.0-lite/edit-sequential |
 | AtlasCloud Seedream V5.0 Pro Edit | bytedance/seedream-v5.0-pro/edit |
+| AtlasCloud Seedream V5.0 Pro Layer Decomposition | bytedance/seedream-v5.0-pro/layer-decomposition |
 | AtlasCloud WAN2.6 Image-Edit | alibaba/wan-2.6/image-edit |
 | AtlasCloud WAN2.7 Image-Edit | alibaba/wan-2.7/image-edit |
 | AtlasCloud WAN2.7 Pro Image-Edit | alibaba/wan-2.7-pro/image-edit |

--- a/src/atlascloud_comfyui/nodes/image/seedream_v50_pro_layer_decomposition.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v50_pro_layer_decomposition.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasSeedreamV50ProLayerDecomposition:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING", "STRING")
+    RETURN_NAMES = ("image_url", "layer_urls", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Image to decompose into layers (URL or base64), exactly one"},
+                ),
+                "size": (
+                    ["auto", "1K", "1.5K", "2K"],
+                    {"default": "auto", "tooltip": "Output resolution tier (auto follows the input image)"},
+                ),
+                "output_format": (["jpeg", "png"], {"default": "jpeg", "tooltip": "File format of the base image"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": "Optional: which elements to split. Leave empty for automatic detection. Supports <bbox>x1 y1 x2 y2</bbox> in [0,1000] coords",
+                    },
+                ),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        size: str,
+        output_format: str,
+        enable_base64_output: bool,
+        prompt: str = "",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for Seedream V5.0 Pro Layer Decomposition")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v5.0-pro/layer-decomposition",
+            "image": image,
+            "size": size,
+            "output_format": output_format,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        # outputs[0] is the base image; the remaining entries are the decomposed layers.
+        return (outputs[0], "\n".join(outputs[1:]), prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_5_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_5_i2v.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_DURATIONS = [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+
+
+class AtlasSeedance25ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": (
+                    "STRING",
+                    {
+                        "default": "",
+                        "tooltip": "First frame image (URL, data:image/...;base64,... or asset://<ASSET_ID>)",
+                    },
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The scene comes alive with gentle motion and cinematic lighting",
+                        "tooltip": "Prompt (optional but recommended)",
+                    },
+                ),
+                "last_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional last frame image (URL/base64/asset://)"},
+                ),
+                "duration": (
+                    _DURATIONS,
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (["adaptive"], {"default": "adaptive", "tooltip": "Aspect ratio (follows the input image)"}),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "output_format": (["mp4", "mov"], {"default": "mp4", "tooltip": "Output container format"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str = "The scene comes alive with gentle motion and cinematic lighting",
+        last_image: str = "",
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        output_format: str = "mp4",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud Seedance 2.5 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.5/image-to-video",
+            "image": image,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+            "output_format": output_format,
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_5_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_5_r2v.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_DURATIONS = [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+
+
+class AtlasSeedance25ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "reference_images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ image URLs/base64/asset://, one per line (up to 30)"},
+                ),
+                "reference_videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0+ video URLs/asset://, one per line (up to 10)"},
+                ),
+            },
+            "optional": {
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "The character in image 1 dances gracefully to the music",
+                        "tooltip": "Prompt (optional). Cite inputs with @Image1 / @Video1 / @Audio1. Video-editing prompts require duration -1",
+                    },
+                ),
+                "reference_audios": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "Reference audio URLs, one per line"},
+                ),
+                "duration": (
+                    _DURATIONS,
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto (required for video-editing mode)"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "output_format": (["mp4", "mov"], {"default": "mp4", "tooltip": "Output container format"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        reference_images: str,
+        reference_videos: str,
+        prompt: str = "The character in image 1 dances gracefully to the music",
+        reference_audios: str = "",
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        output_format: str = "mp4",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        ref_imgs: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        ref_vids: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
+        if not ref_imgs and not ref_vids:
+            raise RuntimeError("Provide at least one reference image or reference video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.5/reference-to-video",
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+            "output_format": output_format,
+        }
+
+        p = (prompt or "").strip()
+        if p:
+            payload["prompt"] = p
+
+        ref_auds: List[str] = [v.strip() for v in (reference_audios or "").splitlines() if v.strip()]
+        if ref_auds:
+            payload["reference_audios"] = ref_auds
+
+        if ref_imgs:
+            payload["reference_images"] = ref_imgs
+        if ref_vids:
+            payload["reference_videos"] = ref_vids
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_5_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/bytedance_seedance_2_5_t2v.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_DURATIONS = [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+
+
+class AtlasSeedance25TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "A golden retriever running on a sunny beach, waves crashing in the background, cinematic lighting",
+                        "tooltip": "Text prompt (Chinese < 500 chars, English < 1000 words)",
+                    },
+                ),
+            },
+            "optional": {
+                "duration": (
+                    _DURATIONS,
+                    {"default": 5, "tooltip": "Duration (seconds), or -1 for auto"},
+                ),
+                "resolution": (["480p", "720p"], {"default": "720p", "tooltip": "Resolution"}),
+                "ratio": (
+                    ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = auto)"},
+                ),
+                "generate_audio": ("BOOLEAN", {"default": True, "tooltip": "Generate audio"}),
+                "watermark": ("BOOLEAN", {"default": False, "tooltip": "Add watermark"}),
+                "return_last_frame": ("BOOLEAN", {"default": False, "tooltip": "Return last frame (if supported)"}),
+                "output_format": (["mp4", "mov"], {"default": "mp4", "tooltip": "Output container format"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 5,
+        resolution: str = "720p",
+        ratio: str = "adaptive",
+        generate_audio: bool = True,
+        watermark: bool = False,
+        return_last_frame: bool = False,
+        output_format: str = "mp4",
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud Seedance 2.5 Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedance-2.5/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "ratio": ratio,
+            "generate_audio": bool(generate_audio),
+            "watermark": bool(watermark),
+            "return_last_frame": bool(return_last_frame),
+            "output_format": output_format,
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -276,6 +276,7 @@ from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_edit import AtlasGrok
 
 from atlascloud_comfyui.nodes.image.seedream_v50_pro_t2i import AtlasSeedreamV50ProTextToImage
 from atlascloud_comfyui.nodes.image.seedream_v50_pro_edit import AtlasSeedreamV50ProEdit
+from atlascloud_comfyui.nodes.image.seedream_v50_pro_layer_decomposition import AtlasSeedreamV50ProLayerDecomposition
 from atlascloud_comfyui.nodes.image.nvidia_cosmos_3_super_t2i import AtlasCosmos3SuperTextToImage
 from atlascloud_comfyui.nodes.video.nvidia_cosmos_3_super_i2v import AtlasCosmos3SuperImageToVideo
 from atlascloud_comfyui.nodes.image.ideogram_v4_turbo_t2i import AtlasIdeogramV4TurboTextToImage
@@ -320,6 +321,9 @@ from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_fast_r2v import Atlas
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_t2v import AtlasSeedance20MiniTextToVideo
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_i2v import AtlasSeedance20MiniImageToVideo
 from atlascloud_comfyui.nodes.video.bytedance_seedance_2_0_mini_r2v import AtlasSeedance20MiniReferenceToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_t2v import AtlasSeedance25TextToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_i2v import AtlasSeedance25ImageToVideo
+from atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_r2v import AtlasSeedance25ReferenceToVideo
 from atlascloud_comfyui.nodes.video.bytedance_avatar_omni_human_v15 import AtlasAvatarOmniHumanV15
 from atlascloud_comfyui.nodes.image.atlascloud_image_upscaler import AtlasImageUpscaler
 from atlascloud_comfyui.nodes.image.atlascloud_face_swap_image import AtlasFaceSwapImage
@@ -481,6 +485,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Seedance 2.0 Mini Text-to-Video": AtlasSeedance20MiniTextToVideo,
     "AtlasCloud Seedance 2.0 Mini Image-to-Video": AtlasSeedance20MiniImageToVideo,
     "AtlasCloud Seedance 2.0 Mini Reference-to-Video": AtlasSeedance20MiniReferenceToVideo,
+    "AtlasCloud Seedance 2.5 Text-to-Video": AtlasSeedance25TextToVideo,
+    "AtlasCloud Seedance 2.5 Image-to-Video": AtlasSeedance25ImageToVideo,
+    "AtlasCloud Seedance 2.5 Reference-to-Video": AtlasSeedance25ReferenceToVideo,
     "AtlasCloud Avatar Omni Human 1.5": AtlasAvatarOmniHumanV15,
     "AtlasCloud Image Upscaler": AtlasImageUpscaler,
     "AtlasCloud Face Swap (Image)": AtlasFaceSwapImage,
@@ -781,6 +788,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Grok Imagine Video Extend": AtlasGrokImagineVideoExtend,
     "AtlasCloud Seedream V5.0 Pro Text-to-Image": AtlasSeedreamV50ProTextToImage,
     "AtlasCloud Seedream V5.0 Pro Edit": AtlasSeedreamV50ProEdit,
+    "AtlasCloud Seedream V5.0 Pro Layer Decomposition": AtlasSeedreamV50ProLayerDecomposition,
     "AtlasCloud Cosmos 3 Super Text-to-Image": AtlasCosmos3SuperTextToImage,
     "AtlasCloud Cosmos 3 Super Image-to-Video": AtlasCosmos3SuperImageToVideo,
     "AtlasCloud Ideogram V4 Turbo Text-to-Image": AtlasIdeogramV4TurboTextToImage,
@@ -858,6 +866,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedance 2.0 Mini Text-to-Video": "AtlasCloud Seedance 2.0 Mini Text-to-Video",
     "AtlasCloud Seedance 2.0 Mini Image-to-Video": "AtlasCloud Seedance 2.0 Mini Image-to-Video",
     "AtlasCloud Seedance 2.0 Mini Reference-to-Video": "AtlasCloud Seedance 2.0 Mini Reference-to-Video",
+    "AtlasCloud Seedance 2.5 Text-to-Video": "AtlasCloud Seedance 2.5 Text-to-Video",
+    "AtlasCloud Seedance 2.5 Image-to-Video": "AtlasCloud Seedance 2.5 Image-to-Video",
+    "AtlasCloud Seedance 2.5 Reference-to-Video": "AtlasCloud Seedance 2.5 Reference-to-Video",
     "AtlasCloud Avatar Omni Human 1.5": "AtlasCloud Avatar Omni Human 1.5",
     "AtlasCloud Image Upscaler": "AtlasCloud Image Upscaler",
     "AtlasCloud Face Swap (Image)": "AtlasCloud Face Swap (Image)",
@@ -1156,6 +1167,7 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud VEED Lipsync": "AtlasCloud VEED Lipsync",
     "AtlasCloud Seedream V5.0 Pro Text-to-Image": "AtlasCloud Seedream V5.0 Pro Text-to-Image",
     "AtlasCloud Seedream V5.0 Pro Edit": "AtlasCloud Seedream V5.0 Pro Edit",
+    "AtlasCloud Seedream V5.0 Pro Layer Decomposition": "AtlasCloud Seedream V5.0 Pro Layer Decomposition",
     "AtlasCloud Cosmos 3 Super Text-to-Image": "AtlasCloud Cosmos 3 Super Text-to-Image",
     "AtlasCloud Cosmos 3 Super Image-to-Video": "AtlasCloud Cosmos 3 Super Image-to-Video",
     "AtlasCloud Ideogram V4 Turbo Text-to-Image": "AtlasCloud Ideogram V4 Turbo Text-to-Image",

--- a/tests/test_new_nodes_2026_08_07.py
+++ b/tests/test_new_nodes_2026_08_07.py
@@ -1,0 +1,172 @@
+"""Metadata-only tests for newly added nodes (2026-08-07).
+
+New models: Seedance 2.5 (text-to-video, image-to-video, reference-to-video) and
+Seedream V5.0 Pro Layer Decomposition.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+_DURATIONS = [-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+
+
+def _seedance_25_common_assertions(cls):
+    inputs = cls.INPUT_TYPES()
+    optional = inputs["optional"]
+    assert "atlas_client" in inputs["required"]
+    assert optional["duration"][0] == _DURATIONS
+    assert optional["duration"][1]["default"] == 5
+    assert optional["resolution"][0] == ["480p", "720p"]
+    assert optional["resolution"][1]["default"] == "720p"
+    assert optional["generate_audio"][0] == "BOOLEAN"
+    assert optional["generate_audio"][1]["default"] is True
+    assert optional["output_format"][0] == ["mp4", "mov"]
+    assert optional["output_format"][1]["default"] == "mp4"
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("video_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Video"
+
+
+def test_seedance_25_t2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_t2v import (
+        AtlasSeedance25TextToVideo,
+    )
+
+    _seedance_25_common_assertions(AtlasSeedance25TextToVideo)
+    inputs = AtlasSeedance25TextToVideo.INPUT_TYPES()
+    assert "prompt" in inputs["required"]
+    assert inputs["optional"]["ratio"][0] == ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"]
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "   "])
+def test_seedance_25_t2v_requires_prompt(bad_prompt):
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_t2v import (
+        AtlasSeedance25TextToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasSeedance25TextToVideo().run(None, bad_prompt)
+
+
+def test_seedance_25_i2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_i2v import (
+        AtlasSeedance25ImageToVideo,
+    )
+
+    _seedance_25_common_assertions(AtlasSeedance25ImageToVideo)
+    inputs = AtlasSeedance25ImageToVideo.INPUT_TYPES()
+    assert "image" in inputs["required"]
+    assert "prompt" in inputs["optional"]
+    assert "last_image" in inputs["optional"]
+    # The API only accepts "adaptive" for image-to-video.
+    assert inputs["optional"]["ratio"][0] == ["adaptive"]
+
+
+@pytest.mark.parametrize("bad_image", ["", "  "])
+def test_seedance_25_i2v_requires_image(bad_image):
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_i2v import (
+        AtlasSeedance25ImageToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasSeedance25ImageToVideo().run(None, bad_image)
+
+
+def test_seedance_25_r2v_metadata():
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_r2v import (
+        AtlasSeedance25ReferenceToVideo,
+    )
+
+    _seedance_25_common_assertions(AtlasSeedance25ReferenceToVideo)
+    inputs = AtlasSeedance25ReferenceToVideo.INPUT_TYPES()
+    assert "reference_images" in inputs["required"]
+    assert "reference_videos" in inputs["required"]
+    assert "reference_audios" in inputs["optional"]
+
+
+@pytest.mark.parametrize("images,videos", [("", ""), ("   ", "\n  \n")])
+def test_seedance_25_r2v_requires_a_reference(images, videos):
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_r2v import (
+        AtlasSeedance25ReferenceToVideo,
+    )
+
+    with pytest.raises(RuntimeError, match="at least one reference image or reference video"):
+        AtlasSeedance25ReferenceToVideo().run(None, images, videos)
+
+
+def test_seedream_v50_pro_layer_decomposition_metadata():
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_pro_layer_decomposition import (
+        AtlasSeedreamV50ProLayerDecomposition,
+    )
+
+    cls = AtlasSeedreamV50ProLayerDecomposition
+    inputs = cls.INPUT_TYPES()
+    required = inputs["required"]
+    assert "atlas_client" in required
+    assert "image" in required
+    assert required["size"][0] == ["auto", "1K", "1.5K", "2K"]
+    assert required["size"][1]["default"] == "auto"
+    assert required["output_format"][0] == ["jpeg", "png"]
+    assert required["output_format"][1]["default"] == "jpeg"
+    assert required["enable_base64_output"][0] == "BOOLEAN"
+    assert "prompt" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING", "STRING")
+    assert cls.RETURN_NAMES == ("image_url", "layer_urls", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Image"
+
+
+@pytest.mark.parametrize("bad_image", ["", "  "])
+def test_seedream_v50_pro_layer_decomposition_requires_image(bad_image):
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_pro_layer_decomposition import (
+        AtlasSeedreamV50ProLayerDecomposition,
+    )
+
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasSeedreamV50ProLayerDecomposition().run(None, bad_image, "auto", "jpeg", False)
+
+
+def test_new_nodes_2026_08_07_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    keys = [
+        "AtlasCloud Seedance 2.5 Text-to-Video",
+        "AtlasCloud Seedance 2.5 Image-to-Video",
+        "AtlasCloud Seedance 2.5 Reference-to-Video",
+        "AtlasCloud Seedream V5.0 Pro Layer Decomposition",
+    ]
+    for key in keys:
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_08_07_model_ids():
+    from src.atlascloud_comfyui.nodes.image.seedream_v50_pro_layer_decomposition import (
+        AtlasSeedreamV50ProLayerDecomposition,
+    )
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_i2v import (
+        AtlasSeedance25ImageToVideo,
+    )
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_r2v import (
+        AtlasSeedance25ReferenceToVideo,
+    )
+    from src.atlascloud_comfyui.nodes.video.bytedance_seedance_2_5_t2v import (
+        AtlasSeedance25TextToVideo,
+    )
+
+    expected = [
+        (AtlasSeedance25TextToVideo, "bytedance/seedance-2.5/text-to-video"),
+        (AtlasSeedance25ImageToVideo, "bytedance/seedance-2.5/image-to-video"),
+        (AtlasSeedance25ReferenceToVideo, "bytedance/seedance-2.5/reference-to-video"),
+        (
+            AtlasSeedreamV50ProLayerDecomposition,
+            "bytedance/seedream-v5.0-pro/layer-decomposition",
+        ),
+    ]
+    for cls, model_id in expected:
+        source = inspect.getsource(cls.run)
+        assert f'"model": "{model_id}"' in source


### PR DESCRIPTION
Daily AtlasCloud → ComfyUI node sync.

## New models

| Node | Model ID |
| --- | --- |
| AtlasCloud Seedance 2.5 Text-to-Video | `bytedance/seedance-2.5/text-to-video` |
| AtlasCloud Seedance 2.5 Image-to-Video | `bytedance/seedance-2.5/image-to-video` |
| AtlasCloud Seedance 2.5 Reference-to-Video | `bytedance/seedance-2.5/reference-to-video` |
| AtlasCloud Seedream V5.0 Pro Layer Decomposition | `bytedance/seedream-v5.0-pro/layer-decomposition` |

Params follow each model's published OpenAPI schema:
- Seedance 2.5 duration enum extends to 30s, resolution is `480p`/`720p` only, adds `output_format` (mp4/mov), and has no `seed` param (unlike 2.0). I2V `ratio` is `adaptive`-only per schema.
- Layer Decomposition returns the base image as `image_url` plus the decomposed layers as newline-joined `layer_urls`.

Also updated: `registry.py` (imports + class/display mappings), README Available Nodes table.

## Testing

- `ruff check .` → all checks passed
- `pytest tests/ -k "not e2e"` → 465 passed, 26 deselected (E2E skipped: no local ComfyUI source on the sync host)
- New metadata-only tests in `tests/test_new_nodes_2026_08_07.py` covering INPUT_TYPES, return signatures, required-input validation, registry wiring, and exact model IDs.

## Out of scope

7 other missing visual-typed models this cycle are `*-to-3d` (Seed3D 2.0, Hunyuan3D Rapid/Pro, Tripo H3.1). They report `type=Image` but output mesh archives, so no existing image-node shape fits — skipped as in prior cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)