### PR TITLE
sync: add 9 AtlasCloud models (2026-08-24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,14 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud HappyHorse 1.0 Reference-to-Video | alibaba/happyhorse-1.0/reference-to-video |
 | AtlasCloud HappyHorse 1.1 Reference-to-Video | alibaba/happyhorse-1.1/reference-to-video |
 | AtlasCloud WAN2.7 Reference-to-Video | alibaba/wan-2.7/reference-to-video |
+| AtlasCloud WAN3.0 Text-to-Video | alibaba/wan-3.0/text-to-video |
+| AtlasCloud WAN3.0 Image-to-Video | alibaba/wan-3.0/image-to-video |
+| AtlasCloud WAN3.0 Reference-to-Video | alibaba/wan-3.0/reference-to-video |
+| AtlasCloud Studio Food Motion | atlascloud/studio/food-motion |
+| AtlasCloud Studio Virtual Try-On | atlascloud/studio/virtual-try-on |
+| AtlasCloud Studio UGC Ad | atlascloud/studio/ugc-ad |
+| AtlasCloud Studio Trend Remix | atlascloud/studio/trend-remix |
+| AtlasCloud Studio TVC Maker | atlascloud/studio/tvc-maker |
 | AtlasCloud WAN2.6 Image-to-Video Flash | alibaba/wan-2.6/image-to-video-flash |
 | AtlasCloud Kling Video O3 Pro Image-to-Video | kwaivgi/kling-video-o3-pro/image-to-video |
 | AtlasCloud Kling Video O3 Std Image-to-Video | kwaivgi/kling-video-o3-std/image-to-video |
@@ -491,6 +499,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Qwen Image Edit Plus 20251215 | alibaba/qwen-image/edit-plus-20251215 |
 | AtlasCloud Qwen Image 3.0 Edit | qwen-image-3.0/edit |
 | AtlasCloud Qwen Image 3.0 Pro Edit | qwen-image-3.0-pro/edit |
+| AtlasCloud Studio Product Visuals | atlascloud/studio/product-visuals |
 | AtlasCloud Grok Imagine IQ Edit | xai/grok-imagine-image-quality/edit |
 | AtlasCloud Grok Imagine Edit | xai/grok-imagine-image/edit |
 | AtlasCloud Grok Imagine Image 2.0 Edit | xai/grok-imagine-image-2.0/edit |

--- a/src/atlascloud_comfyui/nodes/image/atlascloud_studio_product_visuals.py
+++ b/src/atlascloud_comfyui/nodes/image/atlascloud_studio_product_visuals.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_VISUAL_TYPES = ["product_hero", "product_detail", "promo_poster"]
+_RATIOS = ["1:1", "3:4", "4:3", "16:9", "9:16"]
+_RESOLUTIONS = ["1k", "2k", "4k"]
+_FORMATS = ["png", "jpeg"]
+
+
+class AtlasStudioProductVisuals:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "product_image": ("STRING", {"default": "", "tooltip": "Product image URL (<=10MB)"}),
+                "user_prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Brand, key benefits and the visual style you want"},
+                ),
+            },
+            "optional": {
+                "model_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional model image URL; omit to let the model invent one when needed"},
+                ),
+                "visual_type": (_VISUAL_TYPES, {"default": "product_hero", "tooltip": "Layout: hero shot, detail page or poster"}),
+                "ratio": (_RATIOS, {"default": "9:16", "tooltip": "Aspect ratio"}),
+                "resolution": (
+                    _RESOLUTIONS,
+                    {"default": "2k", "tooltip": "Output resolution; 4:3 and 3:4 have no mid tier, 1:1 caps at 2048"},
+                ),
+                "format": (_FORMATS, {"default": "png", "tooltip": "Output image format"}),
+                "count": ("INT", {"default": 1, "min": 1, "max": 4, "tooltip": "Number of images to generate"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 600, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        product_image: str,
+        user_prompt: str,
+        model_image: str = "",
+        visual_type: str = "product_hero",
+        ratio: str = "9:16",
+        resolution: str = "2k",
+        format: str = "png",
+        count: int = 1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 600,
+    ) -> Tuple[str, str]:
+        product_image = (product_image or "").strip()
+        if not product_image:
+            raise RuntimeError("product_image is required for AtlasCloud Studio Product Visuals")
+
+        user_prompt = (user_prompt or "").strip()
+        if not user_prompt:
+            raise RuntimeError("user_prompt is required for AtlasCloud Studio Product Visuals")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/studio/product-visuals",
+            "product_image": product_image,
+            "user_prompt": user_prompt,
+            "visual_type": visual_type,
+            "ratio": ratio,
+            "resolution": resolution,
+            "format": format,
+            "count": int(count),
+        }
+
+        mi = (model_image or "").strip()
+        if mi:
+            payload["model_image"] = mi
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_i2v.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RESOLUTIONS = ["1080P", "720P", "480P"]
+
+
+class AtlasWan30ImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Motion / action for the video (up to 20000 chars)"}),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL (jpeg/jpg/png/bmp/webp)"}),
+            },
+            "optional": {
+                "last_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional last frame; the model interpolates from the first frame to it"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "1080P", "tooltip": "Resolution"}),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": -1, "max": 30, "tooltip": "Video length in seconds (2-30); -1 for smart-duration"},
+                ),
+                "audio": ("BOOLEAN", {"default": True, "tooltip": "Include an audio track (same price either way)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        last_image: str = "",
+        resolution: str = "1080P",
+        duration: int = 5,
+        audio: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN3.0 Image-to-Video")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud WAN3.0 Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-3.0/image-to-video",
+            "prompt": prompt,
+            "image": image,
+            "resolution": resolution,
+            "duration": int(duration),
+            "audio": bool(audio),
+        }
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_r2v.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RESOLUTIONS = ["1080P", "720P", "480P"]
+_RATIOS = ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16"]
+
+# Per-kind caps from the model's x-media-limits.
+_MAX_IMAGES = 10
+_MAX_VIDEOS = 5
+_MAX_AUDIOS = 5
+_MAX_REFERS = 20
+
+
+class AtlasWan30ReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Scene and action for the referenced subjects"}),
+                "reference_images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0-10 reference image URLs, ONE PER LINE"},
+                ),
+            },
+            "optional": {
+                "reference_videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0-5 reference video URLs (<=15s total), ONE PER LINE"},
+                ),
+                "reference_audios": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0-5 reference audio URLs (<=15s total), ONE PER LINE"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "1080P", "tooltip": "Resolution"}),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": -1, "max": 30, "tooltip": "Video length in seconds (2-30); -1 for smart-duration"},
+                ),
+                "ratio": (_RATIOS, {"default": "adaptive", "tooltip": "Aspect ratio; 'adaptive' derives it from the references"}),
+                "audio": ("BOOLEAN", {"default": True, "tooltip": "Include an audio track (same price either way)"}),
+                "enable_thinking": ("BOOLEAN", {"default": True, "tooltip": "Let the model reason over the references first"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        reference_images: str,
+        reference_videos: str = "",
+        reference_audios: str = "",
+        resolution: str = "1080P",
+        duration: int = 5,
+        ratio: str = "adaptive",
+        audio: bool = True,
+        enable_thinking: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN3.0 Reference-to-Video")
+
+        # Split on newlines, NOT commas: base64 data URLs contain a comma.
+        images: List[str] = [u.strip() for u in (reference_images or "").splitlines() if u.strip()]
+        videos: List[str] = [u.strip() for u in (reference_videos or "").splitlines() if u.strip()]
+        audios: List[str] = [u.strip() for u in (reference_audios or "").splitlines() if u.strip()]
+
+        if not images and not videos and not audios:
+            raise RuntimeError("Provide at least one reference image, video or audio")
+        if len(images) > _MAX_IMAGES:
+            raise RuntimeError(f"reference_images maxItems is {_MAX_IMAGES}")
+        if len(videos) > _MAX_VIDEOS:
+            raise RuntimeError(f"reference_videos maxItems is {_MAX_VIDEOS}")
+        if len(audios) > _MAX_AUDIOS:
+            raise RuntimeError(f"reference_audios maxItems is {_MAX_AUDIOS}")
+
+        refers: List[Dict[str, str]] = []
+        refers.extend({"url": u, "type": "image"} for u in images)
+        refers.extend({"url": u, "type": "video"} for u in videos)
+        refers.extend({"url": u, "type": "audio"} for u in audios)
+        if len(refers) > _MAX_REFERS:
+            raise RuntimeError(f"refers maxItems is {_MAX_REFERS}")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-3.0/reference-to-video",
+            "prompt": prompt,
+            "refers": refers,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "audio": bool(audio),
+            "enable_thinking": bool(enable_thinking),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_t2v.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RESOLUTIONS = ["1080P", "720P", "480P"]
+_RATIOS = ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16"]
+
+
+class AtlasWan30TextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Scene, subject and action (up to 20000 chars)"}),
+            },
+            "optional": {
+                "resolution": (_RESOLUTIONS, {"default": "1080P", "tooltip": "Resolution"}),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": -1, "max": 30, "tooltip": "Video length in seconds (2-30); -1 for smart-duration"},
+                ),
+                "ratio": (_RATIOS, {"default": "adaptive", "tooltip": "Aspect ratio; 'adaptive' lets the model choose"}),
+                "audio": ("BOOLEAN", {"default": True, "tooltip": "Include an audio track (same price either way)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str = "1080P",
+        duration: int = 5,
+        ratio: str = "adaptive",
+        audio: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN3.0 Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-3.0/text-to-video",
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "audio": bool(audio),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_studio_food_motion.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_studio_food_motion.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RATIOS = ["16:9", "9:16", "1:1", "3:4", "4:3"]
+_RESOLUTIONS = ["480p", "720p", "720p-esr", "1080p-esr", "1440p-esr", "4k-esr"]
+
+
+class AtlasStudioFoodMotion:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "product_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Food/drink product image URL (single image, <=10MB)"},
+                ),
+                "user_prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Brand, flavors, textures and the tone you want"},
+                ),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 10, "min": 4, "max": 15, "tooltip": "Video length in seconds (4-15)"}),
+                "ratio": (_RATIOS, {"default": "16:9", "tooltip": "Aspect ratio; use 9:16 for vertical short video"}),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Resolution; -esr tiers upscale after generation"}),
+                "generate_audio": (["yes", "no"], {"default": "yes", "tooltip": "Generate ambient/food sound and light score"}),
+                "count": ("INT", {"default": 1, "min": 1, "max": 2, "tooltip": "How many variants to generate"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 1800, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        product_image: str,
+        user_prompt: str,
+        duration: int = 10,
+        ratio: str = "16:9",
+        resolution: str = "720p",
+        generate_audio: str = "yes",
+        count: int = 1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 1800,
+    ) -> Tuple[str, str]:
+        product_image = (product_image or "").strip()
+        if not product_image:
+            raise RuntimeError("product_image is required for AtlasCloud Studio Food Motion")
+
+        user_prompt = (user_prompt or "").strip()
+        if not user_prompt:
+            raise RuntimeError("user_prompt is required for AtlasCloud Studio Food Motion")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/studio/food-motion",
+            "product_image": [product_image],
+            "user_prompt": user_prompt,
+            "duration": int(duration),
+            "ratio": ratio,
+            "resolution": resolution,
+            "generate_audio": generate_audio,
+            "count": int(count),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_studio_trend_remix.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_studio_trend_remix.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RATIOS = ["16:9", "9:16", "1:1", "3:4", "4:3"]
+_RESOLUTIONS = ["480p", "720p", "720p-esr", "1080p-esr", "1440p-esr", "4k-esr"]
+
+
+class AtlasStudioTrendRemix:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "product_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Product image URL to place into the remix (single image, <=10MB)"},
+                ),
+                "reference_video": (
+                    "STRING",
+                    {"default": "", "tooltip": "Trending reference video URL, 4-20s, <=20MB, mp4/mov"},
+                ),
+                "user_prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Brand, selling points and the style/tone you want"},
+                ),
+            },
+            "optional": {
+                "model_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional model image URL; pass it only to lock the same on-camera person"},
+                ),
+                "duration": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 20, "tooltip": "Video length in seconds (4-20); 0 matches the reference video"},
+                ),
+                "ratio": (_RATIOS, {"default": "16:9", "tooltip": "Aspect ratio; use 9:16 for vertical short video"}),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Resolution; -esr tiers upscale after generation"}),
+                "generate_audio": (["yes", "no"], {"default": "yes", "tooltip": "Generate ambient sound and light score"}),
+                "count": ("INT", {"default": 1, "min": 1, "max": 2, "tooltip": "How many variants to generate"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 1800, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        product_image: str,
+        reference_video: str,
+        user_prompt: str,
+        model_image: str = "",
+        duration: int = 0,
+        ratio: str = "16:9",
+        resolution: str = "720p",
+        generate_audio: str = "yes",
+        count: int = 1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 1800,
+    ) -> Tuple[str, str]:
+        product_image = (product_image or "").strip()
+        if not product_image:
+            raise RuntimeError("product_image is required for AtlasCloud Studio Trend Remix")
+
+        reference_video = (reference_video or "").strip()
+        if not reference_video:
+            raise RuntimeError("reference_video is required for AtlasCloud Studio Trend Remix")
+
+        user_prompt = (user_prompt or "").strip()
+        if not user_prompt:
+            raise RuntimeError("user_prompt is required for AtlasCloud Studio Trend Remix")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/studio/trend-remix",
+            "product_image": [product_image],
+            "reference_video": [reference_video],
+            "user_prompt": user_prompt,
+            "ratio": ratio,
+            "resolution": resolution,
+            "generate_audio": generate_audio,
+            "count": int(count),
+        }
+
+        mi = (model_image or "").strip()
+        if mi:
+            payload["model_image"] = [mi]
+
+        # duration is optional: leaving it out makes the clip match the reference video's length.
+        if int(duration) > 0:
+            payload["duration"] = int(duration)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_studio_tvc_maker.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_studio_tvc_maker.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RATIOS = ["16:9", "9:16", "1:1", "3:4", "4:3"]
+_RESOLUTIONS = ["480p", "720p", "720p-esr", "1080p-esr", "1440p-esr", "4k-esr"]
+
+
+class AtlasStudioTvcMaker:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "product_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Product image URL (single image, <=10MB); packaging and copy follow it"},
+                ),
+                "user_prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Brand story, selling points, audience and campaign tone"},
+                ),
+            },
+            "optional": {
+                "model_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional model image URL; omit to invent a character from the brand tone"},
+                ),
+                "duration": ("INT", {"default": 10, "min": 4, "max": 30, "tooltip": "Video length in seconds (4-30)"}),
+                "ratio": (_RATIOS, {"default": "16:9", "tooltip": "Aspect ratio; use 9:16 for vertical short video"}),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Resolution; -esr tiers upscale after generation"}),
+                "generate_audio": (["yes", "no"], {"default": "yes", "tooltip": "Generate ambient sound and light score"}),
+                "count": ("INT", {"default": 1, "min": 1, "max": 2, "tooltip": "How many variants to generate"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 1800, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        product_image: str,
+        user_prompt: str,
+        model_image: str = "",
+        duration: int = 10,
+        ratio: str = "16:9",
+        resolution: str = "720p",
+        generate_audio: str = "yes",
+        count: int = 1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 1800,
+    ) -> Tuple[str, str]:
+        product_image = (product_image or "").strip()
+        if not product_image:
+            raise RuntimeError("product_image is required for AtlasCloud Studio TVC Maker")
+
+        user_prompt = (user_prompt or "").strip()
+        if not user_prompt:
+            raise RuntimeError("user_prompt is required for AtlasCloud Studio TVC Maker")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/studio/tvc-maker",
+            "product_image": [product_image],
+            "user_prompt": user_prompt,
+            "duration": int(duration),
+            "ratio": ratio,
+            "resolution": resolution,
+            "generate_audio": generate_audio,
+            "count": int(count),
+        }
+
+        mi = (model_image or "").strip()
+        if mi:
+            payload["model_image"] = [mi]
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_studio_ugc_ad.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_studio_ugc_ad.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_AD_TYPES = ["creator_recommendation", "before_after", "unboxing"]
+_RATIOS = ["1:1", "3:4", "4:3", "16:9", "9:16"]
+_RESOLUTIONS = ["480p", "720p", "720p-esr", "1080p-esr", "1440p-esr", "4k-esr"]
+
+
+class AtlasStudioUgcAd:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "product_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Product image URL (<=10MB); a clean product shot works best"},
+                ),
+                "user_prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Selling points, brand tone, or specific shooting requests"},
+                ),
+            },
+            "optional": {
+                "model_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional creator/model image URL; omit to invent a creator"},
+                ),
+                "ad_type": (_AD_TYPES, {"default": "creator_recommendation", "tooltip": "Ad format"}),
+                "duration": ("INT", {"default": 10, "min": 4, "max": 15, "tooltip": "Video length in seconds (4-15)"}),
+                "ratio": (_RATIOS, {"default": "9:16", "tooltip": "Aspect ratio; use 9:16 for vertical short video"}),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Resolution; -esr tiers upscale after generation"}),
+                "generate_audio": (["yes", "no"], {"default": "yes", "tooltip": "Generate creator voice-over and ambient sound"}),
+                "count": ("INT", {"default": 1, "min": 1, "max": 2, "tooltip": "How many variants to generate"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 1800, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        product_image: str,
+        user_prompt: str,
+        model_image: str = "",
+        ad_type: str = "creator_recommendation",
+        duration: int = 10,
+        ratio: str = "9:16",
+        resolution: str = "720p",
+        generate_audio: str = "yes",
+        count: int = 1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 1800,
+    ) -> Tuple[str, str]:
+        product_image = (product_image or "").strip()
+        if not product_image:
+            raise RuntimeError("product_image is required for AtlasCloud Studio UGC Ad")
+
+        user_prompt = (user_prompt or "").strip()
+        if not user_prompt:
+            raise RuntimeError("user_prompt is required for AtlasCloud Studio UGC Ad")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/studio/ugc-ad",
+            "product_image": product_image,
+            "user_prompt": user_prompt,
+            "ad_type": ad_type,
+            "duration": int(duration),
+            "ratio": ratio,
+            "resolution": resolution,
+            "generate_audio": generate_audio,
+            "count": int(count),
+        }
+
+        mi = (model_image or "").strip()
+        if mi:
+            payload["model_image"] = mi
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/atlascloud_studio_virtual_try_on.py
+++ b/src/atlascloud_comfyui/nodes/video/atlascloud_studio_virtual_try_on.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RATIOS = ["16:9", "9:16", "1:1", "3:4", "4:3"]
+_RESOLUTIONS = ["480p", "720p", "720p-esr", "1080p-esr", "1440p-esr", "4k-esr"]
+
+
+class AtlasStudioVirtualTryOn:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "product_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Apparel/accessory product image URL (single image, <=10MB)"},
+                ),
+                "user_prompt": (
+                    "STRING",
+                    {"multiline": True, "tooltip": "Brand, selling points, target audience and the look you want"},
+                ),
+            },
+            "optional": {
+                "model_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional model image URL; omit to auto-design a virtual adult model"},
+                ),
+                "duration": ("INT", {"default": 10, "min": 4, "max": 15, "tooltip": "Video length in seconds (4-15)"}),
+                "ratio": (_RATIOS, {"default": "9:16", "tooltip": "Aspect ratio; use 9:16 for vertical short video"}),
+                "resolution": (_RESOLUTIONS, {"default": "720p", "tooltip": "Resolution; -esr tiers upscale after generation"}),
+                "generate_audio": (["yes", "no"], {"default": "yes", "tooltip": "Generate ambient sound and light score"}),
+                "count": ("INT", {"default": 1, "min": 1, "max": 2, "tooltip": "How many variants to generate"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 1800, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        product_image: str,
+        user_prompt: str,
+        model_image: str = "",
+        duration: int = 10,
+        ratio: str = "9:16",
+        resolution: str = "720p",
+        generate_audio: str = "yes",
+        count: int = 1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 1800,
+    ) -> Tuple[str, str]:
+        product_image = (product_image or "").strip()
+        if not product_image:
+            raise RuntimeError("product_image is required for AtlasCloud Studio Virtual Try-On")
+
+        user_prompt = (user_prompt or "").strip()
+        if not user_prompt:
+            raise RuntimeError("user_prompt is required for AtlasCloud Studio Virtual Try-On")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "atlascloud/studio/virtual-try-on",
+            "product_image": [product_image],
+            "user_prompt": user_prompt,
+            "duration": int(duration),
+            "ratio": ratio,
+            "resolution": resolution,
+            "generate_audio": generate_audio,
+            "count": int(count),
+        }
+
+        mi = (model_image or "").strip()
+        if mi:
+            payload["model_image"] = [mi]
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -220,6 +220,7 @@ from atlascloud_comfyui.nodes.image.qwen_image_30_t2i import AtlasQwenImage30Tex
 from atlascloud_comfyui.nodes.image.qwen_image_30_edit import AtlasQwenImage30Edit
 from atlascloud_comfyui.nodes.image.qwen_image_30_pro_t2i import AtlasQwenImage30ProTextToImage
 from atlascloud_comfyui.nodes.image.qwen_image_30_pro_edit import AtlasQwenImage30ProEdit
+from atlascloud_comfyui.nodes.image.atlascloud_studio_product_visuals import AtlasStudioProductVisuals
 
 from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_t2v import AtlasSeedanceV1ProFastTextToVideo
 from atlascloud_comfyui.nodes.video.seedance_v1_pro_fast_i2v import AtlasSeedanceV1ProFastImageToVideo
@@ -343,6 +344,14 @@ from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_t2v import AtlasWan27TextToV
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_i2v import AtlasWan27ImageToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_r2v import AtlasWan27ReferenceToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_video_edit import AtlasWan27VideoEdit
+from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_t2v import AtlasWan30TextToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_i2v import AtlasWan30ImageToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_r2v import AtlasWan30ReferenceToVideo
+from atlascloud_comfyui.nodes.video.atlascloud_studio_food_motion import AtlasStudioFoodMotion
+from atlascloud_comfyui.nodes.video.atlascloud_studio_virtual_try_on import AtlasStudioVirtualTryOn
+from atlascloud_comfyui.nodes.video.atlascloud_studio_ugc_ad import AtlasStudioUgcAd
+from atlascloud_comfyui.nodes.video.atlascloud_studio_trend_remix import AtlasStudioTrendRemix
+from atlascloud_comfyui.nodes.video.atlascloud_studio_tvc_maker import AtlasStudioTvcMaker
 from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_t2v import AtlasHappyHorse10TextToVideo
 from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_i2v import AtlasHappyHorse10ImageToVideo
 from atlascloud_comfyui.nodes.video.alibaba_happyhorse_1_0_r2v import AtlasHappyHorse10ReferenceToVideo
@@ -507,6 +516,14 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN2.7 Image-to-Video": AtlasWan27ImageToVideo,
     "AtlasCloud WAN2.7 Reference-to-Video": AtlasWan27ReferenceToVideo,
     "AtlasCloud WAN2.7 Video-Edit": AtlasWan27VideoEdit,
+    "AtlasCloud WAN3.0 Text-to-Video": AtlasWan30TextToVideo,
+    "AtlasCloud WAN3.0 Image-to-Video": AtlasWan30ImageToVideo,
+    "AtlasCloud WAN3.0 Reference-to-Video": AtlasWan30ReferenceToVideo,
+    "AtlasCloud Studio Food Motion": AtlasStudioFoodMotion,
+    "AtlasCloud Studio Virtual Try-On": AtlasStudioVirtualTryOn,
+    "AtlasCloud Studio UGC Ad": AtlasStudioUgcAd,
+    "AtlasCloud Studio Trend Remix": AtlasStudioTrendRemix,
+    "AtlasCloud Studio TVC Maker": AtlasStudioTvcMaker,
     "AtlasCloud HappyHorse 1.0 Text-to-Video": AtlasHappyHorse10TextToVideo,
     "AtlasCloud HappyHorse 1.0 Image-to-Video": AtlasHappyHorse10ImageToVideo,
     "AtlasCloud HappyHorse 1.0 Reference-to-Video": AtlasHappyHorse10ReferenceToVideo,
@@ -718,6 +735,7 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Qwen Image 3.0 Edit": AtlasQwenImage30Edit,
     "AtlasCloud Qwen Image 3.0 Pro Text-to-Image": AtlasQwenImage30ProTextToImage,
     "AtlasCloud Qwen Image 3.0 Pro Edit": AtlasQwenImage30ProEdit,
+    "AtlasCloud Studio Product Visuals": AtlasStudioProductVisuals,
     "AtlasCloud Seedance V1 Pro Fast Text-to-Video": AtlasSeedanceV1ProFastTextToVideo,
     "AtlasCloud Seedance V1 Pro Fast Image-to-Video": AtlasSeedanceV1ProFastImageToVideo,
     "AtlasCloud Seedance V1 Pro Image-to-Video 1080p": AtlasBytedanceSeedanceV1ProI2V1080p,
@@ -1094,6 +1112,15 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Qwen Image 3.0 Edit": "AtlasCloud Qwen Image 3.0 Edit",
     "AtlasCloud Qwen Image 3.0 Pro Text-to-Image": "AtlasCloud Qwen Image 3.0 Pro Text-to-Image",
     "AtlasCloud Qwen Image 3.0 Pro Edit": "AtlasCloud Qwen Image 3.0 Pro Edit",
+    "AtlasCloud Studio Product Visuals": "AtlasCloud Studio Product Visuals",
+    "AtlasCloud WAN3.0 Text-to-Video": "AtlasCloud WAN3.0 Text-to-Video",
+    "AtlasCloud WAN3.0 Image-to-Video": "AtlasCloud WAN3.0 Image-to-Video",
+    "AtlasCloud WAN3.0 Reference-to-Video": "AtlasCloud WAN3.0 Reference-to-Video",
+    "AtlasCloud Studio Food Motion": "AtlasCloud Studio Food Motion",
+    "AtlasCloud Studio Virtual Try-On": "AtlasCloud Studio Virtual Try-On",
+    "AtlasCloud Studio UGC Ad": "AtlasCloud Studio UGC Ad",
+    "AtlasCloud Studio Trend Remix": "AtlasCloud Studio Trend Remix",
+    "AtlasCloud Studio TVC Maker": "AtlasCloud Studio TVC Maker",
     "AtlasCloud Seedance V1 Pro Fast Text-to-Video": "AtlasCloud Seedance V1 Pro Fast Text-to-Video",
     "AtlasCloud Seedance V1 Pro Fast Image-to-Video": "AtlasCloud Seedance V1 Pro Fast Image-to-Video",
     "AtlasCloud Seedance V1 Pro Image-to-Video 1080p": "AtlasCloud Seedance V1 Pro Image-to-Video 1080p",

--- a/tests/test_new_nodes_2026_08_24.py
+++ b/tests/test_new_nodes_2026_08_24.py
@@ -1,0 +1,292 @@
+"""Metadata-only tests for newly added nodes (2026-08-24).
+
+New models: Alibaba Wan-3.0 (Text/Image/Reference-to-Video) and the AtlasCloud
+Studio family (Product Visuals, Food Motion, Virtual Try-On, UGC Ad, Trend
+Remix, TVC Maker).
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+from src.atlascloud_comfyui.nodes.image.atlascloud_studio_product_visuals import (
+    AtlasStudioProductVisuals,
+)
+from src.atlascloud_comfyui.nodes.video.alibaba_wan_3_0_i2v import AtlasWan30ImageToVideo
+from src.atlascloud_comfyui.nodes.video.alibaba_wan_3_0_r2v import AtlasWan30ReferenceToVideo
+from src.atlascloud_comfyui.nodes.video.alibaba_wan_3_0_t2v import AtlasWan30TextToVideo
+from src.atlascloud_comfyui.nodes.video.atlascloud_studio_food_motion import AtlasStudioFoodMotion
+from src.atlascloud_comfyui.nodes.video.atlascloud_studio_trend_remix import AtlasStudioTrendRemix
+from src.atlascloud_comfyui.nodes.video.atlascloud_studio_tvc_maker import AtlasStudioTvcMaker
+from src.atlascloud_comfyui.nodes.video.atlascloud_studio_ugc_ad import AtlasStudioUgcAd
+from src.atlascloud_comfyui.nodes.video.atlascloud_studio_virtual_try_on import (
+    AtlasStudioVirtualTryOn,
+)
+
+_VIDEO_CLASSES = [
+    AtlasWan30TextToVideo,
+    AtlasWan30ImageToVideo,
+    AtlasWan30ReferenceToVideo,
+    AtlasStudioFoodMotion,
+    AtlasStudioVirtualTryOn,
+    AtlasStudioUgcAd,
+    AtlasStudioTrendRemix,
+    AtlasStudioTvcMaker,
+]
+
+_WAN30_CLASSES = [AtlasWan30TextToVideo, AtlasWan30ImageToVideo, AtlasWan30ReferenceToVideo]
+
+_STUDIO_VIDEO_CLASSES = [
+    AtlasStudioFoodMotion,
+    AtlasStudioVirtualTryOn,
+    AtlasStudioUgcAd,
+    AtlasStudioTrendRemix,
+    AtlasStudioTvcMaker,
+]
+
+
+@pytest.mark.parametrize("cls", _VIDEO_CLASSES)
+def test_video_node_shape(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "atlas_client" in inputs["required"]
+    assert "poll_interval_sec" in inputs["optional"]
+    assert "timeout_sec" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("video_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Video"
+    assert cls.FUNCTION == "run"
+
+
+@pytest.mark.parametrize("cls", _WAN30_CLASSES)
+def test_wan30_common_options(cls):
+    optional = cls.INPUT_TYPES()["optional"]
+    assert optional["resolution"][0] == ["1080P", "720P", "480P"]
+    assert optional["resolution"][1]["default"] == "1080P"
+    # -1 is the schema's "smart duration" sentinel, so min must allow it.
+    assert optional["duration"][1]["min"] == -1
+    assert optional["duration"][1]["max"] == 30
+    assert optional["duration"][1]["default"] == 5
+    assert optional["audio"][0] == "BOOLEAN"
+    assert optional["audio"][1]["default"] is True
+    assert optional["seed"][1]["min"] == -1
+
+
+def test_wan30_t2v_metadata():
+    inputs = AtlasWan30TextToVideo.INPUT_TYPES()
+    assert "prompt" in inputs["required"]
+    ratio = inputs["optional"]["ratio"]
+    assert ratio[0] == ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16"]
+    assert ratio[1]["default"] == "adaptive"
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "   "])
+def test_wan30_t2v_requires_prompt(bad_prompt):
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasWan30TextToVideo().run(None, bad_prompt)
+
+
+def test_wan30_i2v_metadata():
+    inputs = AtlasWan30ImageToVideo.INPUT_TYPES()
+    assert "prompt" in inputs["required"]
+    assert "image" in inputs["required"]
+    assert "last_image" in inputs["optional"]
+    # image-to-video derives the aspect ratio from the first frame.
+    assert "ratio" not in inputs["optional"]
+
+
+def test_wan30_i2v_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasWan30ImageToVideo().run(None, "  ", "https://example.com/a.png")
+
+
+@pytest.mark.parametrize("bad_image", ["", "   "])
+def test_wan30_i2v_requires_image(bad_image):
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasWan30ImageToVideo().run(None, "a prompt", bad_image)
+
+
+def test_wan30_i2v_omits_empty_last_image():
+    source = inspect.getsource(AtlasWan30ImageToVideo.run)
+    assert 'payload["last_image"] = li' in source
+
+
+def test_wan30_r2v_metadata():
+    inputs = AtlasWan30ReferenceToVideo.INPUT_TYPES()
+    assert "prompt" in inputs["required"]
+    assert "reference_images" in inputs["required"]
+    optional = inputs["optional"]
+    assert "reference_videos" in optional
+    assert "reference_audios" in optional
+    assert optional["enable_thinking"][1]["default"] is True
+
+
+def test_wan30_r2v_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasWan30ReferenceToVideo().run(None, " ", "https://example.com/a.png")
+
+
+@pytest.mark.parametrize("bad_refs", ["", "  \n \n"])
+def test_wan30_r2v_requires_at_least_one_reference(bad_refs):
+    with pytest.raises(RuntimeError, match="at least one reference"):
+        AtlasWan30ReferenceToVideo().run(None, "a prompt", bad_refs)
+
+
+def test_wan30_r2v_rejects_too_many_images():
+    urls = "\n".join(f"https://example.com/{i}.png" for i in range(11))
+    with pytest.raises(RuntimeError, match="reference_images maxItems is 10"):
+        AtlasWan30ReferenceToVideo().run(None, "a prompt", urls)
+
+
+def test_wan30_r2v_rejects_too_many_videos():
+    urls = "\n".join(f"https://example.com/{i}.mp4" for i in range(6))
+    with pytest.raises(RuntimeError, match="reference_videos maxItems is 5"):
+        AtlasWan30ReferenceToVideo().run(None, "a prompt", "", urls)
+
+
+def test_wan30_r2v_rejects_too_many_audios():
+    urls = "\n".join(f"https://example.com/{i}.mp3" for i in range(6))
+    with pytest.raises(RuntimeError, match="reference_audios maxItems is 5"):
+        AtlasWan30ReferenceToVideo().run(None, "a prompt", "", "", urls)
+
+
+def test_wan30_r2v_tags_refers_by_kind():
+    source = inspect.getsource(AtlasWan30ReferenceToVideo.run)
+    for kind in ("image", "video", "audio"):
+        assert f'"type": "{kind}"' in source
+
+
+@pytest.mark.parametrize("cls", _STUDIO_VIDEO_CLASSES)
+def test_studio_video_common_options(cls):
+    optional = cls.INPUT_TYPES()["optional"]
+    assert optional["resolution"][0] == ["480p", "720p", "720p-esr", "1080p-esr", "1440p-esr", "4k-esr"]
+    assert optional["resolution"][1]["default"] == "720p"
+    assert optional["generate_audio"][0] == ["yes", "no"]
+    assert optional["generate_audio"][1]["default"] == "yes"
+    assert optional["count"][1]["min"] == 1
+    assert optional["count"][1]["max"] == 2
+
+
+@pytest.mark.parametrize("cls", _STUDIO_VIDEO_CLASSES)
+def test_studio_video_requires_product_image(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "product_image" in inputs["required"]
+    assert "user_prompt" in inputs["required"]
+
+
+def test_studio_food_motion_requires_inputs():
+    with pytest.raises(RuntimeError, match="product_image is required"):
+        AtlasStudioFoodMotion().run(None, "  ", "a prompt")
+    with pytest.raises(RuntimeError, match="user_prompt is required"):
+        AtlasStudioFoodMotion().run(None, "https://example.com/a.png", " ")
+
+
+def test_studio_virtual_try_on_requires_inputs():
+    with pytest.raises(RuntimeError, match="product_image is required"):
+        AtlasStudioVirtualTryOn().run(None, "", "a prompt")
+    with pytest.raises(RuntimeError, match="user_prompt is required"):
+        AtlasStudioVirtualTryOn().run(None, "https://example.com/a.png", "")
+    # Fashion clips default to vertical.
+    assert AtlasStudioVirtualTryOn.INPUT_TYPES()["optional"]["ratio"][1]["default"] == "9:16"
+
+
+def test_studio_ugc_ad_metadata_and_validation():
+    optional = AtlasStudioUgcAd.INPUT_TYPES()["optional"]
+    assert optional["ad_type"][0] == ["creator_recommendation", "before_after", "unboxing"]
+    assert optional["ad_type"][1]["default"] == "creator_recommendation"
+    assert optional["ratio"][1]["default"] == "9:16"
+    with pytest.raises(RuntimeError, match="product_image is required"):
+        AtlasStudioUgcAd().run(None, "", "a prompt")
+    with pytest.raises(RuntimeError, match="user_prompt is required"):
+        AtlasStudioUgcAd().run(None, "https://example.com/a.png", "")
+
+
+def test_studio_trend_remix_requires_reference_video():
+    inputs = AtlasStudioTrendRemix.INPUT_TYPES()
+    assert "reference_video" in inputs["required"]
+    # 0 means "match the reference video length" and is sent as an omitted duration.
+    assert inputs["optional"]["duration"][1]["default"] == 0
+    with pytest.raises(RuntimeError, match="product_image is required"):
+        AtlasStudioTrendRemix().run(None, "", "https://example.com/v.mp4", "a prompt")
+    with pytest.raises(RuntimeError, match="reference_video is required"):
+        AtlasStudioTrendRemix().run(None, "https://example.com/a.png", "  ", "a prompt")
+    with pytest.raises(RuntimeError, match="user_prompt is required"):
+        AtlasStudioTrendRemix().run(None, "https://example.com/a.png", "https://example.com/v.mp4", "")
+
+
+def test_studio_trend_remix_omits_auto_duration():
+    source = inspect.getsource(AtlasStudioTrendRemix.run)
+    assert "if int(duration) > 0:" in source
+
+
+def test_studio_tvc_maker_metadata_and_validation():
+    optional = AtlasStudioTvcMaker.INPUT_TYPES()["optional"]
+    assert optional["duration"][1]["min"] == 4
+    assert optional["duration"][1]["max"] == 30
+    with pytest.raises(RuntimeError, match="product_image is required"):
+        AtlasStudioTvcMaker().run(None, "", "a prompt")
+    with pytest.raises(RuntimeError, match="user_prompt is required"):
+        AtlasStudioTvcMaker().run(None, "https://example.com/a.png", "")
+
+
+def test_studio_product_visuals_metadata():
+    inputs = AtlasStudioProductVisuals.INPUT_TYPES()
+    required = inputs["required"]
+    optional = inputs["optional"]
+    assert "product_image" in required
+    assert "user_prompt" in required
+    assert optional["visual_type"][0] == ["product_hero", "product_detail", "promo_poster"]
+    assert optional["visual_type"][1]["default"] == "product_hero"
+    assert optional["resolution"][0] == ["1k", "2k", "4k"]
+    assert optional["resolution"][1]["default"] == "2k"
+    assert optional["format"][0] == ["png", "jpeg"]
+    assert optional["count"][1]["max"] == 4
+    assert AtlasStudioProductVisuals.RETURN_TYPES == ("STRING", "STRING")
+    assert AtlasStudioProductVisuals.RETURN_NAMES == ("image_url", "prediction_id")
+    assert AtlasStudioProductVisuals.CATEGORY == "AtlasCloud/Image"
+
+
+def test_studio_product_visuals_validation():
+    with pytest.raises(RuntimeError, match="product_image is required"):
+        AtlasStudioProductVisuals().run(None, "  ", "a prompt")
+    with pytest.raises(RuntimeError, match="user_prompt is required"):
+        AtlasStudioProductVisuals().run(None, "https://example.com/a.png", " ")
+
+
+def test_new_nodes_2026_08_24_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    keys = [
+        "AtlasCloud WAN3.0 Text-to-Video",
+        "AtlasCloud WAN3.0 Image-to-Video",
+        "AtlasCloud WAN3.0 Reference-to-Video",
+        "AtlasCloud Studio Product Visuals",
+        "AtlasCloud Studio Food Motion",
+        "AtlasCloud Studio Virtual Try-On",
+        "AtlasCloud Studio UGC Ad",
+        "AtlasCloud Studio Trend Remix",
+        "AtlasCloud Studio TVC Maker",
+    ]
+    for key in keys:
+        assert key in NODE_CLASS_MAPPINGS
+        assert key in NODE_DISPLAY_NAME_MAPPINGS
+
+
+def test_new_nodes_2026_08_24_model_ids():
+    expected = [
+        (AtlasWan30TextToVideo, "alibaba/wan-3.0/text-to-video"),
+        (AtlasWan30ImageToVideo, "alibaba/wan-3.0/image-to-video"),
+        (AtlasWan30ReferenceToVideo, "alibaba/wan-3.0/reference-to-video"),
+        (AtlasStudioProductVisuals, "atlascloud/studio/product-visuals"),
+        (AtlasStudioFoodMotion, "atlascloud/studio/food-motion"),
+        (AtlasStudioVirtualTryOn, "atlascloud/studio/virtual-try-on"),
+        (AtlasStudioUgcAd, "atlascloud/studio/ugc-ad"),
+        (AtlasStudioTrendRemix, "atlascloud/studio/trend-remix"),
+        (AtlasStudioTvcMaker, "atlascloud/studio/tvc-maker"),
+    ]
+    for cls, model_id in expected:
+        source = inspect.getsource(cls.run)
+        assert f'"model": "{model_id}"' in source


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync.

## New models (9)

**Alibaba Wan-3.0**
- `alibaba/wan-3.0/text-to-video` — AtlasCloud WAN3.0 Text-to-Video
- `alibaba/wan-3.0/image-to-video` — AtlasCloud WAN3.0 Image-to-Video
- `alibaba/wan-3.0/reference-to-video` — AtlasCloud WAN3.0 Reference-to-Video

**AtlasCloud Studio**
- `atlascloud/studio/product-visuals` — AtlasCloud Studio Product Visuals (Image)
- `atlascloud/studio/food-motion` — AtlasCloud Studio Food Motion
- `atlascloud/studio/virtual-try-on` — AtlasCloud Studio Virtual Try-On
- `atlascloud/studio/ugc-ad` — AtlasCloud Studio UGC Ad
- `atlascloud/studio/trend-remix` — AtlasCloud Studio Trend Remix
- `atlascloud/studio/tvc-maker` — AtlasCloud Studio TVC Maker

## Notes

- Wan-3.0 exposes `duration = -1` as a "smart duration" sentinel, so the INT widget allows `min = -1`.
- Wan-3.0 reference-to-video takes a single `refers` array of `{url, type}`; the node splits it into three per-kind textareas (images / videos / audios) and enforces the schema's per-kind caps (10 / 5 / 5, 20 total).
- Studio Trend Remix leaves `duration` out of the payload when it is 0, which makes the clip match the reference video's length (schema default).
- The Studio schemas are inconsistent about `product_image` / `model_image` being a bare string vs a 1-element array; each node matches its own schema.

## Tests

- `ruff check .` — passed
- `pytest tests/ -k "not e2e and not test_e2e"` — 531 passed, 26 deselected

E2E was skipped: no ComfyUI source on the sync machine.