### PR TITLE
sync: add 3 AtlasCloud models (2026-08-25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud WAN3.0 Text-to-Video | alibaba/wan-3.0/text-to-video |
 | AtlasCloud WAN3.0 Image-to-Video | alibaba/wan-3.0/image-to-video |
 | AtlasCloud WAN3.0 Reference-to-Video | alibaba/wan-3.0/reference-to-video |
+| AtlasCloud WAN3.0-Prime Text-to-Video | alibaba/wan-3.0-prime/text-to-video |
+| AtlasCloud WAN3.0-Prime Image-to-Video | alibaba/wan-3.0-prime/image-to-video |
+| AtlasCloud WAN3.0-Prime Reference-to-Video | alibaba/wan-3.0-prime/reference-to-video |
 | AtlasCloud Studio Food Motion | atlascloud/studio/food-motion |
 | AtlasCloud Studio Virtual Try-On | atlascloud/studio/virtual-try-on |
 | AtlasCloud Studio UGC Ad | atlascloud/studio/ugc-ad |

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_prime_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_prime_i2v.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RESOLUTIONS = ["1080P", "720P", "480P"]
+
+
+class AtlasWan30PrimeImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Motion / action for the video (up to 20000 chars)"}),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL (jpeg/jpg/png/bmp/webp)"}),
+            },
+            "optional": {
+                "last_image": (
+                    "STRING",
+                    {"default": "", "tooltip": "Optional last frame; the model interpolates from the first frame to it"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "1080P", "tooltip": "Resolution"}),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": -1, "max": 30, "tooltip": "Video length in seconds (2-30); -1 for smart-duration"},
+                ),
+                "audio": ("BOOLEAN", {"default": True, "tooltip": "Include an audio track (same price either way)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        last_image: str = "",
+        resolution: str = "1080P",
+        duration: int = 5,
+        audio: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN3.0-Prime Image-to-Video")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for AtlasCloud WAN3.0-Prime Image-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-3.0-prime/image-to-video",
+            "prompt": prompt,
+            "image": image,
+            "resolution": resolution,
+            "duration": int(duration),
+            "audio": bool(audio),
+        }
+
+        li = (last_image or "").strip()
+        if li:
+            payload["last_image"] = li
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_prime_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_prime_r2v.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RESOLUTIONS = ["1080P", "720P", "480P"]
+_RATIOS = ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16"]
+
+# Per-kind caps from the model's x-media-limits.
+_MAX_IMAGES = 10
+_MAX_VIDEOS = 5
+_MAX_AUDIOS = 5
+_MAX_REFERS = 20
+
+
+class AtlasWan30PrimeReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Scene and action for the referenced subjects"}),
+                "reference_images": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0-10 reference image URLs, ONE PER LINE"},
+                ),
+            },
+            "optional": {
+                "reference_videos": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0-5 reference video URLs (<=15s total), ONE PER LINE"},
+                ),
+                "reference_audios": (
+                    "STRING",
+                    {"multiline": True, "default": "", "tooltip": "0-5 reference audio URLs (<=15s total), ONE PER LINE"},
+                ),
+                "resolution": (_RESOLUTIONS, {"default": "1080P", "tooltip": "Resolution"}),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": -1, "max": 30, "tooltip": "Video length in seconds (2-30); -1 for smart-duration"},
+                ),
+                "ratio": (_RATIOS, {"default": "adaptive", "tooltip": "Aspect ratio; 'adaptive' derives it from the references"}),
+                "audio": ("BOOLEAN", {"default": True, "tooltip": "Include an audio track (same price either way)"}),
+                "enable_thinking": ("BOOLEAN", {"default": True, "tooltip": "Let the model reason over the references first"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        reference_images: str,
+        reference_videos: str = "",
+        reference_audios: str = "",
+        resolution: str = "1080P",
+        duration: int = 5,
+        ratio: str = "adaptive",
+        audio: bool = True,
+        enable_thinking: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN3.0-Prime Reference-to-Video")
+
+        # Split on newlines, NOT commas: base64 data URLs contain a comma.
+        images: List[str] = [u.strip() for u in (reference_images or "").splitlines() if u.strip()]
+        videos: List[str] = [u.strip() for u in (reference_videos or "").splitlines() if u.strip()]
+        audios: List[str] = [u.strip() for u in (reference_audios or "").splitlines() if u.strip()]
+
+        if not images and not videos and not audios:
+            raise RuntimeError("Provide at least one reference image, video or audio")
+        if len(images) > _MAX_IMAGES:
+            raise RuntimeError(f"reference_images maxItems is {_MAX_IMAGES}")
+        if len(videos) > _MAX_VIDEOS:
+            raise RuntimeError(f"reference_videos maxItems is {_MAX_VIDEOS}")
+        if len(audios) > _MAX_AUDIOS:
+            raise RuntimeError(f"reference_audios maxItems is {_MAX_AUDIOS}")
+
+        refers: List[Dict[str, str]] = []
+        refers.extend({"url": u, "type": "image"} for u in images)
+        refers.extend({"url": u, "type": "video"} for u in videos)
+        refers.extend({"url": u, "type": "audio"} for u in audios)
+        if len(refers) > _MAX_REFERS:
+            raise RuntimeError(f"refers maxItems is {_MAX_REFERS}")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-3.0-prime/reference-to-video",
+            "prompt": prompt,
+            "refers": refers,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "audio": bool(audio),
+            "enable_thinking": bool(enable_thinking),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_prime_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/alibaba_wan_3_0_prime_t2v.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+_RESOLUTIONS = ["1080P", "720P", "480P"]
+_RATIOS = ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16"]
+
+
+class AtlasWan30PrimeTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Scene, subject and action (up to 20000 chars)"}),
+            },
+            "optional": {
+                "resolution": (_RESOLUTIONS, {"default": "1080P", "tooltip": "Resolution"}),
+                "duration": (
+                    "INT",
+                    {"default": 5, "min": -1, "max": 30, "tooltip": "Video length in seconds (2-30); -1 for smart-duration"},
+                ),
+                "ratio": (_RATIOS, {"default": "adaptive", "tooltip": "Aspect ratio; 'adaptive' lets the model choose"}),
+                "audio": ("BOOLEAN", {"default": True, "tooltip": "Include an audio track (same price either way)"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str = "1080P",
+        duration: int = 5,
+        ratio: str = "adaptive",
+        audio: bool = True,
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for AtlasCloud WAN3.0-Prime Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "alibaba/wan-3.0-prime/text-to-video",
+            "prompt": prompt,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "audio": bool(audio),
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if not isinstance(first, str):
+            raise RuntimeError(
+                f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}"
+            )
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -347,6 +347,9 @@ from atlascloud_comfyui.nodes.video.alibaba_wan_2_7_video_edit import AtlasWan27
 from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_t2v import AtlasWan30TextToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_i2v import AtlasWan30ImageToVideo
 from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_r2v import AtlasWan30ReferenceToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_prime_t2v import AtlasWan30PrimeTextToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_prime_i2v import AtlasWan30PrimeImageToVideo
+from atlascloud_comfyui.nodes.video.alibaba_wan_3_0_prime_r2v import AtlasWan30PrimeReferenceToVideo
 from atlascloud_comfyui.nodes.video.atlascloud_studio_food_motion import AtlasStudioFoodMotion
 from atlascloud_comfyui.nodes.video.atlascloud_studio_virtual_try_on import AtlasStudioVirtualTryOn
 from atlascloud_comfyui.nodes.video.atlascloud_studio_ugc_ad import AtlasStudioUgcAd
@@ -519,6 +522,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud WAN3.0 Text-to-Video": AtlasWan30TextToVideo,
     "AtlasCloud WAN3.0 Image-to-Video": AtlasWan30ImageToVideo,
     "AtlasCloud WAN3.0 Reference-to-Video": AtlasWan30ReferenceToVideo,
+    "AtlasCloud WAN3.0-Prime Text-to-Video": AtlasWan30PrimeTextToVideo,
+    "AtlasCloud WAN3.0-Prime Image-to-Video": AtlasWan30PrimeImageToVideo,
+    "AtlasCloud WAN3.0-Prime Reference-to-Video": AtlasWan30PrimeReferenceToVideo,
     "AtlasCloud Studio Food Motion": AtlasStudioFoodMotion,
     "AtlasCloud Studio Virtual Try-On": AtlasStudioVirtualTryOn,
     "AtlasCloud Studio UGC Ad": AtlasStudioUgcAd,
@@ -1116,6 +1122,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud WAN3.0 Text-to-Video": "AtlasCloud WAN3.0 Text-to-Video",
     "AtlasCloud WAN3.0 Image-to-Video": "AtlasCloud WAN3.0 Image-to-Video",
     "AtlasCloud WAN3.0 Reference-to-Video": "AtlasCloud WAN3.0 Reference-to-Video",
+    "AtlasCloud WAN3.0-Prime Text-to-Video": "AtlasCloud WAN3.0-Prime Text-to-Video",
+    "AtlasCloud WAN3.0-Prime Image-to-Video": "AtlasCloud WAN3.0-Prime Image-to-Video",
+    "AtlasCloud WAN3.0-Prime Reference-to-Video": "AtlasCloud WAN3.0-Prime Reference-to-Video",
     "AtlasCloud Studio Food Motion": "AtlasCloud Studio Food Motion",
     "AtlasCloud Studio Virtual Try-On": "AtlasCloud Studio Virtual Try-On",
     "AtlasCloud Studio UGC Ad": "AtlasCloud Studio UGC Ad",

--- a/tests/test_new_nodes_2026_08_25.py
+++ b/tests/test_new_nodes_2026_08_25.py
@@ -1,0 +1,166 @@
+"""Metadata-only tests for newly added nodes (2026-08-25).
+
+New models: the Alibaba Wan-3.0-Prime family (Text/Image/Reference-to-Video).
+Its schema mirrors plain Wan-3.0, so these tests also pin the model ids to make
+sure the Prime nodes do not silently fall back to the non-Prime endpoints.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+from src.atlascloud_comfyui.nodes.video.alibaba_wan_3_0_prime_i2v import (
+    AtlasWan30PrimeImageToVideo,
+)
+from src.atlascloud_comfyui.nodes.video.alibaba_wan_3_0_prime_r2v import (
+    AtlasWan30PrimeReferenceToVideo,
+)
+from src.atlascloud_comfyui.nodes.video.alibaba_wan_3_0_prime_t2v import (
+    AtlasWan30PrimeTextToVideo,
+)
+
+_PRIME_CLASSES = [
+    AtlasWan30PrimeTextToVideo,
+    AtlasWan30PrimeImageToVideo,
+    AtlasWan30PrimeReferenceToVideo,
+]
+
+_PRIME_MODEL_IDS = {
+    AtlasWan30PrimeTextToVideo: "alibaba/wan-3.0-prime/text-to-video",
+    AtlasWan30PrimeImageToVideo: "alibaba/wan-3.0-prime/image-to-video",
+    AtlasWan30PrimeReferenceToVideo: "alibaba/wan-3.0-prime/reference-to-video",
+}
+
+
+@pytest.mark.parametrize("cls", _PRIME_CLASSES)
+def test_prime_node_shape(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "atlas_client" in inputs["required"]
+    assert "poll_interval_sec" in inputs["optional"]
+    assert "timeout_sec" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("video_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Video"
+    assert cls.FUNCTION == "run"
+
+
+@pytest.mark.parametrize("cls", _PRIME_CLASSES)
+def test_prime_model_id(cls):
+    source = inspect.getsource(cls.run)
+    assert f'"model": "{_PRIME_MODEL_IDS[cls]}"' in source
+
+
+@pytest.mark.parametrize("cls", _PRIME_CLASSES)
+def test_prime_common_options(cls):
+    optional = cls.INPUT_TYPES()["optional"]
+    assert optional["resolution"][0] == ["1080P", "720P", "480P"]
+    assert optional["resolution"][1]["default"] == "1080P"
+    # -1 is the schema's "smart duration" sentinel, so min must allow it.
+    assert optional["duration"][1]["min"] == -1
+    assert optional["duration"][1]["max"] == 30
+    assert optional["duration"][1]["default"] == 5
+    assert optional["audio"][0] == "BOOLEAN"
+    assert optional["audio"][1]["default"] is True
+    assert optional["seed"][1]["min"] == -1
+
+
+def test_prime_t2v_metadata():
+    inputs = AtlasWan30PrimeTextToVideo.INPUT_TYPES()
+    assert "prompt" in inputs["required"]
+    ratio = inputs["optional"]["ratio"]
+    assert ratio[0] == ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16"]
+    assert ratio[1]["default"] == "adaptive"
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "   "])
+def test_prime_t2v_requires_prompt(bad_prompt):
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasWan30PrimeTextToVideo().run(None, bad_prompt)
+
+
+def test_prime_i2v_metadata():
+    inputs = AtlasWan30PrimeImageToVideo.INPUT_TYPES()
+    assert "prompt" in inputs["required"]
+    assert "image" in inputs["required"]
+    assert "last_image" in inputs["optional"]
+    # image-to-video derives the aspect ratio from the first frame.
+    assert "ratio" not in inputs["optional"]
+
+
+def test_prime_i2v_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasWan30PrimeImageToVideo().run(None, "  ", "https://example.com/a.png")
+
+
+@pytest.mark.parametrize("bad_image", ["", "   "])
+def test_prime_i2v_requires_image(bad_image):
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasWan30PrimeImageToVideo().run(None, "a prompt", bad_image)
+
+
+def test_prime_i2v_omits_empty_last_image():
+    source = inspect.getsource(AtlasWan30PrimeImageToVideo.run)
+    assert 'payload["last_image"] = li' in source
+
+
+def test_prime_r2v_metadata():
+    inputs = AtlasWan30PrimeReferenceToVideo.INPUT_TYPES()
+    assert "prompt" in inputs["required"]
+    assert "reference_images" in inputs["required"]
+    optional = inputs["optional"]
+    assert "reference_videos" in optional
+    assert "reference_audios" in optional
+    assert optional["enable_thinking"][1]["default"] is True
+
+
+def test_prime_r2v_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasWan30PrimeReferenceToVideo().run(None, " ", "https://example.com/a.png")
+
+
+@pytest.mark.parametrize("bad_refs", ["", "  \n \n"])
+def test_prime_r2v_requires_at_least_one_reference(bad_refs):
+    with pytest.raises(RuntimeError, match="at least one reference"):
+        AtlasWan30PrimeReferenceToVideo().run(None, "a prompt", bad_refs)
+
+
+def test_prime_r2v_rejects_too_many_images():
+    urls = "\n".join(f"https://example.com/{i}.png" for i in range(11))
+    with pytest.raises(RuntimeError, match="reference_images maxItems is 10"):
+        AtlasWan30PrimeReferenceToVideo().run(None, "a prompt", urls)
+
+
+def test_prime_r2v_rejects_too_many_videos():
+    urls = "\n".join(f"https://example.com/{i}.mp4" for i in range(6))
+    with pytest.raises(RuntimeError, match="reference_videos maxItems is 5"):
+        AtlasWan30PrimeReferenceToVideo().run(None, "a prompt", "", urls)
+
+
+def test_prime_r2v_rejects_too_many_audios():
+    urls = "\n".join(f"https://example.com/{i}.mp3" for i in range(6))
+    with pytest.raises(RuntimeError, match="reference_audios maxItems is 5"):
+        AtlasWan30PrimeReferenceToVideo().run(None, "a prompt", "", "", urls)
+
+
+def test_prime_r2v_tags_refers_by_kind():
+    source = inspect.getsource(AtlasWan30PrimeReferenceToVideo.run)
+    for kind in ("image", "video", "audio"):
+        assert f'"type": "{kind}"' in source
+
+
+def test_prime_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key, cls in (
+        ("AtlasCloud WAN3.0-Prime Text-to-Video", AtlasWan30PrimeTextToVideo),
+        ("AtlasCloud WAN3.0-Prime Image-to-Video", AtlasWan30PrimeImageToVideo),
+        ("AtlasCloud WAN3.0-Prime Reference-to-Video", AtlasWan30PrimeReferenceToVideo),
+    ):
+        # registry.py imports under the `atlascloud_comfyui.*` path while the
+        # tests import under `src.atlascloud_comfyui.*`, so compare by name.
+        assert NODE_CLASS_MAPPINGS[key].__name__ == cls.__name__
+        assert NODE_DISPLAY_NAME_MAPPINGS[key] == key


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI sync.

## New models (3)

| Node | Model id |
| --- | --- |
| AtlasCloud WAN3.0-Prime Text-to-Video | `alibaba/wan-3.0-prime/text-to-video` |
| AtlasCloud WAN3.0-Prime Image-to-Video | `alibaba/wan-3.0-prime/image-to-video` |
| AtlasCloud WAN3.0-Prime Reference-to-Video | `alibaba/wan-3.0-prime/reference-to-video` |

Wan-3.0-Prime's published schemas are identical to plain Wan-3.0 (same
`resolution` / `duration` smart-duration sentinel / `ratio` / `audio` /
`enable_thinking` / `refers` shape), so the nodes mirror the existing
Wan-3.0 ones with the Prime model ids. Tests pin the model id per node so a
Prime node can't silently fall back to the non-Prime endpoint.

## Diff summary

- API total: 473, visual: 310 (3D-output models excluded)
- Repo supported: 382, missing visual: 3 — all 3 implemented

## Testing

- `python3 -m ruff check .` -> All checks passed
- `python3 -m pytest tests/ -k "not e2e and not test_e2e"` -> 557 passed, 26 deselected

E2E skipped: no ComfyUI source on the sync machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)