### PR TITLE
sync: add 2 AtlasCloud models (2026-09-04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud Baidu ERNIE-Image-Turbo Text-to-Image | baidu/ERNIE-Image-Turbo/text-to-image |
 | AtlasCloud MAI-Image-2.5 Text-to-Image | microsoft/mai-image-2.5/text-to-image |
 | AtlasCloud MAI-Image-2.5-Flash Text-to-Image | microsoft/mai-image-2.5-flash/text-to-image |
+| AtlasCloud MAI-Image-2.5-Pro Text-to-Image | microsoft/mai-image-2.5-pro/text-to-image |
 | AtlasCloud GPT Image-2 Text-to-Image | openai/gpt-image-2/text-to-image |
 | AtlasCloud GPT Image-2 Developer Text-to-Image | openai/gpt-image-2-developer/text-to-image |
 
@@ -497,6 +498,7 @@ This node pack focuses on **image / video / edit** — see the full **[node cata
 | AtlasCloud WAN2.5 Image-Edit | alibaba/wan-2.5/image-edit |
 | AtlasCloud MAI-Image-2.5 Edit | microsoft/mai-image-2.5/edit |
 | AtlasCloud MAI-Image-2.5-Flash Edit | microsoft/mai-image-2.5-flash/edit |
+| AtlasCloud MAI-Image-2.5-Pro Edit | microsoft/mai-image-2.5-pro/edit |
 | AtlasCloud Seedream V4 Edit | bytedance/seedream-v4/edit |
 | AtlasCloud Seedream V4 Edit Sequential | bytedance/seedream-v4/edit-sequential |
 | AtlasCloud Seedream V4.5 Edit | bytedance/seedream-v4.5/edit |

--- a/src/atlascloud_comfyui/nodes/image/mai_image_25_pro_edit.py
+++ b/src/atlascloud_comfyui/nodes/image/mai_image_25_pro_edit.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMAIImage25ProEdit:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Edit instruction"}),
+                "image": ("STRING", {"default": "", "tooltip": "Reference image URL or base64 (JPEG/PNG) to edit"}),
+            },
+            "optional": {
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        image: str,
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for MAI-Image-2.5-Pro Edit")
+
+        image = (image or "").strip()
+        if not image:
+            raise RuntimeError("image is required for MAI-Image-2.5-Pro Edit")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "microsoft/mai-image-2.5-pro/edit",
+            "prompt": prompt,
+            "image": image,
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/nodes/image/mai_image_25_pro_t2i.py
+++ b/src/atlascloud_comfyui/nodes/image/mai_image_25_pro_t2i.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from ..auth.atlas_client_node import AtlasClientHandle
+
+
+class AtlasMAIImage25ProTextToImage:
+    CATEGORY = "AtlasCloud/Image"
+    FUNCTION = "run"
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_url", "prediction_id")
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "atlas_client": ("ATLAS_CLIENT",),
+                "prompt": ("STRING", {"multiline": True, "tooltip": "Text prompt describing the image to generate"}),
+            },
+            "optional": {
+                "size": (
+                    "STRING",
+                    {
+                        "default": "1024*1024",
+                        "tooltip": "Image dimensions WIDTH*HEIGHT (min 768, width*height <= 1,048,576)",
+                    },
+                ),
+                "enable_sync_mode": ("BOOLEAN", {"default": False, "tooltip": "Try to return synchronously"}),
+                "enable_base64_output": ("BOOLEAN", {"default": False, "tooltip": "Return base64 if supported"}),
+                "poll_interval_sec": (
+                    "FLOAT",
+                    {"default": 2.0, "min": 0.5, "max": 10.0, "tooltip": "Polling interval (seconds)"},
+                ),
+                "timeout_sec": (
+                    "INT",
+                    {"default": 300, "min": 30, "max": 7200, "tooltip": "Timeout (seconds)"},
+                ),
+            },
+        }
+
+    def run(
+        self,
+        atlas_client: AtlasClientHandle,
+        prompt: str,
+        size: str = "1024*1024",
+        enable_sync_mode: bool = False,
+        enable_base64_output: bool = False,
+        poll_interval_sec: float = 2.0,
+        timeout_sec: int = 300,
+    ) -> Tuple[str, str]:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise RuntimeError("prompt is required for MAI-Image-2.5-Pro Text-to-Image")
+
+        client = atlas_client.client
+
+        payload: Dict[str, Any] = {
+            "model": "microsoft/mai-image-2.5-pro/text-to-image",
+            "prompt": prompt,
+            "size": str(size).strip(),
+            "enable_sync_mode": bool(enable_sync_mode),
+            "enable_base64_output": bool(enable_base64_output),
+        }
+
+        prediction_id = client.generate_image(payload)
+        result = client.poll_prediction(
+            prediction_id,
+            poll_interval_sec=float(poll_interval_sec),
+            timeout_sec=float(timeout_sec),
+        )
+
+        outputs = (result.get("data") or {}).get("outputs") or []
+        if not outputs:
+            raise RuntimeError(f"No outputs returned for prediction {prediction_id}: {result}")
+
+        first = outputs[0]
+        if isinstance(first, dict):
+            url = first.get("url") or first.get("image") or first.get("output")
+            if isinstance(url, str) and url.strip():
+                return (url, prediction_id)
+            raise RuntimeError(f"Unexpected output object for prediction {prediction_id}: {first}")
+
+        if not isinstance(first, str):
+            raise RuntimeError(f"Unexpected output type for prediction {prediction_id}: {type(first).__name__} {first!r}")
+
+        return (first, prediction_id)

--- a/src/atlascloud_comfyui/registry.py
+++ b/src/atlascloud_comfyui/registry.py
@@ -419,6 +419,8 @@ from atlascloud_comfyui.nodes.image.mai_image_25_t2i import AtlasMAIImage25TextT
 from atlascloud_comfyui.nodes.image.mai_image_25_flash_t2i import AtlasMAIImage25FlashTextToImage
 from atlascloud_comfyui.nodes.image.mai_image_25_edit import AtlasMAIImage25Edit
 from atlascloud_comfyui.nodes.image.mai_image_25_flash_edit import AtlasMAIImage25FlashEdit
+from atlascloud_comfyui.nodes.image.mai_image_25_pro_t2i import AtlasMAIImage25ProTextToImage
+from atlascloud_comfyui.nodes.image.mai_image_25_pro_edit import AtlasMAIImage25ProEdit
 from atlascloud_comfyui.nodes.video.vidu_q1_t2v import AtlasViduQ1TextToVideo
 from atlascloud_comfyui.nodes.video.vidu_q1_i2v import AtlasViduQ1ImageToVideo
 from atlascloud_comfyui.nodes.video.vidu_q1_start_end import AtlasViduQ1StartEndToVideo
@@ -469,6 +471,8 @@ NODE_CLASS_MAPPINGS: Dict[str, Type[Any]] = {
     "AtlasCloud MAI-Image-2.5-Flash Text-to-Image": AtlasMAIImage25FlashTextToImage,
     "AtlasCloud MAI-Image-2.5 Edit": AtlasMAIImage25Edit,
     "AtlasCloud MAI-Image-2.5-Flash Edit": AtlasMAIImage25FlashEdit,
+    "AtlasCloud MAI-Image-2.5-Pro Text-to-Image": AtlasMAIImage25ProTextToImage,
+    "AtlasCloud MAI-Image-2.5-Pro Edit": AtlasMAIImage25ProEdit,
     "AtlasCloud WAN2.5 Image-Edit": AtlasWan25ImageEdit,
     "AtlasCloud WAN2.6 Image-Edit": AtlasWAN26ImageEdit,
     "AtlasCloud WAN2.6 Image-to-Video": AtlasWAN26ImageToVideo,
@@ -881,6 +885,8 @@ NODE_DISPLAY_NAME_MAPPINGS: Dict[str, str] = {
     "AtlasCloud MAI-Image-2.5-Flash Text-to-Image": "AtlasCloud MAI-Image-2.5-Flash Text-to-Image",
     "AtlasCloud MAI-Image-2.5 Edit": "AtlasCloud MAI-Image-2.5 Edit",
     "AtlasCloud MAI-Image-2.5-Flash Edit": "AtlasCloud MAI-Image-2.5-Flash Edit",
+    "AtlasCloud MAI-Image-2.5-Pro Text-to-Image": "AtlasCloud MAI-Image-2.5-Pro Text-to-Image",
+    "AtlasCloud MAI-Image-2.5-Pro Edit": "AtlasCloud MAI-Image-2.5-Pro Edit",
     "AtlasCloud WAN2.5 Image-Edit": "AtlasCloud WAN2.5 Image-Edit",
     "AtlasCloud WAN2.6 Image-Edit": "AtlasCloud WAN2.6 Image-Edit",
     "AtlasCloud WAN2.6 Image-to-Video": "AtlasCloud WAN2.6 Image-to-Video",

--- a/tests/test_new_nodes_2026_09_04.py
+++ b/tests/test_new_nodes_2026_09_04.py
@@ -1,0 +1,99 @@
+"""Metadata-only tests for newly added nodes (2026-09-04).
+
+New models: the MAI-Image-2.5-Pro image pair (Text-to-Image / Edit). The Pro
+tier shares the request schema of the existing `microsoft/mai-image-2.5/*`
+nodes, so these tests mainly pin the model ids to make sure the Pro nodes do
+not silently fall back to the base or `-flash` tiers.
+These tests MUST NOT require ATLASCLOUD_API_KEY.
+"""
+
+import inspect
+
+import pytest
+
+from src.atlascloud_comfyui.nodes.image.mai_image_25_pro_edit import (
+    AtlasMAIImage25ProEdit,
+)
+from src.atlascloud_comfyui.nodes.image.mai_image_25_pro_t2i import (
+    AtlasMAIImage25ProTextToImage,
+)
+
+_PRO_MODEL_IDS = {
+    AtlasMAIImage25ProTextToImage: "microsoft/mai-image-2.5-pro/text-to-image",
+    AtlasMAIImage25ProEdit: "microsoft/mai-image-2.5-pro/edit",
+}
+
+_PRO_CLASSES = list(_PRO_MODEL_IDS)
+
+
+@pytest.mark.parametrize("cls", _PRO_CLASSES)
+def test_mai_pro_node_shape(cls):
+    inputs = cls.INPUT_TYPES()
+    assert "atlas_client" in inputs["required"]
+    assert "prompt" in inputs["required"]
+    assert "enable_sync_mode" in inputs["optional"]
+    assert "enable_base64_output" in inputs["optional"]
+    assert "poll_interval_sec" in inputs["optional"]
+    assert "timeout_sec" in inputs["optional"]
+    assert cls.RETURN_TYPES == ("STRING", "STRING")
+    assert cls.RETURN_NAMES == ("image_url", "prediction_id")
+    assert cls.CATEGORY == "AtlasCloud/Image"
+    assert cls.FUNCTION == "run"
+
+
+@pytest.mark.parametrize("cls", _PRO_CLASSES)
+def test_mai_pro_model_id(cls):
+    source = inspect.getsource(cls.run)
+    assert f'"model": "{_PRO_MODEL_IDS[cls]}"' in source
+    # must not fall back to the base or flash tiers
+    assert '"model": "microsoft/mai-image-2.5/' not in source
+    assert '"model": "microsoft/mai-image-2.5-flash/' not in source
+
+
+@pytest.mark.parametrize("cls", _PRO_CLASSES)
+@pytest.mark.parametrize("bad_prompt", ["", "  \n \n"])
+def test_mai_pro_requires_prompt(cls, bad_prompt):
+    args = ("https://example.com/a.png",) if cls is AtlasMAIImage25ProEdit else ()
+    with pytest.raises(RuntimeError, match="prompt is required"):
+        cls().run(None, bad_prompt, *args)
+
+
+def test_mai_pro_t2i_size_default():
+    size = AtlasMAIImage25ProTextToImage.INPUT_TYPES()["optional"]["size"]
+    assert size[0] == "STRING"
+    assert size[1]["default"] == "1024*1024"
+
+
+def test_mai_pro_t2i_has_no_image_input():
+    inputs = AtlasMAIImage25ProTextToImage.INPUT_TYPES()
+    assert "image" not in inputs["required"]
+    assert "image" not in inputs["optional"]
+
+
+def test_mai_pro_edit_image_input():
+    inputs = AtlasMAIImage25ProEdit.INPUT_TYPES()
+    assert "image" in inputs["required"]
+    # the edit schema exposes no size control
+    assert "size" not in inputs["optional"]
+
+
+@pytest.mark.parametrize("bad_image", ["", "   "])
+def test_mai_pro_edit_requires_image(bad_image):
+    with pytest.raises(RuntimeError, match="image is required"):
+        AtlasMAIImage25ProEdit().run(None, "a prompt", bad_image)
+
+
+def test_mai_pro_nodes_registered():
+    from src.atlascloud_comfyui.registry import (
+        NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+    for key, cls in (
+        ("AtlasCloud MAI-Image-2.5-Pro Text-to-Image", AtlasMAIImage25ProTextToImage),
+        ("AtlasCloud MAI-Image-2.5-Pro Edit", AtlasMAIImage25ProEdit),
+    ):
+        # registry.py imports under the `atlascloud_comfyui.*` path while the
+        # tests import under `src.atlascloud_comfyui.*`, so compare by name.
+        assert NODE_CLASS_MAPPINGS[key].__name__ == cls.__name__
+        assert NODE_DISPLAY_NAME_MAPPINGS[key] == key


### PR DESCRIPTION
Daily AtlasCloud -> ComfyUI node sync.

## New models
- `microsoft/mai-image-2.5-pro/text-to-image` — AtlasCloud MAI-Image-2.5-Pro Text-to-Image
- `microsoft/mai-image-2.5-pro/edit` — AtlasCloud MAI-Image-2.5-Pro Edit

Both follow the existing `microsoft/mai-image-2.5/*` node pattern (same request schema:
`prompt` + optional `size` for t2i, `prompt` + required `image` for edit, plus the
standard `enable_sync_mode` / `enable_base64_output` flags), verified against each
model's published schema.

## Changes
- `src/atlascloud_comfyui/nodes/image/mai_image_25_pro_t2i.py` (new)
- `src/atlascloud_comfyui/nodes/image/mai_image_25_pro_edit.py` (new)
- `src/atlascloud_comfyui/registry.py` — imports + class/display-name mappings
- `README.md` — Available Nodes rows
- `tests/test_new_nodes_2026_09_04.py` (new, metadata-only)

## Tests
- `ruff check .` — passed
- `pytest tests/ -k "not e2e"` — 699 passed, 26 deselected
- E2E skipped locally (no ComfyUI source on this machine)