### PR TITLE
sync: add 2 AtlasCloud models (2026-09-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud MiniMax H3-Developer Text-to-Video | minimax/h3-developer/text-to-video |
 | AtlasCloud MiniMax H3-Developer Image-to-Video | minimax/h3-developer/image-to-video |
 | AtlasCloud MiniMax H3-Developer Reference-to-Video | minimax/h3-developer/reference-to-video |
+| AtlasCloud MiniMax H3 Max Text-to-Video | minimax/h3-max/text-to-video |
+| AtlasCloud MiniMax H3 Max Image-to-Video | minimax/h3-max/image-to-video |
 | AtlasCloud Tencent Image Upscaler | tencent/image/upscaler |
 | AtlasCloud Tencent Video Upscaler | tencent/video/upscaler |
 | AtlasCloud BytePlus Video Upscaler | byteplus/video/upscaler |

--- a/src/atlascloud_comfyui/nodes/video/minimax_h3_max_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/minimax_h3_max_i2v.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMinimaxH3MaxImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL or base64"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the motion / action"}),
+            },
+            "optional": {
+                "end_image": ("STRING", {"default": "", "tooltip": "Optional last frame image URL or base64"}),
+                "resolution": (["480P", "768P"], {"default": "768P", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 8, "min": 5, "max": 15, "tooltip": "Duration (seconds)"}),
+                "ratio": (
+                    ["adaptive"],
+                    {"default": "adaptive", "tooltip": "Aspect ratio (adaptive = follow the first frame)"},
+                ),
+                "prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Expand the prompt for better results"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        image: str,
+        prompt: str,
+        end_image: str = "",
+        resolution: str = "768P",
+        duration: int = 8,
+        ratio: str = "adaptive",
+        prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        img = (image or "").strip()
+        if not img:
+            raise RuntimeError("image is required for MiniMax H3 Max Image-to-Video")
+
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/h3-max/image-to-video",
+            "image": img,
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "prompt_expansion": bool(prompt_expansion),
+        }
+
+        if (end_image or "").strip():
+            payload["end_image"] = end_image.strip()
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/minimax_h3_max_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/minimax_h3_max_t2v.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMinimaxH3MaxTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the video"}),
+            },
+            "optional": {
+                "resolution": (["480P", "768P"], {"default": "768P", "tooltip": "Output resolution"}),
+                "duration": ("INT", {"default": 8, "min": 5, "max": 15, "tooltip": "Duration (seconds)"}),
+                "ratio": (
+                    ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+                    {"default": "1:1", "tooltip": "Aspect ratio"},
+                ),
+                "prompt_expansion": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Expand the prompt for better results"},
+                ),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        resolution: str = "768P",
+        duration: int = 8,
+        ratio: str = "1:1",
+        prompt_expansion: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        p = (prompt or "").strip()
+        if not p:
+            raise RuntimeError("prompt is required for MiniMax H3 Max Text-to-Video")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "minimax/h3-max/text-to-video",
+            "prompt": p,
+            "resolution": resolution,
+            "duration": int(duration),
+            "ratio": ratio,
+            "prompt_expansion": bool(prompt_expansion),
+        }
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -253,6 +253,8 @@ from atlascloud_comfyui.nodes.video.minimax_h3_r2v import AtlasMinimaxH3Referenc
 from atlascloud_comfyui.nodes.video.minimax_h3_developer_t2v import AtlasMinimaxH3DeveloperTextToVideo
 from atlascloud_comfyui.nodes.video.minimax_h3_developer_i2v import AtlasMinimaxH3DeveloperImageToVideo
 from atlascloud_comfyui.nodes.video.minimax_h3_developer_r2v import AtlasMinimaxH3DeveloperReferenceToVideo
+from atlascloud_comfyui.nodes.video.minimax_h3_max_t2v import AtlasMinimaxH3MaxTextToVideo
+from atlascloud_comfyui.nodes.video.minimax_h3_max_i2v import AtlasMinimaxH3MaxImageToVideo
 from atlascloud_comfyui.nodes.video.byteplus_video_upscaler import AtlasBytePlusVideoUpscaler
 from atlascloud_comfyui.nodes.video.tencent_video_upscaler import AtlasTencentVideoUpscaler
 from atlascloud_comfyui.nodes.image.tencent_image_upscaler import AtlasTencentImageUpscaler
@@ -710,6 +712,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud MiniMax H3-Developer Text-to-Video": AtlasMinimaxH3DeveloperTextToVideo,
     "AtlasCloud MiniMax H3-Developer Image-to-Video": AtlasMinimaxH3DeveloperImageToVideo,
     "AtlasCloud MiniMax H3-Developer Reference-to-Video": AtlasMinimaxH3DeveloperReferenceToVideo,
+    "AtlasCloud MiniMax H3 Max Text-to-Video": AtlasMinimaxH3MaxTextToVideo,
+    "AtlasCloud MiniMax H3 Max Image-to-Video": AtlasMinimaxH3MaxImageToVideo,
     "AtlasCloud Tencent Image Upscaler": AtlasTencentImageUpscaler,
     "AtlasCloud Tencent Video Upscaler": AtlasTencentVideoUpscaler,
     "AtlasCloud BytePlus Video Upscaler": AtlasBytePlusVideoUpscaler,
@@ -1096,6 +1100,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud MiniMax H3-Developer Text-to-Video": "AtlasCloud MiniMax H3-Developer Text-to-Video",
     "AtlasCloud MiniMax H3-Developer Image-to-Video": "AtlasCloud MiniMax H3-Developer Image-to-Video",
     "AtlasCloud MiniMax H3-Developer Reference-to-Video": "AtlasCloud MiniMax H3-Developer Reference-to-Video",
+    "AtlasCloud MiniMax H3 Max Text-to-Video": "AtlasCloud MiniMax H3 Max Text-to-Video",
+    "AtlasCloud MiniMax H3 Max Image-to-Video": "AtlasCloud MiniMax H3 Max Image-to-Video",
     "AtlasCloud Tencent Image Upscaler": "AtlasCloud Tencent Image Upscaler",
     "AtlasCloud Tencent Video Upscaler": "AtlasCloud Tencent Video Upscaler",
     "AtlasCloud BytePlus Video Upscaler": "AtlasCloud BytePlus Video Upscaler",

--- a/tests/test_new_nodes_2026_09_01.py
+++ b/tests/test_new_nodes_2026_09_01.py
@@ -1,0 +1,129 @@
+"""Metadata-only tests for newly added nodes (2026-09-01).
+
+New models: the MiniMax H3 Max video family (Text-to-Video / Image-to-Video).
+H3 Max sits between the 2K-only `minimax/h3/*` nodes and the self-hosted
+`minimax/h3-developer/*` ones: it takes 480P/768P resolutions and a
+`prompt_expansion` switch, and its image-to-video variant only accepts the
+`adaptive` aspect ratio — so these tests pin the model ids, the enums and the
+payload keys.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+from src.atlascloud_comfyui.nodes.video.minimax_h3_max_i2v import AtlasMinimaxH3MaxImageToVideo
+from src.atlascloud_comfyui.nodes.video.minimax_h3_max_t2v import AtlasMinimaxH3MaxTextToVideo
+
+_H3_MAX_CLASSES = [AtlasMinimaxH3MaxTextToVideo, AtlasMinimaxH3MaxImageToVideo]
+
+_H3_MAX_MODEL_IDS = {
+    AtlasMinimaxH3MaxTextToVideo: "minimax/h3-max/text-to-video",
+    AtlasMinimaxH3MaxImageToVideo: "minimax/h3-max/image-to-video",
+}
+
+
+@pytest.mark.parametrize("cls", _H3_MAX_CLASSES)
+def test_h3_max_node_shape(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "atlas_client" in inputs["required"]
+    assert "prompt" in inputs["required"]
+    assert "poll_interval_sec" in inputs["optional"]
+    assert "timeout_sec" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("video_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Video"
+    assert cls.FUNCTION == "run"
+
+
+@pytest.mark.parametrize("cls", _H3_MAX_CLASSES)
+def test_h3_max_model_id(cls):
+    source = inspect.getsource(cls.run)
+    assert f'"model": "{_H3_MAX_MODEL_IDS[cls]}"' in source
+    # must not fall back to the plain H3 or the self-hosted H3-Developer tier
+    assert '"model": "minimax/h3/' not in source
+    assert '"model": "minimax/h3-developer/' not in source
+
+
+@pytest.mark.parametrize("cls", _H3_MAX_CLASSES)
+def test_h3_max_resolution_and_duration(cls):
+    optional = cls.INPUT_TYPES()["optional"]
+    assert optional["resolution"][0] == ["480P", "768P"]
+    assert optional["resolution"][1]["default"] == "768P"
+    duration = optional["duration"]
+    assert duration[0] == "INT"
+    assert duration[1]["default"] == 8
+    assert duration[1]["min"] == 5
+    assert duration[1]["max"] == 15
+
+
+@pytest.mark.parametrize("cls", _H3_MAX_CLASSES)
+def test_h3_max_prompt_expansion(cls):
+    optional = cls.INPUT_TYPES()["optional"]
+    assert optional["prompt_expansion"][0] == "BOOLEAN"
+    assert optional["prompt_expansion"][1]["default"] is False
+    assert '"prompt_expansion": bool(prompt_expansion)' in inspect.getsource(cls.run)
+
+
+def test_h3_max_t2v_ratio_presets():
+    ratio = AtlasMinimaxH3MaxTextToVideo.INPUT_TYPES()["optional"]["ratio"]
+    assert ratio[0] == ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"]
+    assert ratio[1]["default"] == "1:1"
+
+
+def test_h3_max_i2v_ratio_is_adaptive_only():
+    ratio = AtlasMinimaxH3MaxImageToVideo.INPUT_TYPES()["optional"]["ratio"]
+    assert ratio[0] == ["adaptive"]
+    assert ratio[1]["default"] == "adaptive"
+
+
+def test_h3_max_t2v_has_no_image_input():
+    inputs = AtlasMinimaxH3MaxTextToVideo.INPUT_TYPES()
+    assert "image" not in inputs["required"]
+    assert "image" not in inputs["optional"]
+    assert "end_image" not in inputs["optional"]
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "  \n \n"])
+def test_h3_max_t2v_requires_prompt(bad_prompt):
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasMinimaxH3MaxTextToVideo().run(None, bad_prompt)
+
+
+def test_h3_max_i2v_image_inputs():
+    inputs = AtlasMinimaxH3MaxImageToVideo.INPUT_TYPES()
+    assert "image" in inputs["required"]
+    assert "end_image" in inputs["optional"]
+
+
+@pytest.mark.parametrize("bad_image", ["", "   "])
+def test_h3_max_i2v_requires_image(bad_image):
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasMinimaxH3MaxImageToVideo().run(None, bad_image, "a prompt")
+
+
+def test_h3_max_i2v_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasMinimaxH3MaxImageToVideo().run(None, "https://example.com/a.png", "  ")
+
+
+def test_h3_max_i2v_end_image_is_optional_in_payload():
+    source = inspect.getsource(AtlasMinimaxH3MaxImageToVideo.run)
+    assert 'payload["end_image"] = end_image.strip()' in source
+
+
+def test_h3_max_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key, cls in (
+        ("AtlasCloud MiniMax H3 Max Text-to-Video", AtlasMinimaxH3MaxTextToVideo),
+        ("AtlasCloud MiniMax H3 Max Image-to-Video", AtlasMinimaxH3MaxImageToVideo),
+    ):
+        # registry.py imports under the `atlascloud_comfyui.*` path while the
+        # tests import under `src.atlascloud_comfyui.*`, so compare by name.
+        assert NODE_CLASS_MAPPINGS[key].__name__ == cls.__name__
+        assert NODE_DISPLAY_NAME_MAPPINGS[key] == key


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync.

## New models

- `minimax/h3-max/text-to-video` → **AtlasCloud MiniMax H3 Max Text-to-Video** (`AtlasMinimaxH3MaxTextToVideo`)
- `minimax/h3-max/image-to-video` → **AtlasCloud MiniMax H3 Max Image-to-Video** (`AtlasMinimaxH3MaxImageToVideo`)

H3 Max sits between the 2K-only `minimax/h3/*` nodes and the self-hosted `minimax/h3-developer/*` ones: it exposes 480P/768P resolutions, 5-15s durations and a `prompt_expansion` switch. The image-to-video variant takes an optional `end_image` last frame and only accepts the `adaptive` aspect ratio (per the published schema).

## Changes

- `src/atlascloud_comfyui/nodes/video/minimax_h3_max_t2v.py` (new)
- `src/atlascloud_comfyui/nodes/video/minimax_h3_max_i2v.py` (new)
- `src/atlascloud_comfyui/registry.py` — imports + `NODE_CLASS_MAPPINGS` + `NODE_DISPLAY_NAME_MAPPINGS`
- `README.md` — Available Nodes table
- `tests/test_new_nodes_2026_09_01.py` (new, metadata-only)

## Tests

- `ruff check .` → All checks passed
- `pytest tests/ -k "not e2e and not test_e2e"` → 635 passed, 26 deselected

E2E was skipped locally (no ComfyUI source on the sync machine); the new tests are metadata-only and never call the live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)