### PR TITLE
sync: add 2 AtlasCloud models (2026-08-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Qwen Image 3.0 Text-to-Image | qwen-image-3.0/text-to-image |
 | AtlasCloud Grok Imagine IQ Text-to-Image | xai/grok-imagine-image-quality/text-to-image |
 | AtlasCloud Grok Imagine Text-to-Image | xai/grok-imagine-image/text-to-image |
+| AtlasCloud Grok Imagine Image 2.0 Text-to-Image | xai/grok-imagine-image-2.0/text-to-image |
 | AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
 | AtlasCloud MAI-Image-2.5 Text-to-Image | microsoft/mai-image-2.5/text-to-image |
 | AtlasCloud MAI-Image-2.5-Flash Text-to-Image | microsoft/mai-image-2.5-flash/text-to-image |
@@ -490,6 +491,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Qwen Image 3.0 Edit | qwen-image-3.0/edit |
 | AtlasCloud Grok Imagine IQ Edit | xai/grok-imagine-image-quality/edit |
 | AtlasCloud Grok Imagine Edit | xai/grok-imagine-image/edit |
+| AtlasCloud Grok Imagine Image 2.0 Edit | xai/grok-imagine-image-2.0/edit |
 | AtlasCloud GPT Image-2 Edit | openai/gpt-image-2/edit |
 | AtlasCloud GPT Image-2 Developer Edit | openai/gpt-image-2-developer/edit |
 | AtlasCloud LTX 2.3 Quality Text-to-Video | ltx-2.3-quality/text-to-video |

--- a/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_20_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_20_edit.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineImage20Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit prompt; cite multiple sources as <IMAGE_0>, <IMAGE_1>, <IMAGE_2>"}),
+                "image_urls": ("STRING", {"multiline": True, "tooltip": "1-3 image URLs or data URIs (one per line)"}),
+                "resolution": (["1k", "2k"], {"default": "1k"}),
+                "quality": (["low", "medium"], {"default": "medium", "tooltip": "low is cheaper and ~8x faster; medium is the best output"}),
+                "aspect_ratio": (
+                    ["auto", "1:1", "3:4", "4:3", "9:16", "16:9", "2:3", "3:2", "9:19.5", "19.5:9", "9:20", "20:9", "1:2", "2:1"],
+                    {"default": "auto", "tooltip": "Aspect ratio"},
+                ),
+                "num_images": ([1, 2, 3, 4], {"default": 1}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image_urls: str,
+        resolution: str,
+        quality: str,
+        aspect_ratio: str,
+        num_images: int,
+        enable_base64_output: bool,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        images: List[str] = [u.strip() for u in (image_urls or "").splitlines() if u.strip()]
+        if not images:
+            raise RuntimeError("image_urls is required (provide 1-3 URLs, one per line)")
+        if len(images) > 3:
+            raise RuntimeError("image_urls maxItems is 3")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-image-2.0/edit",
+            "prompt": prompt,
+            "image_urls": images,
+            "resolution": resolution,
+            "quality": quality,
+            "aspect_ratio": aspect_ratio,
+            "num_images": int(num_images),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_20_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/xai_grok_imagine_image_20_t2i.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGrokImagineImage20TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (up to 8000 characters)"}),
+                "resolution": (["1k", "2k"], {"default": "1k"}),
+                "quality": (["low", "medium"], {"default": "medium", "tooltip": "low is cheaper and ~8x faster; medium is the best output"}),
+                "aspect_ratio": (
+                    ["1:1", "3:4", "4:3", "9:16", "16:9", "2:3", "3:2", "9:19.5", "19.5:9", "9:20", "20:9", "1:2", "2:1"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "num_images": ([1, 2, 3, 4], {"default": 1}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+            },
+            "optional": {
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str,
+        quality: str,
+        aspect_ratio: str,
+        num_images: int,
+        enable_base64_output: bool,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "xai/grok-imagine-image-2.0/text-to-image",
+            "prompt": prompt,
+            "resolution": resolution,
+            "quality": quality,
+            "aspect_ratio": aspect_ratio,
+            "num_images": int(num_images),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -273,6 +273,8 @@ from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_t2i import At
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_quality_edit import AtlasGrokImagineImageQualityEdit
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_t2i import AtlasGrokImagineImageTextToImage
 from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_edit import AtlasGrokImagineImageEdit
+from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_20_t2i import AtlasGrokImagineImage20TextToImage
+from atlascloud_comfyui.nodes.image.xai_grok_imagine_image_20_edit import AtlasGrokImagineImage20Edit
 
 from atlascloud_comfyui.nodes.image.seedream_v50_pro_t2i import AtlasSeedreamV50ProTextToImage
 from atlascloud_comfyui.nodes.image.seedream_v50_pro_edit import AtlasSeedreamV50ProEdit
@@ -751,6 +753,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Grok Imagine IQ Edit": AtlasGrokImagineImageQualityEdit,
     "AtlasCloud Grok Imagine Text-to-Image": AtlasGrokImagineImageTextToImage,
     "AtlasCloud Grok Imagine Edit": AtlasGrokImagineImageEdit,
+    "AtlasCloud Grok Imagine Image 2.0 Text-to-Image": AtlasGrokImagineImage20TextToImage,
+    "AtlasCloud Grok Imagine Image 2.0 Edit": AtlasGrokImagineImage20Edit,
     "AtlasCloud Kling V2.0 I2V Master": AtlasKlingV20I2VMaster,
     "AtlasCloud VEO3 Fast Image-to-Video": AtlasVeo3FastImageToVideo,
     "AtlasCloud Kling V2.1 T2V Master": AtlasKlingV21T2VMaster,
@@ -1123,6 +1127,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Grok Imagine IQ Edit": "AtlasCloud Grok Imagine IQ Edit",
     "AtlasCloud Grok Imagine Text-to-Image": "AtlasCloud Grok Imagine Text-to-Image",
     "AtlasCloud Grok Imagine Edit": "AtlasCloud Grok Imagine Edit",
+    "AtlasCloud Grok Imagine Image 2.0 Text-to-Image": "AtlasCloud Grok Imagine Image 2.0 Text-to-Image",
+    "AtlasCloud Grok Imagine Image 2.0 Edit": "AtlasCloud Grok Imagine Image 2.0 Edit",
     "AtlasCloud Kling V2.0 I2V Master": "AtlasCloud Kling V2.0 I2V Master",
     "AtlasCloud VEO3 Fast Image-to-Video": "AtlasCloud VEO3 Fast Image-to-Video",
     "AtlasCloud Kling V2.1 T2V Master": "AtlasCloud Kling V2.1 T2V Master",

--- a/tests/test_new_nodes_2026_08_11.py
+++ b/tests/test_new_nodes_2026_08_11.py
@@ -1,0 +1,106 @@
+"""Metadata-only tests for newly added nodes (2026-08-11).
+
+New models: xAI Grok Imagine Image 2.0 (text-to-image, edit).
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+_T2I_RATIOS = ["1:1", "3:4", "4:3", "9:16", "16:9", "2:3", "3:2", "9:19.5", "19.5:9", "9:20", "20:9", "1:2", "2:1"]
+
+
+def _grok_image_20_common_assertions(cls):
+    inputs = cls.INPUT_TYPES()
+    required = inputs["required"]
+    assert "atlas_client" in required
+    assert "prompt" in required
+    assert required["resolution"][0] == ["1k", "2k"]
+    assert required["resolution"][1]["default"] == "1k"
+    assert required["quality"][0] == ["low", "medium"]
+    assert required["quality"][1]["default"] == "medium"
+    assert required["num_images"][0] == [1, 2, 3, 4]
+    assert required["enable_base64_output"][0] == "BOOLEAN"
+    assert "poll_interval_sec" in inputs["optional"]
+    assert "timeout_sec" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("image_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Image"
+
+
+def test_grok_imagine_image_20_t2i_metadata():
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_20_t2i import (
+        AtlasGrokImagineImage20TextToImage,
+    )
+
+    _grok_image_20_common_assertions(AtlasGrokImagineImage20TextToImage)
+    inputs = AtlasGrokImagineImage20TextToImage.INPUT_TYPES()
+    assert inputs["required"]["aspect_ratio"][0] == _T2I_RATIOS
+    assert inputs["required"]["aspect_ratio"][1]["default"] == "1:1"
+
+
+def test_grok_imagine_image_20_edit_metadata():
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_20_edit import (
+        AtlasGrokImagineImage20Edit,
+    )
+
+    _grok_image_20_common_assertions(AtlasGrokImagineImage20Edit)
+    inputs = AtlasGrokImagineImage20Edit.INPUT_TYPES()
+    assert "image_urls" in inputs["required"]
+    # The edit endpoint adds an "auto" ratio on top of the text-to-image set.
+    assert inputs["required"]["aspect_ratio"][0] == ["auto"] + _T2I_RATIOS
+    assert inputs["required"]["aspect_ratio"][1]["default"] == "auto"
+
+
+@pytest.mark.parametrize("bad_urls", ["", "   ", "\n  \n"])
+def test_grok_imagine_image_20_edit_requires_image_urls(bad_urls):
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_20_edit import (
+        AtlasGrokImagineImage20Edit,
+    )
+
+    with pytest.raises(RuntimeError, match="image_urls is required"):
+        AtlasGrokImagineImage20Edit().run(None, "edit it", bad_urls, "1k", "medium", "auto", 1, False)
+
+
+def test_grok_imagine_image_20_edit_rejects_more_than_three_images():
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_20_edit import (
+        AtlasGrokImagineImage20Edit,
+    )
+
+    urls = "\n".join(f"https://example.com/{i}.png" for i in range(4))
+    with pytest.raises(RuntimeError, match="maxItems is 3"):
+        AtlasGrokImagineImage20Edit().run(None, "edit it", urls, "1k", "medium", "auto", 1, False)
+
+
+def test_new_nodes_2026_08_11_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    keys = [
+        "AtlasCloud Grok Imagine Image 2.0 Text-to-Image",
+        "AtlasCloud Grok Imagine Image 2.0 Edit",
+    ]
+    for key in keys:
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_08_11_model_ids():
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_20_edit import (
+        AtlasGrokImagineImage20Edit,
+    )
+    from src.atlascloud_comfyui.nodes.image.xai_grok_imagine_image_20_t2i import (
+        AtlasGrokImagineImage20TextToImage,
+    )
+
+    expected = [
+        (AtlasGrokImagineImage20TextToImage, "xai/grok-imagine-image-2.0/text-to-image"),
+        (AtlasGrokImagineImage20Edit, "xai/grok-imagine-image-2.0/edit"),
+    ]
+    for cls, model_id in expected:
+        source = inspect.getsource(cls.run)
+        assert f'"model": "{model_id}"' in source
+        assert '"quality": quality' in source


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync for 2026-08-11.

## New models
- \`xai/grok-imagine-image-2.0/text-to-image\` — AtlasCloud Grok Imagine Image 2.0 Text-to-Image
- \`xai/grok-imagine-image-2.0/edit\` — AtlasCloud Grok Imagine Image 2.0 Edit

Both follow the existing Grok Imagine image node style and add the new \`quality\` tier (low/medium) exposed by the 2.0 schema. The edit node validates \`image_urls\` (1-3, per schema \`maxItems\`).

## Diff summary
API total 467 / visual 327; repo supported 369; missing visual 9 — 7 of those are \`*-to-3d\` models (mesh/zip outputs, no image-node infra fits) and remain out of scope.

## Tests
- \`python3 -m ruff check .\` → All checks passed
- \`python3 -m pytest tests/ -k "not e2e and not test_e2e"\` → 473 passed, 26 deselected

E2E skipped: no local ComfyUI source on the sync machine.