### PR TITLE
sync: add 4 AtlasCloud models (2026-08-31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Seedream V4 Sequential Text-to-Image | bytedance/seedream-v4/sequential |
 | AtlasCloud Seedream V4.5 Text-to-Image | bytedance/seedream-v4.5 |
 | AtlasCloud Seedream V4.5 Sequential Text-to-Image | bytedance/seedream-v4.5/sequential |
+| AtlasCloud Seedream V4.7 Text-to-Image | bytedance/seedream-v4.7/text-to-image |
+| AtlasCloud Seedream V4.7 Sequential Text-to-Image | bytedance/seedream-v4.7/sequential |
 | AtlasCloud ZImage Turbo Text-to-Image | z-image/turbo |
 | AtlasCloud Ideogram V3 Quality Text-to-Image | ideogram-ai/ideogram-v3-quality |
 | AtlasCloud Ideogram V3 Turbo Text-to-Image | ideogram-ai/ideogram-v3-turbo |
@@ -492,6 +494,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Seedream V4 Edit Sequential | bytedance/seedream-v4/edit-sequential |
 | AtlasCloud Seedream V4.5 Edit | bytedance/seedream-v4.5/edit |
 | AtlasCloud Seedream V4.5 Edit Sequential | bytedance/seedream-v4.5/edit-sequential |
+| AtlasCloud Seedream V4.7 Edit | bytedance/seedream-v4.7/edit |
+| AtlasCloud Seedream V4.7 Edit Sequential | bytedance/seedream-v4.7/edit-sequential |
 | AtlasCloud Qwen Image Edit | atlascloud/qwen-image/edit |
 | AtlasCloud Qwen Image Edit (Alibaba) | alibaba/qwen-image/edit |
 | AtlasCloud Qwen Image Edit Plus (Alibaba) | alibaba/qwen-image/edit-plus |

--- a/src/atlascloud_comfyui/nodes/image/seedream_v47_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v47_edit.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+from .seedream_v47_t2i import SEEDREAM_V47_SIZES
+
+
+class AtlasSeedreamV47Edit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "size": (SEEDREAM_V47_SIZES, {"default": "2048*2048", "tooltip": "Output image size WIDTH*HEIGHT"}),
+            },
+            "optional": {
+                "prompt_expansion_mode": (
+                    ["standard", "fast"],
+                    {"default": "standard", "tooltip": "'standard' favours quality; 'fast' lowers latency"},
+                ),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        size: str = "2048*2048",
+        prompt_expansion_mode: str = "standard",
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v4.7/edit",
+            "images": image_list,
+            "prompt": p,
+            "size": str(size).strip(),
+            "prompt_expansion_mode": prompt_expansion_mode,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v47_edit_sequential.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v47_edit_sequential.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+from .seedream_v47_t2i import SEEDREAM_V47_SIZES
+
+
+class AtlasSeedreamV47EditSequential:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 image URLs/base64, one per line"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "size": (SEEDREAM_V47_SIZES, {"default": "2048*2048", "tooltip": "Output image size WIDTH*HEIGHT"}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 14, "tooltip": "Max images to generate (1-14)"}),
+            },
+            "optional": {
+                "prompt_expansion_mode": (
+                    ["standard", "fast"],
+                    {"default": "standard", "tooltip": "'standard' favours quality; 'fast' lowers latency"},
+                ),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        images: str,
+        prompt: str,
+        size: str = "2048*2048",
+        num_images: int = 1,
+        prompt_expansion_mode: str = "standard",
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        image_list: List[str] = [v.strip() for v in (images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("images maxItems is 10")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v4.7/edit-sequential",
+            "images": image_list,
+            "prompt": p,
+            "size": str(size).strip(),
+            "num_images": int(num_images),
+            "prompt_expansion_mode": prompt_expansion_mode,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v47_sequential_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v47_sequential_t2i.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+from .seedream_v47_t2i import SEEDREAM_V47_SIZES
+
+
+class AtlasSeedreamV47SequentialTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Prompt (should describe a sequence)"}),
+                "size": (SEEDREAM_V47_SIZES, {"default": "2048*2048", "tooltip": "Output image size WIDTH*HEIGHT"}),
+                "num_images": ("INT", {"default": 1, "min": 1, "max": 14, "tooltip": "Max images to generate (1-14)"}),
+            },
+            "optional": {
+                "prompt_expansion_mode": (
+                    ["standard", "fast"],
+                    {"default": "standard", "tooltip": "'standard' favours quality; 'fast' lowers latency"},
+                ),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "2048*2048",
+        num_images: int = 1,
+        prompt_expansion_mode: str = "standard",
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v4.7/sequential",
+            "prompt": p,
+            "size": str(size).strip(),
+            "num_images": int(num_images),
+            "prompt_expansion_mode": prompt_expansion_mode,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=poll_interval_sec, timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/seedream_v47_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/seedream_v47_t2i.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+# Shared size presets for the Seedream v4.7 family (1K / 2K / 4K tiers).
+SEEDREAM_V47_SIZES = [
+    "2048*2048", "2304*1728", "1728*2304", "2848*1600", "1600*2848",
+    "2496*1664", "1664*2496", "3136*1344", "4096*4096", "4704*3520",
+    "3520*4704", "5504*3040", "3040*5504", "4992*3328", "3328*4992",
+    "6240*2656", "1024*1024", "1280*720", "720*1280", "1248*832",
+    "832*1248", "1568*672",
+]
+
+
+class AtlasSeedreamV47TextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "The positive prompt for the generation"}),
+                "size": (SEEDREAM_V47_SIZES, {"default": "2048*2048", "tooltip": "Output image size WIDTH*HEIGHT"}),
+            },
+            "optional": {
+                "prompt_expansion_mode": (
+                    ["standard", "fast"],
+                    {"default": "standard", "tooltip": "'standard' favours quality; 'fast' lowers latency"},
+                ),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 instead of URL if supported"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "2048*2048",
+        prompt_expansion_mode: str = "standard",
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "bytedance/seedream-v4.7/text-to-image",
+            "prompt": p,
+            "size": str(size).strip(),
+            "prompt_expansion_mode": prompt_expansion_mode,
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=poll_interval_sec,
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -136,6 +136,10 @@ from atlascloud_comfyui.nodes.image.seedream_v45_t2i import AtlasSeedreamV45Text
 from atlascloud_comfyui.nodes.image.seedream_v45_edit import AtlasSeedreamV45Edit
 from atlascloud_comfyui.nodes.image.seedream_v45_sequential_t2i import AtlasSeedreamV45SequentialTextToImage
 from atlascloud_comfyui.nodes.image.seedream_v45_edit_sequential import AtlasSeedreamV45EditSequential
+from atlascloud_comfyui.nodes.image.seedream_v47_t2i import AtlasSeedreamV47TextToImage
+from atlascloud_comfyui.nodes.image.seedream_v47_sequential_t2i import AtlasSeedreamV47SequentialTextToImage
+from atlascloud_comfyui.nodes.image.seedream_v47_edit import AtlasSeedreamV47Edit
+from atlascloud_comfyui.nodes.image.seedream_v47_edit_sequential import AtlasSeedreamV47EditSequential
 from atlascloud_comfyui.nodes.image.seedream_v4_t2i import AtlasSeedreamV4TextToImage
 from atlascloud_comfyui.nodes.image.seedream_v4_sequential_t2i import AtlasSeedreamV4SequentialTextToImage
 from atlascloud_comfyui.nodes.image.seedream_v4_edit import AtlasSeedreamV4Edit
@@ -556,6 +560,10 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Seedream V4.5 Edit": AtlasSeedreamV45Edit,
     "AtlasCloud Seedream V4.5 Sequential Text-to-Image": AtlasSeedreamV45SequentialTextToImage,
     "AtlasCloud Seedream V4.5 Edit Sequential": AtlasSeedreamV45EditSequential,
+    "AtlasCloud Seedream V4.7 Text-to-Image": AtlasSeedreamV47TextToImage,
+    "AtlasCloud Seedream V4.7 Sequential Text-to-Image": AtlasSeedreamV47SequentialTextToImage,
+    "AtlasCloud Seedream V4.7 Edit": AtlasSeedreamV47Edit,
+    "AtlasCloud Seedream V4.7 Edit Sequential": AtlasSeedreamV47EditSequential,
     "AtlasCloud ZImage Turbo Lora Text-to-Image": AtlasZImageTurboLoraTextToImage,
     "AtlasCloud ZImage Turbo Text-to-Image": AtlasZImageTurboTextToImage,
     "AtlasCloud Nano Banana Pro Text-to-Image Ultra": AtlasNanoBananaProTextToImageUltra,
@@ -946,6 +954,10 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Seedream V4.5 Edit": "AtlasCloud Seedream V4.5 Edit",
     "AtlasCloud Seedream V4.5 Sequential Text-to-Image": "AtlasCloud Seedream V4.5 Sequential Text-to-Image",
     "AtlasCloud Seedream V4.5 Edit Sequential": "AtlasCloud Seedream V4.5 Edit Sequential",
+    "AtlasCloud Seedream V4.7 Text-to-Image": "AtlasCloud Seedream V4.7 Text-to-Image",
+    "AtlasCloud Seedream V4.7 Sequential Text-to-Image": "AtlasCloud Seedream V4.7 Sequential Text-to-Image",
+    "AtlasCloud Seedream V4.7 Edit": "AtlasCloud Seedream V4.7 Edit",
+    "AtlasCloud Seedream V4.7 Edit Sequential": "AtlasCloud Seedream V4.7 Edit Sequential",
     "AtlasCloud Image Preview": "AtlasCloud Image Preview",
     "AtlasCloud ZImage Turbo Lora Text-to-Image": "AtlasCloud ZImage Turbo Lora Text-to-Image",
     "AtlasCloud ZImage Turbo Text-to-Image": "AtlasCloud ZImage Turbo Text-to-Image",

--- a/tests/test_new_nodes_2026_08_31.py
+++ b/tests/test_new_nodes_2026_08_31.py
@@ -1,0 +1,157 @@
+"""Metadata-only tests for newly added nodes (2026-08-31).
+
+New models: the Seedream v4.7 family (Text-to-Image / Sequential / Edit /
+Edit Sequential). Unlike the v4/v4.5 nodes, v4.7 takes `num_images` (not
+`max_images`, max 14) and a `prompt_expansion_mode` switch, and its base
+text-to-image endpoint is suffixed `/text-to-image` rather than being the bare
+family id — so these tests pin both the model ids and the payload keys.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+from src.atlascloud_comfyui.nodes.image.seedream_v47_edit import AtlasSeedreamV47Edit
+from src.atlascloud_comfyui.nodes.image.seedream_v47_edit_sequential import (
+    AtlasSeedreamV47EditSequential,
+)
+from src.atlascloud_comfyui.nodes.image.seedream_v47_sequential_t2i import (
+    AtlasSeedreamV47SequentialTextToImage,
+)
+from src.atlascloud_comfyui.nodes.image.seedream_v47_t2i import (
+    SEEDREAM_V47_SIZES,
+    AtlasSeedreamV47TextToImage,
+)
+
+_V47_CLASSES = [
+    AtlasSeedreamV47TextToImage,
+    AtlasSeedreamV47SequentialTextToImage,
+    AtlasSeedreamV47Edit,
+    AtlasSeedreamV47EditSequential,
+]
+
+_V47_MODEL_IDS = {
+    AtlasSeedreamV47TextToImage: "bytedance/seedream-v4.7/text-to-image",
+    AtlasSeedreamV47SequentialTextToImage: "bytedance/seedream-v4.7/sequential",
+    AtlasSeedreamV47Edit: "bytedance/seedream-v4.7/edit",
+    AtlasSeedreamV47EditSequential: "bytedance/seedream-v4.7/edit-sequential",
+}
+
+_EDIT_CLASSES = [AtlasSeedreamV47Edit, AtlasSeedreamV47EditSequential]
+_SEQUENTIAL_CLASSES = [AtlasSeedreamV47SequentialTextToImage, AtlasSeedreamV47EditSequential]
+
+
+@pytest.mark.parametrize("cls", _V47_CLASSES)
+def test_v47_node_shape(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "atlas_client" in inputs["required"]
+    assert "prompt" in inputs["required"]
+    assert "size" in inputs["required"]
+    assert "poll_interval_sec" in inputs["optional"]
+    assert "timeout_sec" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("image_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Image"
+    assert cls.FUNCTION == "run"
+
+
+@pytest.mark.parametrize("cls", _V47_CLASSES)
+def test_v47_model_id(cls):
+    source = inspect.getsource(cls.run)
+    assert f'"model": "{_V47_MODEL_IDS[cls]}"' in source
+    # must not fall back to an older Seedream generation
+    assert '"model": "bytedance/seedream-v4.5' not in source
+    assert '"model": "bytedance/seedream-v4"' not in source
+
+
+@pytest.mark.parametrize("cls", _V47_CLASSES)
+def test_v47_size_presets(cls):
+    size = cls.INPUT_TYPES()["required"]["size"]
+    assert size[0] == SEEDREAM_V47_SIZES
+    assert size[1]["default"] == "2048*2048"
+    # the 1K, 2K and 4K tiers are all offered
+    assert "1024*1024" in SEEDREAM_V47_SIZES
+    assert "2048*2048" in SEEDREAM_V47_SIZES
+    assert "4096*4096" in SEEDREAM_V47_SIZES
+
+
+@pytest.mark.parametrize("cls", _V47_CLASSES)
+def test_v47_prompt_expansion_mode(cls):
+    optional = cls.INPUT_TYPES()["optional"]
+    assert optional["prompt_expansion_mode"][0] == ["standard", "fast"]
+    assert optional["prompt_expansion_mode"][1]["default"] == "standard"
+    assert '"prompt_expansion_mode": prompt_expansion_mode' in inspect.getsource(cls.run)
+
+
+@pytest.mark.parametrize("cls", _SEQUENTIAL_CLASSES)
+def test_v47_sequential_num_images(cls):
+    num_images = cls.INPUT_TYPES()["required"]["num_images"]
+    assert num_images[0] == "INT"
+    assert num_images[1]["default"] == 1
+    assert num_images[1]["min"] == 1
+    assert num_images[1]["max"] == 14
+    source = inspect.getsource(cls.run)
+    assert '"num_images": int(num_images)' in source
+    # v4.7 renamed the v4/v4.5 `max_images` field
+    assert "max_images" not in source
+
+
+@pytest.mark.parametrize("cls", [AtlasSeedreamV47TextToImage, AtlasSeedreamV47SequentialTextToImage])
+def test_v47_t2i_has_no_images_input(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "images" not in inputs["required"]
+    assert "images" not in inputs["optional"]
+
+
+def test_v47_t2i_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasSeedreamV47TextToImage().run(None, "   ")
+
+
+def test_v47_sequential_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasSeedreamV47SequentialTextToImage().run(None, "")
+
+
+@pytest.mark.parametrize("cls", _EDIT_CLASSES)
+def test_v47_edit_images_input(cls):
+    assert "images" in cls.INPUT_TYPES()["required"]
+
+
+@pytest.mark.parametrize("cls", _EDIT_CLASSES)
+@pytest.mark.parametrize("bad_images", ["", "  \n \n"])
+def test_v47_edit_requires_images(cls, bad_images):
+    with pytest.raises(RuntimeError, match="images is required"):
+        cls().run(None, bad_images, "a prompt")
+
+
+@pytest.mark.parametrize("cls", _EDIT_CLASSES)
+def test_v47_edit_rejects_more_than_ten_images(cls):
+    images = "\n".join(f"https://example.com/{i}.png" for i in range(11))
+    with pytest.raises(RuntimeError, match="images maxItems is 10"):
+        cls().run(None, images, "a prompt")
+
+
+@pytest.mark.parametrize("cls", _EDIT_CLASSES)
+def test_v47_edit_requires_prompt(cls):
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        cls().run(None, "https://example.com/a.png", "  ")
+
+
+def test_v47_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key, cls in (
+        ("AtlasCloud Seedream V4.7 Text-to-Image", AtlasSeedreamV47TextToImage),
+        ("AtlasCloud Seedream V4.7 Sequential Text-to-Image", AtlasSeedreamV47SequentialTextToImage),
+        ("AtlasCloud Seedream V4.7 Edit", AtlasSeedreamV47Edit),
+        ("AtlasCloud Seedream V4.7 Edit Sequential", AtlasSeedreamV47EditSequential),
+    ):
+        # registry.py imports under the `atlascloud_comfyui.*` path while the
+        # tests import under `src.atlascloud_comfyui.*`, so compare by name.
+        assert NODE_CLASS_MAPPINGS[key].__name__ == cls.__name__
+        assert NODE_DISPLAY_NAME_MAPPINGS[key] == key


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI sync. Adds the Seedream v4.7 image family.

## New models
- `bytedance/seedream-v4.7/text-to-image` → AtlasCloud Seedream V4.7 Text-to-Image
- `bytedance/seedream-v4.7/sequential` → AtlasCloud Seedream V4.7 Sequential Text-to-Image
- `bytedance/seedream-v4.7/edit` → AtlasCloud Seedream V4.7 Edit
- `bytedance/seedream-v4.7/edit-sequential` → AtlasCloud Seedream V4.7 Edit Sequential

## Notes
- v4.7 renames v4/v4.5's `max_images` to `num_images` (max 14) and adds a `prompt_expansion_mode` (`standard` / `fast`) switch.
- The base text-to-image endpoint is `bytedance/seedream-v4.7/text-to-image`, not the bare family id used by v4/v4.5.
- Size is an enum of the 1K/2K/4K presets from the published schema, shared across the four nodes via `SEEDREAM_V47_SIZES`.
- Edit nodes validate `images` (1-10 lines) and a non-empty `prompt` before calling the API.

## Tests
- `python3 -m ruff check .` → All checks passed
- `pytest tests/ -k "not e2e and not test_e2e"` → 616 passed, 26 deselected
- New metadata-only tests in `tests/test_new_nodes_2026_08_31.py` (no live API calls); E2E skipped locally — no ComfyUI source on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)