### PR TITLE
sync: add 3 AtlasCloud models (2026-08-28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud MiniMax H3 Text-to-Video | minimax/h3/text-to-video |
 | AtlasCloud MiniMax H3 Image-to-Video | minimax/h3/image-to-video |
 | AtlasCloud MiniMax H3 Reference-to-Video | minimax/h3/reference-to-video |
+| AtlasCloud MiniMax H3-Developer Text-to-Video | minimax/h3-developer/text-to-video |
+| AtlasCloud MiniMax H3-Developer Image-to-Video | minimax/h3-developer/image-to-video |
+| AtlasCloud MiniMax H3-Developer Reference-to-Video | minimax/h3-developer/reference-to-video |
 | AtlasCloud Tencent Image Upscaler | tencent/image/upscaler |
 | AtlasCloud Tencent Video Upscaler | tencent/video/upscaler |
 | AtlasCloud BytePlus Video Upscaler | byteplus/video/upscaler |

--- a/src/atlascloud_comfyui/nodes/video/minimax_h3_developer_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/minimax_h3_developer_i2v.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMinimaxH3DeveloperImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the motion / action"}),
+            },
+            "optional": {
+                "end_image": ("STRING", {"default": "", "tooltip": "Optional last frame image URL or base64"}),
+                "resolution": (["480P", "768P"], {"default": "768P", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 8, "min": 4, "max": 15, "tooltip": "Duration (seconds)"}),
+                "ratio": (
+                    ["adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (derived from the first frame)"},
+                ),
+                "prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Expand the prompt for better results"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        end_image: str = "",
+        resolution: str = "768P",
+        duration: int = 8,
+        ratio: str = "adaptive",
+        prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required for MiniMax H3-Developer Image-to-Video")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/h3-developer/image-to-video",
+            "image": img,
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "prompt_expansion": bool(prompt_expansion),
+        }
+
+        if (end_image or "").strip():
+            payload["end_image"] = end_image.strip()
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/minimax_h3_developer_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/minimax_h3_developer_r2v.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMinimaxH3DeveloperReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "refers": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                        "tooltip": (
+                            "Reference image/video/audio URLs, one per line "
+                            "(at least one image or video; audio alone is not allowed)"
+                        ),
+                    },
+                ),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the video"}),
+            },
+            "optional": {
+                "resolution": (["480P", "768P"], {"default": "768P", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 8, "min": 4, "max": 15, "tooltip": "Duration (seconds)"}),
+                "ratio": (
+                    ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = let the model choose)"},
+                ),
+                "prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Expand the prompt for better results"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        refers: str,
+        prompt: str,
+        resolution: str = "768P",
+        duration: int = 8,
+        ratio: str = "adaptive",
+        prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        urls: List[str] = [v.strip() for v in (refers or "").splitlines() if v.strip()]
+        if not urls:
+            raise RuntimeError(
+                "refers is required for MiniMax H3-Developer Reference-to-Video "
+                "(at least one image or video URL)"
+            )
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/h3-developer/reference-to-video",
+            "refers": [{"url": u} for u in urls],
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "prompt_expansion": bool(prompt_expansion),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/minimax_h3_developer_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/minimax_h3_developer_t2v.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMinimaxH3DeveloperTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the video"}),
+            },
+            "optional": {
+                "resolution": (["480P", "768P"], {"default": "768P", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 8, "min": 4, "max": 15, "tooltip": "Duration (seconds)"}),
+                "ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Expand the prompt for better results"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str = "768P",
+        duration: int = 8,
+        ratio: str = "1:1",
+        prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required for MiniMax H3-Developer Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/h3-developer/text-to-video",
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "prompt_expansion": bool(prompt_expansion),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -246,6 +246,9 @@ from atlascloud_comfyui.nodes.video.atlascloud_wan_2_7_spicy_r2v import AtlasWan
 from atlascloud_comfyui.nodes.video.minimax_h3_t2v import AtlasMinimaxH3TextToVideo
 from atlascloud_comfyui.nodes.video.minimax_h3_i2v import AtlasMinimaxH3ImageToVideo
 from atlascloud_comfyui.nodes.video.minimax_h3_r2v import AtlasMinimaxH3ReferenceToVideo
+from atlascloud_comfyui.nodes.video.minimax_h3_developer_t2v import AtlasMinimaxH3DeveloperTextToVideo
+from atlascloud_comfyui.nodes.video.minimax_h3_developer_i2v import AtlasMinimaxH3DeveloperImageToVideo
+from atlascloud_comfyui.nodes.video.minimax_h3_developer_r2v import AtlasMinimaxH3DeveloperReferenceToVideo
 from atlascloud_comfyui.nodes.video.byteplus_video_upscaler import AtlasBytePlusVideoUpscaler
 from atlascloud_comfyui.nodes.video.tencent_video_upscaler import AtlasTencentVideoUpscaler
 from atlascloud_comfyui.nodes.image.tencent_image_upscaler import AtlasTencentImageUpscaler
@@ -696,6 +699,9 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud MiniMax H3 Text-to-Video": AtlasMinimaxH3TextToVideo,
     "AtlasCloud MiniMax H3 Image-to-Video": AtlasMinimaxH3ImageToVideo,
     "AtlasCloud MiniMax H3 Reference-to-Video": AtlasMinimaxH3ReferenceToVideo,
+    "AtlasCloud MiniMax H3-Developer Text-to-Video": AtlasMinimaxH3DeveloperTextToVideo,
+    "AtlasCloud MiniMax H3-Developer Image-to-Video": AtlasMinimaxH3DeveloperImageToVideo,
+    "AtlasCloud MiniMax H3-Developer Reference-to-Video": AtlasMinimaxH3DeveloperReferenceToVideo,
     "AtlasCloud Tencent Image Upscaler": AtlasTencentImageUpscaler,
     "AtlasCloud Tencent Video Upscaler": AtlasTencentVideoUpscaler,
     "AtlasCloud BytePlus Video Upscaler": AtlasBytePlusVideoUpscaler,
@@ -1075,6 +1081,9 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud MiniMax H3 Text-to-Video": "AtlasCloud MiniMax H3 Text-to-Video",
     "AtlasCloud MiniMax H3 Image-to-Video": "AtlasCloud MiniMax H3 Image-to-Video",
     "AtlasCloud MiniMax H3 Reference-to-Video": "AtlasCloud MiniMax H3 Reference-to-Video",
+    "AtlasCloud MiniMax H3-Developer Text-to-Video": "AtlasCloud MiniMax H3-Developer Text-to-Video",
+    "AtlasCloud MiniMax H3-Developer Image-to-Video": "AtlasCloud MiniMax H3-Developer Image-to-Video",
+    "AtlasCloud MiniMax H3-Developer Reference-to-Video": "AtlasCloud MiniMax H3-Developer Reference-to-Video",
     "AtlasCloud Tencent Image Upscaler": "AtlasCloud Tencent Image Upscaler",
     "AtlasCloud Tencent Video Upscaler": "AtlasCloud Tencent Video Upscaler",
     "AtlasCloud BytePlus Video Upscaler": "AtlasCloud BytePlus Video Upscaler",

--- a/tests/test_new_nodes_2026_08_28.py
+++ b/tests/test_new_nodes_2026_08_28.py
@@ -1,0 +1,153 @@
+"""Metadata-only tests for newly added nodes (2026-08-28).
+
+New models: the MiniMax H3-Developer family (Text/Image/Reference-to-Video).
+These are the self-hosted "developer" tier of MiniMax H3 — same shape as the
+plain H3 nodes but with 480P/768P resolutions and a prompt_expansion switch,
+so these tests also pin the model ids to make sure the Developer nodes do not
+silently fall back to the non-Developer endpoints.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+from src.atlascloud_comfyui.nodes.video.minimax_h3_developer_i2v import (
+    AtlasMinimaxH3DeveloperImageToVideo,
+)
+from src.atlascloud_comfyui.nodes.video.minimax_h3_developer_r2v import (
+    AtlasMinimaxH3DeveloperReferenceToVideo,
+)
+from src.atlascloud_comfyui.nodes.video.minimax_h3_developer_t2v import (
+    AtlasMinimaxH3DeveloperTextToVideo,
+)
+
+_DEV_CLASSES = [
+    AtlasMinimaxH3DeveloperTextToVideo,
+    AtlasMinimaxH3DeveloperImageToVideo,
+    AtlasMinimaxH3DeveloperReferenceToVideo,
+]
+
+_DEV_MODEL_IDS = {
+    AtlasMinimaxH3DeveloperTextToVideo: "minimax/h3-developer/text-to-video",
+    AtlasMinimaxH3DeveloperImageToVideo: "minimax/h3-developer/image-to-video",
+    AtlasMinimaxH3DeveloperReferenceToVideo: "minimax/h3-developer/reference-to-video",
+}
+
+
+@pytest.mark.parametrize("cls", _DEV_CLASSES)
+def test_dev_node_shape(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "atlas_client" in inputs["required"]
+    assert "prompt" in inputs["required"]
+    assert "poll_interval_sec" in inputs["optional"]
+    assert "timeout_sec" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("video_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Video"
+    assert cls.FUNCTION == "run"
+
+
+@pytest.mark.parametrize("cls", _DEV_CLASSES)
+def test_dev_model_id(cls):
+    source = inspect.getsource(cls.run)
+    assert f'"model": "{_DEV_MODEL_IDS[cls]}"' in source
+    # must not fall back to the non-developer endpoint
+    assert '"model": "minimax/h3/' not in source
+
+
+@pytest.mark.parametrize("cls", _DEV_CLASSES)
+def test_dev_common_options(cls):
+    optional = cls.INPUT_TYPES()["optional"]
+    assert optional["resolution"][0] == ["480P", "768P"]
+    assert optional["resolution"][1]["default"] == "768P"
+    assert optional["duration"][1]["min"] == 4
+    assert optional["duration"][1]["max"] == 15
+    assert optional["duration"][1]["default"] == 8
+    assert optional["prompt_expansion"][0] == "BOOLEAN"
+    assert optional["prompt_expansion"][1]["default"] is False
+
+
+@pytest.mark.parametrize("cls", _DEV_CLASSES)
+def test_dev_sends_prompt_expansion(cls):
+    source = inspect.getsource(cls.run)
+    assert '"prompt_expansion": bool(prompt_expansion)' in source
+
+
+def test_dev_t2v_metadata():
+    ratio = AtlasMinimaxH3DeveloperTextToVideo.INPUT_TYPES()["optional"]["ratio"]
+    assert ratio[0] == ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+    assert ratio[1]["default"] == "1:1"
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "   "])
+def test_dev_t2v_requires_prompt(bad_prompt):
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasMinimaxH3DeveloperTextToVideo().run(None, bad_prompt)
+
+
+def test_dev_i2v_metadata():
+    inputs = AtlasMinimaxH3DeveloperImageToVideo.INPUT_TYPES()
+    assert "image" in inputs["required"]
+    assert "end_image" in inputs["optional"]
+    # the schema only accepts 'adaptive' here — the ratio comes from the first frame
+    ratio = inputs["optional"]["ratio"]
+    assert ratio[0] == ["adaptive"]
+    assert ratio[1]["default"] == "adaptive"
+
+
+@pytest.mark.parametrize("bad_image", ["", "   "])
+def test_dev_i2v_requires_image(bad_image):
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasMinimaxH3DeveloperImageToVideo().run(None, bad_image, "a prompt")
+
+
+def test_dev_i2v_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasMinimaxH3DeveloperImageToVideo().run(None, "https://example.com/a.png", "  ")
+
+
+def test_dev_i2v_omits_empty_end_image():
+    source = inspect.getsource(AtlasMinimaxH3DeveloperImageToVideo.run)
+    assert 'payload["end_image"] = end_image.strip()' in source
+
+
+def test_dev_r2v_metadata():
+    inputs = AtlasMinimaxH3DeveloperReferenceToVideo.INPUT_TYPES()
+    assert "refers" in inputs["required"]
+    ratio = inputs["optional"]["ratio"]
+    assert ratio[0] == ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+    assert ratio[1]["default"] == "adaptive"
+
+
+@pytest.mark.parametrize("bad_refers", ["", "  \n \n"])
+def test_dev_r2v_requires_refers(bad_refers):
+    with pytest.raises(RuntimeError, match="refers is required"):
+        AtlasMinimaxH3DeveloperReferenceToVideo().run(None, bad_refers, "a prompt")
+
+
+def test_dev_r2v_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasMinimaxH3DeveloperReferenceToVideo().run(None, "https://example.com/a.png", " ")
+
+
+def test_dev_r2v_wraps_refers_as_url_objects():
+    source = inspect.getsource(AtlasMinimaxH3DeveloperReferenceToVideo.run)
+    assert '[{"url": u} for u in urls]' in source
+
+
+def test_dev_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key, cls in (
+        ("AtlasCloud MiniMax H3-Developer Text-to-Video", AtlasMinimaxH3DeveloperTextToVideo),
+        ("AtlasCloud MiniMax H3-Developer Image-to-Video", AtlasMinimaxH3DeveloperImageToVideo),
+        ("AtlasCloud MiniMax H3-Developer Reference-to-Video", AtlasMinimaxH3DeveloperReferenceToVideo),
+    ):
+        # registry.py imports under the `atlascloud_comfyui.*` path while the
+        # tests import under `src.atlascloud_comfyui.*`, so compare by name.
+        assert NODE_CLASS_MAPPINGS[key].__name__ == cls.__name__
+        assert NODE_DISPLAY_NAME_MAPPINGS[key] == key


### PR DESCRIPTION
Daily AtlasCloud → ComfyUI node sync.

## New models (3)

The MiniMax **H3-Developer** family (self-hosted tier of MiniMax H3):

| Node | Model id |
| --- | --- |
| AtlasCloud MiniMax H3-Developer Text-to-Video | `minimax/h3-developer/text-to-video` |
| AtlasCloud MiniMax H3-Developer Image-to-Video | `minimax/h3-developer/image-to-video` |
| AtlasCloud MiniMax H3-Developer Reference-to-Video | `minimax/h3-developer/reference-to-video` |

Params follow each model's published schema: `resolution` 480P/768P (default 768P),
`duration` 4–15s (default 8), per-endpoint `ratio` enums (t2v full set / i2v `adaptive`
only / r2v `adaptive` + full set), and a `prompt_expansion` switch. I2V requires
`image`, R2V requires at least one `refers` URL, all three require `prompt`.

Note: the upstream `minimax-h3-developer-text-to-video.json` schema has a stale
`model` default of `minimax/h3/text-to-video`. The node uses the id from the models
API (`minimax/h3-developer/text-to-video`), and a test pins it so it can't regress to
the non-Developer endpoint.

## Changes

- 3 new node files under `src/atlascloud_comfyui/nodes/video/`
- `registry.py`: imports + `NODE_CLASS_MAPPINGS` + `NODE_DISPLAY_NAME_MAPPINGS`
- `README.md`: Available Nodes table
- `tests/test_new_nodes_2026_08_28.py`: metadata-only tests (no API key, no network)

## Test summary

- `ruff check .` → All checks passed
- `pytest tests/ -k "not e2e"` → **583 passed**, 26 deselected

E2E was not run locally (no ComfyUI source on the sync machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)