### PR TITLE
sync: add 5 AtlasCloud models (2026-09-02)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Cosmos 3 Super Image-to-Video | nvidia/cosmos-3-super/image-to-video |
 | AtlasCloud Gemini Omni Flash Reference-to-Video | google/gemini-omni-flash/reference-to-video |
 | AtlasCloud Gemini Omni Flash Video Edit | google/gemini-omni-flash/video-edit |
+| AtlasCloud Gemini Omni 1.1 Flash Text-to-Video | google/gemini-omni-1.1-flash/text-to-video |
+| AtlasCloud Gemini Omni 1.1 Flash Image-to-Video | google/gemini-omni-1.1-flash/image-to-video |
+| AtlasCloud Gemini Omni 1.1 Flash Reference-to-Video | google/gemini-omni-1.1-flash/reference-to-video |
+| AtlasCloud Gemini Omni 1.1 Flash Video Edit | google/gemini-omni-1.1-flash/video-edit |
+| AtlasCloud Gemini Omni 1.1 Flash Video Extend | google/gemini-omni-1.1-flash/video-extend |
 | AtlasCloud Grok Imagine Video Text-to-Video | xai/grok-imagine-video/text-to-video |
 | AtlasCloud VEO2 Text-to-Video | google/veo2 |
 | AtlasCloud WAN2.6 Text-to-Video | alibaba/wan-2.6/text-to-video |

--- a/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_i2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_i2v.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGeminiOmni11FlashImageToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (max 20,000 chars)"}),
+                "image": ("STRING", {"default": "", "tooltip": "First frame image URL/base64 (<=20MB)"}),
+            },
+            "optional": {
+                "last_image": ("STRING", {"default": "", "tooltip": "Optional last frame image URL/base64; the model interpolates between image and last_image"}),
+                "duration": ("INT", {"default": 10, "min": 3, "max": 10, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["360p", "720p", "1080p", "4k"], {"default": "720p", "tooltip": "Resolution (360p is a fast draft mode)"}),
+                "thinking_level": (["default", "high", "low"], {"default": "default", "tooltip": "Internal reasoning level"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        last_image: str = "",
+        duration: int = 10,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        thinking_level: str = "default",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/gemini-omni-1.1-flash/image-to-video",
+            "prompt": prompt,
+            "image": image,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "thinking_level": thinking_level,
+        }
+
+        last_image = (last_image or "").strip()
+        if last_image:
+            payload["last_image"] = last_image
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_r2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_r2v.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGeminiOmni11FlashReferenceToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (max 20,000 chars); reference an upload with <IMAGE_REF_N> / <VIDEO_REF_N> (0-based)"}),
+                "reference_images": ("STRING", {"multiline": True, "default": "", "tooltip": "1-10 reference image URLs/base64, one per line"}),
+            },
+            "optional": {
+                "reference_videos": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional 1-3 reference video URLs (MP4, <=3s each), one per line"}),
+                "duration": ("INT", {"default": 10, "min": 3, "max": 10, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["360p", "720p", "1080p", "4k"], {"default": "720p", "tooltip": "Resolution (360p is a fast draft mode)"}),
+                "thinking_level": (["default", "high", "low"], {"default": "default", "tooltip": "Internal reasoning level"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        reference_images: str,
+        reference_videos: str = "",
+        duration: int = 10,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        thinking_level: str = "default",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        image_list: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        if not image_list:
+            raise RuntimeError("reference_images is required (1-10 lines)")
+        if len(image_list) > 10:
+            raise RuntimeError("reference_images maxItems is 10")
+
+        video_list: List[str] = [v.strip() for v in (reference_videos or "").splitlines() if v.strip()]
+        if len(video_list) > 3:
+            raise RuntimeError("reference_videos maxItems is 3")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/gemini-omni-1.1-flash/reference-to-video",
+            "prompt": prompt,
+            "reference_images": image_list,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "thinking_level": thinking_level,
+        }
+
+        if video_list:
+            payload["reference_videos"] = video_list
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_t2v.py
+++ b/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_t2v.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGeminiOmni11FlashTextToVideo:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt (max 20,000 chars)"}),
+            },
+            "optional": {
+                "duration": ("INT", {"default": 10, "min": 3, "max": 10, "tooltip": "Duration (seconds)"}),
+                "aspect_ratio": (["16:9", "9:16"], {"default": "16:9", "tooltip": "Aspect ratio"}),
+                "resolution": (["360p", "720p", "1080p", "4k"], {"default": "720p", "tooltip": "Resolution (360p is a fast draft mode)"}),
+                "thinking_level": (["default", "high", "low"], {"default": "default", "tooltip": "Internal reasoning level"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        duration: int = 10,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        thinking_level: str = "default",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/gemini-omni-1.1-flash/text-to-video",
+            "prompt": prompt,
+            "duration": int(duration),
+            "aspect_ratio": aspect_ratio,
+            "resolution": resolution,
+            "thinking_level": thinking_level,
+        }
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_video_edit.py
+++ b/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_video_edit.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGeminiOmni11FlashVideoEdit:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video": ("STRING", {"default": "", "tooltip": "Source video URL (MP4, <=10s)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit prompt (max 20,000 chars); reference an upload with <IMAGE_REF_N> (0-based)"}),
+            },
+            "optional": {
+                "reference_images": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional 1-10 reference image URLs/base64, one per line"}),
+                "thinking_level": (["default", "high", "low"], {"default": "default", "tooltip": "Internal reasoning level"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video: str,
+        prompt: str,
+        reference_images: str = "",
+        thinking_level: str = "default",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required")
+
+        image_list: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        if len(image_list) > 10:
+            raise RuntimeError("reference_images maxItems is 10")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/gemini-omni-1.1-flash/video-edit",
+            "video": video,
+            "prompt": prompt,
+            "thinking_level": thinking_level,
+        }
+
+        if image_list:
+            payload["reference_images"] = image_list
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_video_extend.py
+++ b/src/atlascloud_comfyui/nodes/video/google_gemini_omni_1_1_flash_video_extend.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasGeminiOmni11FlashVideoExtend:
+    CATEGORY = "AtlasCloud/Video"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("video_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "video": ("STRING", {"default": "", "tooltip": "Source video URL to extend (MP4, <=10s)"}),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "How the video should continue (max 20,000 chars); reference an upload with <IMAGE_REF_N> (0-based)"}),
+            },
+            "optional": {
+                "reference_images": ("STRING", {"multiline": True, "default": "", "tooltip": "Optional 1-10 reference image URLs/base64, one per line"}),
+                "duration": ("INT", {"default": 10, "min": 3, "max": 10, "tooltip": "Continuation length (seconds); total video must stay <=40s"}),
+                "resolution": (["360p", "720p", "1080p", "4k"], {"default": "720p", "tooltip": "Resolution (360p is a fast draft mode)"}),
+                "thinking_level": (["default", "high", "low"], {"default": "default", "tooltip": "Internal reasoning level"}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1, "tooltip": "Random if -1"}),
+                "poll_interval_sec": ("FLOAT", {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"}),
+                "timeout_sec": ("INT", {"default": 900, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"}),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        video: str,
+        prompt: str,
+        reference_images: str = "",
+        duration: int = 10,
+        resolution: str = "720p",
+        thinking_level: str = "default",
+        seed: int = -1,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 900,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required")
+
+        video = (video or "").strip()
+        if not video:
+            raise RuntimeError("video is required")
+
+        image_list: List[str] = [v.strip() for v in (reference_images or "").splitlines() if v.strip()]
+        if len(image_list) > 10:
+            raise RuntimeError("reference_images maxItems is 10")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "google/gemini-omni-1.1-flash/video-extend",
+            "video": video,
+            "prompt": prompt,
+            "duration": int(duration),
+            "resolution": resolution,
+            "thinking_level": thinking_level,
+        }
+
+        if image_list:
+            payload["reference_images"] = image_list
+
+        if int(seed) >= 0:
+            payload["seed"] = int(seed)
+
+        prediction_id = client.generate_video(payload)
+        result = client.poll_prediction(prediction_id, poll_interval_sec=float(poll_interval_sec), timeout_sec=float(timeout_sec))
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        return (outputs[0], prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -94,6 +94,11 @@ from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_t2v import AtlasGem
 from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_i2v import AtlasGeminiOmniFlashImageToVideo
 from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_r2v import AtlasGeminiOmniFlashReferenceToVideo
 from atlascloud_comfyui.nodes.video.google_gemini_omni_flash_video_edit import AtlasGeminiOmniFlashVideoEdit
+from atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_t2v import AtlasGeminiOmni11FlashTextToVideo
+from atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_i2v import AtlasGeminiOmni11FlashImageToVideo
+from atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_r2v import AtlasGeminiOmni11FlashReferenceToVideo
+from atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_video_edit import AtlasGeminiOmni11FlashVideoEdit
+from atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_video_extend import AtlasGeminiOmni11FlashVideoExtend
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_t2v import AtlasGrokImagineVideoTextToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_i2v import AtlasGrokImagineVideoImageToVideo
 from atlascloud_comfyui.nodes.video.xai_grok_imagine_video_v15_i2v import AtlasGrokImagineVideoV15ImageToVideo
@@ -678,6 +683,11 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud Gemini Omni Flash Image-to-Video": AtlasGeminiOmniFlashImageToVideo,
     "AtlasCloud Gemini Omni Flash Reference-to-Video": AtlasGeminiOmniFlashReferenceToVideo,
     "AtlasCloud Gemini Omni Flash Video Edit": AtlasGeminiOmniFlashVideoEdit,
+    "AtlasCloud Gemini Omni 1.1 Flash Text-to-Video": AtlasGeminiOmni11FlashTextToVideo,
+    "AtlasCloud Gemini Omni 1.1 Flash Image-to-Video": AtlasGeminiOmni11FlashImageToVideo,
+    "AtlasCloud Gemini Omni 1.1 Flash Reference-to-Video": AtlasGeminiOmni11FlashReferenceToVideo,
+    "AtlasCloud Gemini Omni 1.1 Flash Video Edit": AtlasGeminiOmni11FlashVideoEdit,
+    "AtlasCloud Gemini Omni 1.1 Flash Video Extend": AtlasGeminiOmni11FlashVideoExtend,
     "AtlasCloud VEO3.1 Reference-to-Video": AtlasVeo31ReferenceToVideo,
     "AtlasCloud VEO3.1 Image-to-Video": AtlasVeo31ImageToVideo,
     "AtlasCloud VEO3 Image-to-Video": AtlasVeo3ImageToVideo,
@@ -1066,6 +1076,11 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud Gemini Omni Flash Image-to-Video": "AtlasCloud Gemini Omni Flash Image-to-Video",
     "AtlasCloud Gemini Omni Flash Reference-to-Video": "AtlasCloud Gemini Omni Flash Reference-to-Video",
     "AtlasCloud Gemini Omni Flash Video Edit": "AtlasCloud Gemini Omni Flash Video Edit",
+    "AtlasCloud Gemini Omni 1.1 Flash Text-to-Video": "AtlasCloud Gemini Omni 1.1 Flash Text-to-Video",
+    "AtlasCloud Gemini Omni 1.1 Flash Image-to-Video": "AtlasCloud Gemini Omni 1.1 Flash Image-to-Video",
+    "AtlasCloud Gemini Omni 1.1 Flash Reference-to-Video": "AtlasCloud Gemini Omni 1.1 Flash Reference-to-Video",
+    "AtlasCloud Gemini Omni 1.1 Flash Video Edit": "AtlasCloud Gemini Omni 1.1 Flash Video Edit",
+    "AtlasCloud Gemini Omni 1.1 Flash Video Extend": "AtlasCloud Gemini Omni 1.1 Flash Video Extend",
     "AtlasCloud VEO3.1 Reference-to-Video": "AtlasCloud VEO3.1 Reference-to-Video",
     "AtlasCloud VEO3.1 Image-to-Video": "AtlasCloud VEO3.1 Image-to-Video",
     "AtlasCloud VEO3 Image-to-Video": "AtlasCloud VEO3 Image-to-Video",

--- a/tests/test_new_nodes_2026_09_02.py
+++ b/tests/test_new_nodes_2026_09_02.py
@@ -1,0 +1,236 @@
+"""Metadata-only tests for newly added nodes (2026-09-02).
+
+New models: the Gemini Omni 1.1 Flash video family (Text-to-Video /
+Image-to-Video / Reference-to-Video / Video Edit / Video Extend). The 1.1 tier
+differs from the existing `google/gemini-omni-flash/*` nodes: resolutions go up
+to 4k, the reference payload keys are `reference_images`/`reference_videos`
+(not `images`), image-to-video gained a `last_image` interpolation frame, and
+video-extend is a brand-new capability — so these tests pin the model ids, the
+enums and the payload keys.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+from src.atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_i2v import (
+    AtlasGeminiOmni11FlashImageToVideo,
+)
+from src.atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_r2v import (
+    AtlasGeminiOmni11FlashReferenceToVideo,
+)
+from src.atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_t2v import (
+    AtlasGeminiOmni11FlashTextToVideo,
+)
+from src.atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_video_edit import (
+    AtlasGeminiOmni11FlashVideoEdit,
+)
+from src.atlascloud_comfyui.nodes.video.google_gemini_omni_1_1_flash_video_extend import (
+    AtlasGeminiOmni11FlashVideoExtend,
+)
+
+_OMNI_11_MODEL_IDS = {
+    AtlasGeminiOmni11FlashTextToVideo: "google/gemini-omni-1.1-flash/text-to-video",
+    AtlasGeminiOmni11FlashImageToVideo: "google/gemini-omni-1.1-flash/image-to-video",
+    AtlasGeminiOmni11FlashReferenceToVideo: "google/gemini-omni-1.1-flash/reference-to-video",
+    AtlasGeminiOmni11FlashVideoEdit: "google/gemini-omni-1.1-flash/video-edit",
+    AtlasGeminiOmni11FlashVideoExtend: "google/gemini-omni-1.1-flash/video-extend",
+}
+
+_OMNI_11_CLASSES = list(_OMNI_11_MODEL_IDS)
+
+# video-edit takes no duration/resolution controls in its schema
+_RESOLUTION_CLASSES = [c for c in _OMNI_11_CLASSES if c is not AtlasGeminiOmni11FlashVideoEdit]
+# only text/image/reference-to-video expose an aspect ratio
+_ASPECT_RATIO_CLASSES = [
+    AtlasGeminiOmni11FlashTextToVideo,
+    AtlasGeminiOmni11FlashImageToVideo,
+    AtlasGeminiOmni11FlashReferenceToVideo,
+]
+
+
+@pytest.mark.parametrize("cls", _OMNI_11_CLASSES)
+def test_omni_11_node_shape(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "atlas_client" in inputs["required"]
+    assert "prompt" in inputs["required"]
+    assert "thinking_level" in inputs["optional"]
+    assert "poll_interval_sec" in inputs["optional"]
+    assert "timeout_sec" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("video_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Video"
+    assert cls.FUNCTION == "run"
+
+
+@pytest.mark.parametrize("cls", _OMNI_11_CLASSES)
+def test_omni_11_model_id(cls):
+    source = inspect.getsource(cls.run)
+    assert f'"model": "{_OMNI_11_MODEL_IDS[cls]}"' in source
+    # must not fall back to the 1.0 tier or its developer variants
+    assert '"model": "google/gemini-omni-flash/' not in source
+
+
+@pytest.mark.parametrize("cls", _OMNI_11_CLASSES)
+def test_omni_11_thinking_level(cls):
+    thinking_level = cls.INPUT_TYPES()["optional"]["thinking_level"]
+    assert thinking_level[0] == ["default", "high", "low"]
+    assert thinking_level[1]["default"] == "default"
+
+
+@pytest.mark.parametrize("cls", _RESOLUTION_CLASSES)
+def test_omni_11_resolution_and_duration(cls):
+    optional = cls.INPUT_TYPES()["optional"]
+    resolution = optional["resolution"]
+    assert resolution[0] == ["360p", "720p", "1080p", "4k"]
+    assert resolution[1]["default"] == "720p"
+    duration = optional["duration"]
+    assert duration[0] == "INT"
+    assert duration[1]["default"] == 10
+    assert duration[1]["min"] == 3
+    assert duration[1]["max"] == 10
+
+
+@pytest.mark.parametrize("cls", _ASPECT_RATIO_CLASSES)
+def test_omni_11_aspect_ratio(cls):
+    aspect_ratio = cls.INPUT_TYPES()["optional"]["aspect_ratio"]
+    assert aspect_ratio[0] == ["16:9", "9:16"]
+    assert aspect_ratio[1]["default"] == "16:9"
+
+
+def test_omni_11_video_edit_has_no_resolution_or_duration():
+    optional = AtlasGeminiOmni11FlashVideoEdit.INPUT_TYPES()["optional"]
+    assert "resolution" not in optional
+    assert "duration" not in optional
+    assert "aspect_ratio" not in optional
+
+
+@pytest.mark.parametrize("cls", _OMNI_11_CLASSES)
+def test_omni_11_seed_only_sent_when_non_negative(cls):
+    source = inspect.getsource(cls.run)
+    assert "if int(seed) >= 0:" in source
+    assert 'payload["seed"] = int(seed)' in source
+
+
+@pytest.mark.parametrize("bad_prompt", ["", "  \n \n"])
+def test_omni_11_t2v_requires_prompt(bad_prompt):
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasGeminiOmni11FlashTextToVideo().run(None, bad_prompt)
+
+
+def test_omni_11_t2v_has_no_media_inputs():
+    inputs = AtlasGeminiOmni11FlashTextToVideo.INPUT_TYPES()
+    for key in ("image", "last_image", "video", "reference_images", "reference_videos"):
+        assert key not in inputs["required"]
+        assert key not in inputs["optional"]
+
+
+def test_omni_11_i2v_image_inputs():
+    inputs = AtlasGeminiOmni11FlashImageToVideo.INPUT_TYPES()
+    assert "image" in inputs["required"]
+    assert "last_image" in inputs["optional"]
+
+
+@pytest.mark.parametrize("bad_image", ["", "   "])
+def test_omni_11_i2v_requires_image(bad_image):
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasGeminiOmni11FlashImageToVideo().run(None, "a prompt", bad_image)
+
+
+def test_omni_11_i2v_requires_prompt():
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        AtlasGeminiOmni11FlashImageToVideo().run(None, "  ", "https://example.com/a.png")
+
+
+def test_omni_11_i2v_last_image_is_optional_in_payload():
+    source = inspect.getsource(AtlasGeminiOmni11FlashImageToVideo.run)
+    assert 'payload["last_image"] = last_image' in source
+
+
+def test_omni_11_r2v_reference_inputs():
+    inputs = AtlasGeminiOmni11FlashReferenceToVideo.INPUT_TYPES()
+    assert "reference_images" in inputs["required"]
+    assert "reference_videos" in inputs["optional"]
+    # the 1.0 node used a flat `images` key; 1.1 renamed it
+    source = inspect.getsource(AtlasGeminiOmni11FlashReferenceToVideo.run)
+    assert '"reference_images": image_list' in source
+    assert '"images":' not in source
+
+
+@pytest.mark.parametrize("bad_images", ["", "   \n\n  "])
+def test_omni_11_r2v_requires_reference_images(bad_images):
+    with pytest.raises(RuntimeError, match="reference_images is required"):
+        AtlasGeminiOmni11FlashReferenceToVideo().run(None, "a prompt", bad_images)
+
+
+def test_omni_11_r2v_rejects_more_than_ten_images():
+    images = "\n".join(f"https://example.com/{i}.png" for i in range(11))
+    with pytest.raises(RuntimeError, match="reference_images maxItems is 10"):
+        AtlasGeminiOmni11FlashReferenceToVideo().run(None, "a prompt", images)
+
+
+def test_omni_11_r2v_rejects_more_than_three_videos():
+    videos = "\n".join(f"https://example.com/{i}.mp4" for i in range(4))
+    with pytest.raises(RuntimeError, match="reference_videos maxItems is 3"):
+        AtlasGeminiOmni11FlashReferenceToVideo().run(
+            None, "a prompt", "https://example.com/a.png", videos
+        )
+
+
+@pytest.mark.parametrize(
+    "cls", [AtlasGeminiOmni11FlashVideoEdit, AtlasGeminiOmni11FlashVideoExtend]
+)
+def test_omni_11_video_ops_require_video(cls):
+    with pytest.raises(RuntimeError, match="video is required"):
+        cls().run(None, "  ", "a prompt")
+
+
+@pytest.mark.parametrize(
+    "cls", [AtlasGeminiOmni11FlashVideoEdit, AtlasGeminiOmni11FlashVideoExtend]
+)
+def test_omni_11_video_ops_require_prompt(cls):
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        cls().run(None, "https://example.com/a.mp4", "   ")
+
+
+@pytest.mark.parametrize(
+    "cls", [AtlasGeminiOmni11FlashVideoEdit, AtlasGeminiOmni11FlashVideoExtend]
+)
+def test_omni_11_video_ops_reference_images_optional(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "video" in inputs["required"]
+    assert "reference_images" in inputs["optional"]
+    source = inspect.getsource(cls.run)
+    assert 'payload["reference_images"] = image_list' in source
+
+
+@pytest.mark.parametrize(
+    "cls", [AtlasGeminiOmni11FlashVideoEdit, AtlasGeminiOmni11FlashVideoExtend]
+)
+def test_omni_11_video_ops_reject_more_than_ten_images(cls):
+    images = "\n".join(f"https://example.com/{i}.png" for i in range(11))
+    with pytest.raises(RuntimeError, match="reference_images maxItems is 10"):
+        cls().run(None, "https://example.com/a.mp4", "a prompt", images)
+
+
+def test_omni_11_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key, cls in (
+        ("AtlasCloud Gemini Omni 1.1 Flash Text-to-Video", AtlasGeminiOmni11FlashTextToVideo),
+        ("AtlasCloud Gemini Omni 1.1 Flash Image-to-Video", AtlasGeminiOmni11FlashImageToVideo),
+        (
+            "AtlasCloud Gemini Omni 1.1 Flash Reference-to-Video",
+            AtlasGeminiOmni11FlashReferenceToVideo,
+        ),
+        ("AtlasCloud Gemini Omni 1.1 Flash Video Edit", AtlasGeminiOmni11FlashVideoEdit),
+        ("AtlasCloud Gemini Omni 1.1 Flash Video Extend", AtlasGeminiOmni11FlashVideoExtend),
+    ):
+        # registry.py imports under the `atlascloud_comfyui.*` path while the
+        # tests import under `src.atlascloud_comfyui.*`, so compare by name.
+        assert NODE_CLASS_MAPPINGS[key].__name__ == cls.__name__
+        assert NODE_DISPLAY_NAME_MAPPINGS[key] == key


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI sync. Adds the **Gemini Omni 1.1 Flash** video family (5 models, all new since the last sync).

## New models

| Node | Model |
|------|-------|
| AtlasCloud Gemini Omni 1.1 Flash Text-to-Video | `google/gemini-omni-1.1-flash/text-to-video` |
| AtlasCloud Gemini Omni 1.1 Flash Image-to-Video | `google/gemini-omni-1.1-flash/image-to-video` |
| AtlasCloud Gemini Omni 1.1 Flash Reference-to-Video | `google/gemini-omni-1.1-flash/reference-to-video` |
| AtlasCloud Gemini Omni 1.1 Flash Video Edit | `google/gemini-omni-1.1-flash/video-edit` |
| AtlasCloud Gemini Omni 1.1 Flash Video Extend | `google/gemini-omni-1.1-flash/video-extend` |

## Notes vs. the existing 1.0 `google/gemini-omni-flash/*` nodes

- Resolution enum is `360p / 720p / 1080p / 4k` (1.0 nodes only expose `720p`).
- Reference payload keys are `reference_images` / `reference_videos` (1.0 used a flat `images`); caps are 10 images / 3 clips.
- Image-to-Video gained an optional `last_image` interpolation frame.
- Video Extend is a new capability for this family (3-10s continuation, total <= 40s).
- Video Edit takes no duration/resolution/aspect-ratio per its schema.
- Required-input validation (prompt / image / video / reference_images) runs before the client is touched.

## Testing

- `python3 -m ruff check .` → All checks passed
- `python3 -m pytest tests/ -k "not e2e and not test_e2e"` → **685 passed**, 26 deselected

E2E was skipped: no local ComfyUI source on the sync machine, so only metadata-level tests ran (`tests/test_new_nodes_2026_09_02.py`, 40 new cases, no live API calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)